### PR TITLE
Use `fs` library so even Windows users can run build.

### DIFF
--- a/webpack_config/webpack.prod.js
+++ b/webpack_config/webpack.prod.js
@@ -1,16 +1,19 @@
 'use strict'
 process.env.NODE_ENV = 'production'
 
-const exec = require('child_process').execSync
 const webpack = require('webpack')
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
 const ProgressPlugin = require('webpack/lib/ProgressPlugin')
 // const OfflinePlugin = require('offline-plugin')
 const base = require('./webpack.base')
 const config = require('./config')
+const fs = require('fs')
+const distFolder = 'dist/';
 
 
-exec('rm -rf dist/')
+if (fs.existsSync(distFolder))
+    fs.rmdirSync(distFolder)
+
 base.devtool = 'cheap-source-map'
 base.module.loaders.push(
     {


### PR DESCRIPTION
Noticed that we were using `exec` to run unix-style commands for clearing up old builds.

This'll use FS so it'll work on everyone's machine :)

![image](https://user-images.githubusercontent.com/304269/27061204-323c9626-4fb0-11e7-86f9-65aac648983b.png)

