### PR TITLE
Wallet pr fixes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -28,7 +28,8 @@
     "no-trailing-spaces": [1, { "skipBlankLines": true }],
     "no-unreachable": 1,
     "no-alert": 0,
-    "react/jsx-uses-react": 1
+    "react/jsx-uses-react": 1,
+    "no-unused-vars": [1, { "argsIgnorePattern": "^_" }]
   },
   "globals": {
     "SyntheticInputEvent": false,

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,0 @@
-{
-  "printWidth": 80,
-  "parser": "flow",
-  "single-quote": true
-}

--- a/common/actions/generateWallet.js
+++ b/common/actions/generateWallet.js
@@ -1,27 +1,22 @@
-import { genNewPkey, pkeyToAddress, genNewKeystore } from 'libs/keystore';
-
+// @flow
 import {
   GENERATE_WALLET_CONFIRM_CONTINUE_TO_PAPER,
   GENERATE_WALLET_FILE,
   GENERATE_WALLET_DOWNLOAD_FILE,
   GENERATE_WALLET_SHOW_PASSWORD,
   GENERATE_WALLET_CONTINUE_TO_UNLOCK
-} from 'actions/generateWalletConstants';
+} from "actions/generateWalletConstants";
+import { PrivKeyWallet } from "libs/wallet";
 
 export const showPasswordGenerateWallet = () => {
   return { type: GENERATE_WALLET_SHOW_PASSWORD };
 };
 
-export const generateUTCGenerateWallet = password => {
-  const privateKey = genNewPkey();
-  const address = pkeyToAddress(privateKey);
-  const walletFile = genNewKeystore(privateKey, password);
-
+export const generateUTCGenerateWallet = (password: string) => {
   return {
     type: GENERATE_WALLET_FILE,
-    privateKey: privateKey.toString('hex'),
-    address: `0x${address}`,
-    walletFile
+    wallet: PrivKeyWallet.generate(),
+    password
   };
 };
 

--- a/common/actions/generateWallet.js
+++ b/common/actions/generateWallet.js
@@ -5,8 +5,8 @@ import {
   GENERATE_WALLET_DOWNLOAD_FILE,
   GENERATE_WALLET_SHOW_PASSWORD,
   GENERATE_WALLET_CONTINUE_TO_UNLOCK
-} from "actions/generateWalletConstants";
-import { PrivKeyWallet } from "libs/wallet";
+} from 'actions/generateWalletConstants';
+import { PrivKeyWallet } from 'libs/wallet';
 
 export const showPasswordGenerateWallet = () => {
   return { type: GENERATE_WALLET_SHOW_PASSWORD };

--- a/common/actions/wallet.js
+++ b/common/actions/wallet.js
@@ -1,25 +1,29 @@
 // @flow
-import type { PrivateKeyUnlockParams } from 'libs/wallet/privkey';
-import BaseWallet from 'libs/wallet/base';
-import Big from 'big.js';
+import BaseWallet from "libs/wallet/base";
+import Big from "big.js";
+
+export type PrivateKeyUnlockParams = {
+  key: string,
+  password: string
+};
 
 export type UnlockPrivateKeyAction = {
-  type: 'WALLET_UNLOCK_PRIVATE_KEY',
+  type: "WALLET_UNLOCK_PRIVATE_KEY",
   payload: PrivateKeyUnlockParams
 };
 
 export type SetWalletAction = {
-  type: 'WALLET_SET',
+  type: "WALLET_SET",
   payload: BaseWallet
 };
 
 export type SetBalanceAction = {
-  type: 'WALLET_SET_BALANCE',
+  type: "WALLET_SET_BALANCE",
   payload: Big
 };
 
 export type SetTokenBalancesAction = {
-  type: 'WALLET_SET_TOKEN_BALANCES',
+  type: "WALLET_SET_TOKEN_BALANCES",
   payload: {
     [string]: Big
   }
@@ -35,21 +39,21 @@ export function unlockPrivateKey(
   value: PrivateKeyUnlockParams
 ): UnlockPrivateKeyAction {
   return {
-    type: 'WALLET_UNLOCK_PRIVATE_KEY',
+    type: "WALLET_UNLOCK_PRIVATE_KEY",
     payload: value
   };
 }
 
 export function setWallet(value: BaseWallet): SetWalletAction {
   return {
-    type: 'WALLET_SET',
+    type: "WALLET_SET",
     payload: value
   };
 }
 
 export function setBalance(value: Big): SetBalanceAction {
   return {
-    type: 'WALLET_SET_BALANCE',
+    type: "WALLET_SET_BALANCE",
     payload: value
   };
 }
@@ -58,7 +62,7 @@ export function setTokenBalances(payload: {
   [string]: Big
 }): SetTokenBalancesAction {
   return {
-    type: 'WALLET_SET_TOKEN_BALANCES',
+    type: "WALLET_SET_TOKEN_BALANCES",
     payload
   };
 }

--- a/common/actions/wallet.js
+++ b/common/actions/wallet.js
@@ -1,6 +1,6 @@
 // @flow
-import BaseWallet from "libs/wallet/base";
-import Big from "big.js";
+import BaseWallet from 'libs/wallet/base';
+import Big from 'big.js';
 
 export type PrivateKeyUnlockParams = {
   key: string,
@@ -8,22 +8,22 @@ export type PrivateKeyUnlockParams = {
 };
 
 export type UnlockPrivateKeyAction = {
-  type: "WALLET_UNLOCK_PRIVATE_KEY",
+  type: 'WALLET_UNLOCK_PRIVATE_KEY',
   payload: PrivateKeyUnlockParams
 };
 
 export type SetWalletAction = {
-  type: "WALLET_SET",
+  type: 'WALLET_SET',
   payload: BaseWallet
 };
 
 export type SetBalanceAction = {
-  type: "WALLET_SET_BALANCE",
+  type: 'WALLET_SET_BALANCE',
   payload: Big
 };
 
 export type SetTokenBalancesAction = {
-  type: "WALLET_SET_TOKEN_BALANCES",
+  type: 'WALLET_SET_TOKEN_BALANCES',
   payload: {
     [string]: Big
   }
@@ -39,21 +39,21 @@ export function unlockPrivateKey(
   value: PrivateKeyUnlockParams
 ): UnlockPrivateKeyAction {
   return {
-    type: "WALLET_UNLOCK_PRIVATE_KEY",
+    type: 'WALLET_UNLOCK_PRIVATE_KEY',
     payload: value
   };
 }
 
 export function setWallet(value: BaseWallet): SetWalletAction {
   return {
-    type: "WALLET_SET",
+    type: 'WALLET_SET',
     payload: value
   };
 }
 
 export function setBalance(value: Big): SetBalanceAction {
   return {
-    type: "WALLET_SET_BALANCE",
+    type: 'WALLET_SET_BALANCE',
     payload: value
   };
 }
@@ -62,7 +62,7 @@ export function setTokenBalances(payload: {
   [string]: Big
 }): SetTokenBalancesAction {
   return {
-    type: "WALLET_SET_TOKEN_BALANCES",
+    type: 'WALLET_SET_TOKEN_BALANCES',
     payload
   };
 }

--- a/common/components/BalanceSidebar/AddCustomTokenForm.jsx
+++ b/common/components/BalanceSidebar/AddCustomTokenForm.jsx
@@ -1,28 +1,28 @@
 // @flow
-import React from 'react';
-import { isValidETHAddress, isPositiveIntegerOrZero } from 'libs/validators';
-import translate from 'translations';
+import React from "react";
+import { isValidETHAddress, isPositiveIntegerOrZero } from "libs/validators";
+import translate from "translations";
 
 export default class AddCustomTokenForm extends React.Component {
   props: {
     onSave: ({ address: string, symbol: string, decimal: number }) => void
   };
   state = {
-    address: '',
-    symbol: '',
-    decimal: ''
+    address: "",
+    symbol: "",
+    decimal: ""
   };
 
   render() {
     return (
       <div className="custom-token-fields">
         <label>
-          {translate('TOKEN_Addr')}
+          {translate("TOKEN_Addr")}
         </label>
         <input
           className={
-            'form-control input-sm ' +
-            (isValidETHAddress(this.state.address) ? 'is-valid' : 'is-invalid')
+            "form-control input-sm " +
+            (isValidETHAddress(this.state.address) ? "is-valid" : "is-invalid")
           }
           type="text"
           name="address"
@@ -30,12 +30,12 @@ export default class AddCustomTokenForm extends React.Component {
           onChange={this.onFieldChange}
         />
         <label>
-          {translate('TOKEN_Symbol')}
+          {translate("TOKEN_Symbol")}
         </label>
         <input
           className={
-            'form-control input-sm ' +
-            (this.state.symbol !== '' ? 'is-valid' : 'is-invalid')
+            "form-control input-sm " +
+            (this.state.symbol !== "" ? "is-valid" : "is-invalid")
           }
           type="text"
           name="symbol"
@@ -43,14 +43,14 @@ export default class AddCustomTokenForm extends React.Component {
           onChange={this.onFieldChange}
         />
         <label>
-          {translate('TOKEN_Dec')}
+          {translate("TOKEN_Dec")}
         </label>
         <input
           className={
-            'form-control input-sm ' +
+            "form-control input-sm " +
             (isPositiveIntegerOrZero(parseInt(this.state.decimal))
-              ? 'is-valid'
-              : 'is-invalid')
+              ? "is-valid"
+              : "is-invalid")
           }
           type="text"
           name="decimal"
@@ -59,11 +59,11 @@ export default class AddCustomTokenForm extends React.Component {
         />
         <div
           className={`btn btn-primary btn-sm ${this.isValid()
-            ? ''
-            : 'disabled'}`}
+            ? ""
+            : "disabled"}`}
           onClick={this.onSave}
         >
-          {translate('x_Save')}
+          {translate("x_Save")}
         </div>
       </div>
     );
@@ -77,7 +77,7 @@ export default class AddCustomTokenForm extends React.Component {
     if (!isValidETHAddress(address)) {
       return false;
     }
-    if (this.state.symbol === '') {
+    if (symbol === "") {
       return false;
     }
 

--- a/common/components/BalanceSidebar/AddCustomTokenForm.jsx
+++ b/common/components/BalanceSidebar/AddCustomTokenForm.jsx
@@ -1,28 +1,28 @@
 // @flow
-import React from "react";
-import { isValidETHAddress, isPositiveIntegerOrZero } from "libs/validators";
-import translate from "translations";
+import React from 'react';
+import { isValidETHAddress, isPositiveIntegerOrZero } from 'libs/validators';
+import translate from 'translations';
 
 export default class AddCustomTokenForm extends React.Component {
   props: {
     onSave: ({ address: string, symbol: string, decimal: number }) => void
   };
   state = {
-    address: "",
-    symbol: "",
-    decimal: ""
+    address: '',
+    symbol: '',
+    decimal: ''
   };
 
   render() {
     return (
       <div className="custom-token-fields">
         <label>
-          {translate("TOKEN_Addr")}
+          {translate('TOKEN_Addr')}
         </label>
         <input
           className={
-            "form-control input-sm " +
-            (isValidETHAddress(this.state.address) ? "is-valid" : "is-invalid")
+            'form-control input-sm ' +
+            (isValidETHAddress(this.state.address) ? 'is-valid' : 'is-invalid')
           }
           type="text"
           name="address"
@@ -30,12 +30,12 @@ export default class AddCustomTokenForm extends React.Component {
           onChange={this.onFieldChange}
         />
         <label>
-          {translate("TOKEN_Symbol")}
+          {translate('TOKEN_Symbol')}
         </label>
         <input
           className={
-            "form-control input-sm " +
-            (this.state.symbol !== "" ? "is-valid" : "is-invalid")
+            'form-control input-sm ' +
+            (this.state.symbol !== '' ? 'is-valid' : 'is-invalid')
           }
           type="text"
           name="symbol"
@@ -43,14 +43,14 @@ export default class AddCustomTokenForm extends React.Component {
           onChange={this.onFieldChange}
         />
         <label>
-          {translate("TOKEN_Dec")}
+          {translate('TOKEN_Dec')}
         </label>
         <input
           className={
-            "form-control input-sm " +
+            'form-control input-sm ' +
             (isPositiveIntegerOrZero(parseInt(this.state.decimal))
-              ? "is-valid"
-              : "is-invalid")
+              ? 'is-valid'
+              : 'is-invalid')
           }
           type="text"
           name="decimal"
@@ -59,11 +59,11 @@ export default class AddCustomTokenForm extends React.Component {
         />
         <div
           className={`btn btn-primary btn-sm ${this.isValid()
-            ? ""
-            : "disabled"}`}
+            ? ''
+            : 'disabled'}`}
           onClick={this.onSave}
         >
-          {translate("x_Save")}
+          {translate('x_Save')}
         </div>
       </div>
     );
@@ -77,7 +77,7 @@ export default class AddCustomTokenForm extends React.Component {
     if (!isValidETHAddress(address)) {
       return false;
     }
-    if (symbol === "") {
+    if (symbol === '') {
       return false;
     }
 

--- a/common/components/BalanceSidebar/TokenBalances.jsx
+++ b/common/components/BalanceSidebar/TokenBalances.jsx
@@ -1,10 +1,10 @@
 // @flow
-import React from "react";
-import translate from "translations";
-import TokenRow from "./TokenRow";
-import AddCustomTokenForm from "./AddCustomTokenForm";
-import type { TokenBalance } from "selectors/wallet";
-import type { Token } from "config/data";
+import React from 'react';
+import translate from 'translations';
+import TokenRow from './TokenRow';
+import AddCustomTokenForm from './AddCustomTokenForm';
+import type { TokenBalance } from 'selectors/wallet';
+import type { Token } from 'config/data';
 
 type Props = {
   tokens: TokenBalance[],
@@ -23,7 +23,7 @@ export default class TokenBalances extends React.Component {
     const { tokens } = this.props;
     return (
       <section className="token-balances">
-        <h5>{translate("sidebar_TokenBal")}</h5>
+        <h5>{translate('sidebar_TokenBal')}</h5>
         <table className="account-info">
           <tbody>
             {tokens
@@ -48,14 +48,14 @@ export default class TokenBalances extends React.Component {
           className="btn btn-default btn-sm"
           onClick={this.toggleShowAllTokens}
         >
-          {!this.state.showAllTokens ? "Show All Tokens" : "Hide Tokens"}
-        </a>{" "}
+          {!this.state.showAllTokens ? 'Show All Tokens' : 'Hide Tokens'}
+        </a>{' '}
         <a
           className="btn btn-default btn-sm"
           onClick={this.toggleShowCustomTokenForm}
         >
           <span>
-            {translate("SEND_custom")}
+            {translate('SEND_custom')}
           </span>
         </a>
         {this.state.showCustomTokenForm &&

--- a/common/components/BalanceSidebar/TokenRow.jsx
+++ b/common/components/BalanceSidebar/TokenRow.jsx
@@ -1,9 +1,8 @@
 // @flow
-import React from 'react';
-import Big from 'big.js';
-import translate from 'translations';
-import { formatNumber } from 'utils/formatters';
-import removeIcon from 'assets/images/icon-remove.svg';
+import React from "react";
+import Big from "big.js";
+import { formatNumber } from "utils/formatters";
+import removeIcon from "assets/images/icon-remove.svg";
 
 export default class TokenRow extends React.Component {
   props: {
@@ -34,9 +33,7 @@ export default class TokenRow extends React.Component {
               onClick={this.onRemove}
             />}
           <span>
-            {showLongBalance
-              ? balance.toString()
-              : formatNumber(balance)}
+            {showLongBalance ? balance.toString() : formatNumber(balance)}
           </span>
         </td>
         <td>

--- a/common/components/BalanceSidebar/TokenRow.jsx
+++ b/common/components/BalanceSidebar/TokenRow.jsx
@@ -1,8 +1,8 @@
 // @flow
-import React from "react";
-import Big from "big.js";
-import { formatNumber } from "utils/formatters";
-import removeIcon from "assets/images/icon-remove.svg";
+import React from 'react';
+import Big from 'big.js';
+import { formatNumber } from 'utils/formatters';
+import removeIcon from 'assets/images/icon-remove.svg';
 
 export default class TokenRow extends React.Component {
   props: {

--- a/common/components/PaperWallet/index.jsx
+++ b/common/components/PaperWallet/index.jsx
@@ -72,23 +72,10 @@ const styles = {
   infoLabel: {
     fontWeight: 600
   },
-
   identiconContainer: {
     position: 'absolute',
     right: '15px',
     bottom: '45px'
-  },
-  identiconWrapper: {
-    float: 'left',
-    width: '42px',
-    height: '42px',
-    overflow: 'hidden',
-    backgroundSize: '100%',
-    borderRadius: '50%',
-    boxShadow: `
-      inset rgba(255, 255, 255, 0.5) 0 2px 2px,
-      inset rgba(0, 0, 0, 0.6) 0 -1px 8px
-    `
   },
   identiconText: {
     float: 'left',
@@ -152,8 +139,8 @@ export default class PaperWallet extends React.Component {
         </div>
 
         <div style={styles.identiconContainer}>
-          <div style={styles.identiconWrapper}>
-            <Identicon address={address} forPrinting />
+          <div style={{ float: 'left' }}>
+            <Identicon address={address} size={'42px'} />
           </div>
           <p style={styles.identiconText}>
             Always look for this icon when sending to this wallet

--- a/common/components/PaperWallet/index.jsx
+++ b/common/components/PaperWallet/index.jsx
@@ -1,71 +1,71 @@
 // @flow
-import React from "react";
-import { QRCode, Identicon } from "components/ui";
-import type PrivKeyWallet from "libs/wallet/privkey";
+import React from 'react';
+import { QRCode, Identicon } from 'components/ui';
+import type PrivKeyWallet from 'libs/wallet/privkey';
 
-import ethLogo from "assets/images/logo-ethereum-1.png";
-import sidebarImg from "assets/images/print-sidebar.png";
-import notesBg from "assets/images/notes-bg.png";
+import ethLogo from 'assets/images/logo-ethereum-1.png';
+import sidebarImg from 'assets/images/print-sidebar.png';
+import notesBg from 'assets/images/notes-bg.png';
 
 const walletWidth = 680;
 const walletHeight = 280;
 
 const styles = {
   container: {
-    position: "relative",
-    margin: "0 auto",
+    position: 'relative',
+    margin: '0 auto',
     width: `${walletWidth}px`,
     height: `${walletHeight}px`,
-    border: "1px solid #163151",
-    userSelect: "none",
-    cursor: "default"
+    border: '1px solid #163151',
+    userSelect: 'none',
+    cursor: 'default'
   },
 
   // Images
   sidebar: {
-    float: "left",
-    height: "100%",
-    width: "auto"
+    float: 'left',
+    height: '100%',
+    width: 'auto'
   },
   ethLogo: {
-    position: "absolute",
-    left: "86px",
-    height: "100%",
-    width: "auto",
-    zIndex: "-1"
+    position: 'absolute',
+    left: '86px',
+    height: '100%',
+    width: 'auto',
+    zIndex: '-1'
   },
 
   // Blocks / QR Codes
   block: {
-    position: "relative",
-    float: "left",
-    width: "27.5%",
-    padding: "20px"
+    position: 'relative',
+    float: 'left',
+    width: '27.5%',
+    padding: '20px'
   },
   blockText: {
-    position: "absolute",
-    top: "50%",
-    left: "100%",
-    width: "100%",
+    position: 'absolute',
+    top: '50%',
+    left: '100%',
+    width: '100%',
     margin: 0,
-    transform: "translate(-50%, -50%) rotate(-90deg)",
-    fontSize: "13px",
-    fontWeight: "600",
-    color: "#0b7290",
-    textAlign: "center",
-    textTransform: "uppercase",
-    letterSpacing: "1px"
+    transform: 'translate(-50%, -50%) rotate(-90deg)',
+    fontSize: '13px',
+    fontWeight: '600',
+    color: '#0b7290',
+    textAlign: 'center',
+    textTransform: 'uppercase',
+    letterSpacing: '1px'
   },
   // Address / private key info
   infoContainer: {
-    float: "left",
-    width: "85%",
-    padding: "0 20px"
+    float: 'left',
+    width: '85%',
+    padding: '0 20px'
   },
   infoText: {
-    margin: "0 0 8px",
-    textAlign: "left",
-    fontSize: "14px",
+    margin: '0 0 8px',
+    textAlign: 'left',
+    fontSize: '14px',
     fontFamily: 'Menlo, Monaco, Consolas, "Courier New", monospace',
     fontWeight: 300
   },
@@ -74,29 +74,29 @@ const styles = {
   },
 
   identiconContainer: {
-    position: "absolute",
-    right: "15px",
-    bottom: "45px"
+    position: 'absolute',
+    right: '15px',
+    bottom: '45px'
   },
   identiconWrapper: {
-    float: "left",
-    width: "42px",
-    height: "42px",
-    overflow: "hidden",
-    backgroundSize: "100%",
-    borderRadius: "50%",
+    float: 'left',
+    width: '42px',
+    height: '42px',
+    overflow: 'hidden',
+    backgroundSize: '100%',
+    borderRadius: '50%',
     boxShadow: `
       inset rgba(255, 255, 255, 0.5) 0 2px 2px,
       inset rgba(0, 0, 0, 0.6) 0 -1px 8px
     `
   },
   identiconText: {
-    float: "left",
-    width: "130px",
-    padding: "0 5px",
-    margin: "12px 0 0",
-    fontSize: "9px",
-    textAlign: "center"
+    float: 'left',
+    width: '130px',
+    padding: '0 5px',
+    margin: '12px 0 0',
+    fontSize: '9px',
+    textAlign: 'center'
   },
   box: {
     width: 150,

--- a/common/components/PaperWallet/index.jsx
+++ b/common/components/PaperWallet/index.jsx
@@ -1,0 +1,165 @@
+// @flow
+import React from "react";
+import { QRCode, Identicon } from "components/ui";
+import type PrivKeyWallet from "libs/wallet/privkey";
+
+import ethLogo from "assets/images/logo-ethereum-1.png";
+import sidebarImg from "assets/images/print-sidebar.png";
+import notesBg from "assets/images/notes-bg.png";
+
+const walletWidth = 680;
+const walletHeight = 280;
+
+const styles = {
+  container: {
+    position: "relative",
+    margin: "0 auto",
+    width: `${walletWidth}px`,
+    height: `${walletHeight}px`,
+    border: "1px solid #163151",
+    userSelect: "none",
+    cursor: "default"
+  },
+
+  // Images
+  sidebar: {
+    float: "left",
+    height: "100%",
+    width: "auto"
+  },
+  ethLogo: {
+    position: "absolute",
+    left: "86px",
+    height: "100%",
+    width: "auto",
+    zIndex: "-1"
+  },
+
+  // Blocks / QR Codes
+  block: {
+    position: "relative",
+    float: "left",
+    width: "27.5%",
+    padding: "20px"
+  },
+  blockText: {
+    position: "absolute",
+    top: "50%",
+    left: "100%",
+    width: "100%",
+    margin: 0,
+    transform: "translate(-50%, -50%) rotate(-90deg)",
+    fontSize: "13px",
+    fontWeight: "600",
+    color: "#0b7290",
+    textAlign: "center",
+    textTransform: "uppercase",
+    letterSpacing: "1px"
+  },
+  // Address / private key info
+  infoContainer: {
+    float: "left",
+    width: "85%",
+    padding: "0 20px"
+  },
+  infoText: {
+    margin: "0 0 8px",
+    textAlign: "left",
+    fontSize: "14px",
+    fontFamily: 'Menlo, Monaco, Consolas, "Courier New", monospace',
+    fontWeight: 300
+  },
+  infoLabel: {
+    fontWeight: 600
+  },
+
+  identiconContainer: {
+    position: "absolute",
+    right: "15px",
+    bottom: "45px"
+  },
+  identiconWrapper: {
+    float: "left",
+    width: "42px",
+    height: "42px",
+    overflow: "hidden",
+    backgroundSize: "100%",
+    borderRadius: "50%",
+    boxShadow: `
+      inset rgba(255, 255, 255, 0.5) 0 2px 2px,
+      inset rgba(0, 0, 0, 0.6) 0 -1px 8px
+    `
+  },
+  identiconText: {
+    float: "left",
+    width: "130px",
+    padding: "0 5px",
+    margin: "12px 0 0",
+    fontSize: "9px",
+    textAlign: "center"
+  },
+  box: {
+    width: 150,
+    height: 150
+  }
+};
+
+type Props = {
+  wallet: PrivKeyWallet
+};
+
+export default class PaperWallet extends React.Component {
+  props: Props;
+  render() {
+    const address = this.props.wallet.getAddress();
+    const privateKey = this.props.wallet.getPrivateKey();
+
+    return (
+      <div style={styles.container}>
+        <img src={sidebarImg} style={styles.sidebar} />
+        <img src={ethLogo} style={styles.ethLogo} />
+
+        <div style={styles.block}>
+          <div style={styles.box}>
+            <QRCode data={address} />
+          </div>
+          <p style={styles.blockText}>YOUR ADDRESS</p>
+        </div>
+
+        <div style={styles.block}>
+          <img src={notesBg} style={styles.box} />
+          <p style={styles.blockText}>AMOUNT / NOTES</p>
+        </div>
+
+        <div style={styles.block}>
+          <div style={styles.box}>
+            <QRCode data={privateKey} />
+          </div>
+          <p style={styles.blockText}>YOUR PRIVATE KEY</p>
+        </div>
+
+        <div style={styles.infoContainer}>
+          <p style={styles.infoText}>
+            <strong style={styles.infoLabel}>Your Address:</strong>
+            <br />
+            {address}
+          </p>
+          <p style={styles.infoText}>
+            <strong style={styles.infoLabel}>Your Private Key:</strong>
+            <br />
+            {privateKey}
+          </p>
+        </div>
+
+        <div style={styles.identiconContainer}>
+          <div style={styles.identiconWrapper}>
+            <Identicon address={address} forPrinting />
+          </div>
+          <p style={styles.identiconText}>
+            Always look for this icon when sending to this wallet
+          </p>
+        </div>
+      </div>
+    );
+  }
+}

--- a/common/components/PrintableWallet/index.jsx
+++ b/common/components/PrintableWallet/index.jsx
@@ -25,23 +25,36 @@ export default class PrintableWallet extends Component {
   };
 
   componentDidMount() {
-    // Start generating QR Codes as soon as component is ready
-    const opts = {
-      color: {
-        dark: '#000',
-        light: '#fff'
+    // Start generating QR codes immediately
+    this._generateQrCode(this.props.privateKey, 'qrCodePkey');
+    this._generateQrCode(this.props.address, 'qrCodeAddress');
+  }
+
+  componentWillReceiveProps(nextProps) {
+    // Regenerate QR codes if props change
+    if (nextProps.privateKey !== this.props.privateKey) {
+      this._generateQrCode(nextProps.privateKey, 'qrCodePkey');
+    }
+    if (nextProps.address !== this.props.address) {
+      this._generateQrCode(nextProps.address, 'qrCodeAddress');
+    }
+  }
+
+  _generateQrCode(value, stateKey) {
+    QRCode.toDataURL(
+      value,
+      {
+        color: {
+          dark: '#000',
+          light: '#fff'
+        },
+        margin: 0,
+        errorCorrectionLevel: 'H'
       },
-      margin: 0,
-      errorCorrectionLevel: 'H'
-    };
-
-    QRCode.toDataURL(this.props.privateKey, opts, (err, url) => {
-      this.setState({ qrCodePkey: url });
-    });
-
-    QRCode.toDataURL(this.props.address, opts, (err, url) => {
-      this.setState({ qrCodeAddress: url });
-    });
+      (err, url) => {
+        this.setState({ [stateKey]: url });
+      }
+    );
   }
 
   print = () => {

--- a/common/components/PrintableWallet/index.jsx
+++ b/common/components/PrintableWallet/index.jsx
@@ -135,6 +135,10 @@ export default class PrintableWallet extends Component {
         margin: "12px 0 0",
         fontSize: "9px",
         textAlign: "center"
+      },
+      box: {
+        width: 150,
+        height: 150
       }
     };
 
@@ -144,17 +148,21 @@ export default class PrintableWallet extends Component {
         <img src={ethLogo} style={styles.ethLogo} />
 
         <div style={styles.block}>
-          <QRCode data={this.props.address} size={150} />
+          <div style={styles.box}>
+            <QRCode data={this.props.address} />
+          </div>
           <p style={styles.blockText}>YOUR ADDRESS</p>
         </div>
 
         <div style={styles.block}>
-          <img src={notesBg} style={{ width: 150, hight: 150 }} />
+          <img src={notesBg} style={styles.box} />
           <p style={styles.blockText}>AMOUNT / NOTES</p>
         </div>
 
         <div style={styles.block}>
-          <QRCode data={this.props.privateKey} size={150} />
+          <div style={styles.box}>
+            <QRCode data={this.props.privateKey} />
+          </div>
           <p style={styles.blockText}>YOUR PRIVATE KEY</p>
         </div>
 

--- a/common/components/PrintableWallet/index.jsx
+++ b/common/components/PrintableWallet/index.jsx
@@ -163,9 +163,9 @@ export default class PrintableWallet extends Component {
         backgroundSize: '100%',
         borderRadius: '50%',
         boxShadow: `
-					inset rgba(255, 255, 255, 0.5) 0 2px 2px,
-					inset rgba(0, 0, 0, 0.6) 0 -1px 8px
-				`
+          inset rgba(255, 255, 255, 0.5) 0 2px 2px,
+          inset rgba(0, 0, 0, 0.6) 0 -1px 8px
+        `
       },
       identiconText: {
         float: 'left',

--- a/common/components/PrintableWallet/index.jsx
+++ b/common/components/PrintableWallet/index.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import translate from 'translations';
 import QRCode from 'qrcode';
 import { toDataUrl as makeIdenticon } from 'ethereum-blockies';
+import printElement from 'utils/printElement';
 
 import ethLogo from 'assets/images/logo-ethereum-1.png';
 import sidebarImg from 'assets/images/print-sidebar.png';
@@ -44,41 +45,25 @@ export default class PrintableWallet extends Component {
   }
 
   print = () => {
-    const popup = window.open(
-      'about:blank',
-      'printWalletWindow',
-      `width=${walletWidth + 60},height=${walletHeight + 60},scrollbars=no`
-    );
+    printElement(this._renderPaperWallet(), {
+      popupFeatures: {
+        width: walletWidth + 60,
+        height: walletHeight + 60,
+        scrollbars: 'no'
+      },
+      styles: `
+        * {
+          box-sizing: border-box;
+        }
 
-    // We'll save ourselves from re-rendering by just using a ref for the html
-    focus();
-    popup.document.open();
-    popup.document.write(`
-			<html>
-				<head>
-					<style>
-						* {
-							box-sizing: border-box;
-						}
-
-						body {
-							font-family: Lato, sans-serif;
-							font-size: 1rem;
-							line-height: 1.4;
-							margin: 0;
-						}
-					</style>
-					<script>
-						setTimeout(function() {
-							window.print();
-						}, 500);
-					</script>
-				</head>
-				<body>
-					${this._wallet.outerHTML}
-				</body>
-			</html>
-		`);
+        body {
+          font-family: Lato, sans-serif;
+          font-size: 1rem;
+          line-height: 1.4;
+          margin: 0;
+        }
+      `
+    });
   };
 
   _renderPaperWallet() {

--- a/common/components/PrintableWallet/index.jsx
+++ b/common/components/PrintableWallet/index.jsx
@@ -165,7 +165,7 @@ export default class PrintableWallet extends Component {
     };
 
     return (
-      <div style={styles.container} ref={el => (this._wallet = el)}>
+      <div style={styles.container}>
         <img src={sidebarImg} style={styles.sidebar} />
         <img src={ethLogo} style={styles.ethLogo} />
 

--- a/common/components/PrintableWallet/index.jsx
+++ b/common/components/PrintableWallet/index.jsx
@@ -1,10 +1,10 @@
 // @flow
-import React, { Component } from "react";
-import PropTypes from "prop-types";
-import translate from "translations";
-import printElement from "utils/printElement";
-import { PaperWallet } from "components";
-import type PrivKeyWallet from "libs/wallet/privkey";
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import translate from 'translations';
+import printElement from 'utils/printElement';
+import { PaperWallet } from 'components';
+import type PrivKeyWallet from 'libs/wallet/privkey';
 
 type Props = {
   wallet: PrivKeyWallet
@@ -19,7 +19,7 @@ export default class PrintableWallet extends Component {
   print = () => {
     printElement(<PaperWallet wallet={this.props.wallet} />, {
       popupFeatures: {
-        scrollbars: "no"
+        scrollbars: 'no'
       },
       styles: `
         * {
@@ -42,12 +42,12 @@ export default class PrintableWallet extends Component {
         <PaperWallet wallet={this.props.wallet} />
         <a
           role="button"
-          aria-label={translate("x_Print")}
+          aria-label={translate('x_Print')}
           aria-describedby="x_PrintDesc"
-          className={"btn btn-lg btn-primary"}
+          className={'btn btn-lg btn-primary'}
           onClick={this.print}
         >
-          {translate("x_Print")}
+          {translate('x_Print')}
         </a>
       </div>
     );

--- a/common/components/PrintableWallet/index.jsx
+++ b/common/components/PrintableWallet/index.jsx
@@ -3,32 +3,22 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import translate from "translations";
 import printElement from "utils/printElement";
-import { QRCode, Identicon } from "components/ui";
-
-import ethLogo from "assets/images/logo-ethereum-1.png";
-import sidebarImg from "assets/images/print-sidebar.png";
-import notesBg from "assets/images/notes-bg.png";
-
-const walletWidth = 680;
-const walletHeight = 280;
+import { PaperWallet } from "components";
+import type PrivKeyWallet from "libs/wallet/privkey";
 
 type Props = {
-  privateKey: string,
-  address: string
+  wallet: PrivKeyWallet
 };
 
 export default class PrintableWallet extends Component {
   props: Props;
   static propTypes = {
-    privateKey: PropTypes.string,
-    address: PropTypes.string
+    wallet: PropTypes.object.isRequired
   };
 
   print = () => {
-    printElement(this._renderPaperWallet(), {
+    printElement(<PaperWallet wallet={this.props.wallet} />, {
       popupFeatures: {
-        width: walletWidth + 60,
-        height: walletHeight + 60,
         scrollbars: "no"
       },
       styles: `
@@ -46,155 +36,10 @@ export default class PrintableWallet extends Component {
     });
   };
 
-  _renderPaperWallet() {
-    const { privateKey, address } = this.props;
-    const styles = {
-      container: {
-        position: "relative",
-        margin: "0 auto",
-        width: `${walletWidth}px`,
-        height: `${walletHeight}px`,
-        border: "1px solid #163151",
-        userSelect: "none",
-        cursor: "default"
-      },
-
-      // Images
-      sidebar: {
-        float: "left",
-        height: "100%",
-        width: "auto"
-      },
-      ethLogo: {
-        position: "absolute",
-        left: "86px",
-        height: "100%",
-        width: "auto",
-        zIndex: "-1"
-      },
-
-      // Blocks / QR Codes
-      block: {
-        position: "relative",
-        float: "left",
-        width: "27.5%",
-        padding: "20px"
-      },
-      blockText: {
-        position: "absolute",
-        top: "50%",
-        left: "100%",
-        width: "100%",
-        margin: 0,
-        transform: "translate(-50%, -50%) rotate(-90deg)",
-        fontSize: "13px",
-        fontWeight: "600",
-        color: "#0b7290",
-        textAlign: "center",
-        textTransform: "uppercase",
-        letterSpacing: "1px"
-      },
-      // Address / private key info
-      infoContainer: {
-        float: "left",
-        width: "85%",
-        padding: "0 20px"
-      },
-      infoText: {
-        margin: "0 0 8px",
-        textAlign: "left",
-        fontSize: "14px",
-        fontFamily: 'Menlo, Monaco, Consolas, "Courier New", monospace',
-        fontWeight: 300
-      },
-      infoLabel: {
-        fontWeight: 600
-      },
-
-      identiconContainer: {
-        position: "absolute",
-        right: "15px",
-        bottom: "45px"
-      },
-      identiconWrapper: {
-        float: "left",
-        width: "42px",
-        height: "42px",
-        overflow: "hidden",
-        backgroundSize: "100%",
-        borderRadius: "50%",
-        boxShadow: `
-          inset rgba(255, 255, 255, 0.5) 0 2px 2px,
-          inset rgba(0, 0, 0, 0.6) 0 -1px 8px
-        `
-      },
-      identiconText: {
-        float: "left",
-        width: "130px",
-        padding: "0 5px",
-        margin: "12px 0 0",
-        fontSize: "9px",
-        textAlign: "center"
-      },
-      box: {
-        width: 150,
-        height: 150
-      }
-    };
-
-    return (
-      <div style={styles.container}>
-        <img src={sidebarImg} style={styles.sidebar} />
-        <img src={ethLogo} style={styles.ethLogo} />
-
-        <div style={styles.block}>
-          <div style={styles.box}>
-            <QRCode data={this.props.address} />
-          </div>
-          <p style={styles.blockText}>YOUR ADDRESS</p>
-        </div>
-
-        <div style={styles.block}>
-          <img src={notesBg} style={styles.box} />
-          <p style={styles.blockText}>AMOUNT / NOTES</p>
-        </div>
-
-        <div style={styles.block}>
-          <div style={styles.box}>
-            <QRCode data={this.props.privateKey} />
-          </div>
-          <p style={styles.blockText}>YOUR PRIVATE KEY</p>
-        </div>
-
-        <div style={styles.infoContainer}>
-          <p style={styles.infoText}>
-            <strong style={styles.infoLabel}>Your Address:</strong>
-            <br />
-            {address}
-          </p>
-          <p style={styles.infoText}>
-            <strong style={styles.infoLabel}>Your Private Key:</strong>
-            <br />
-            {privateKey}
-          </p>
-        </div>
-
-        <div style={styles.identiconContainer}>
-          <div style={styles.identiconWrapper}>
-            <Identicon address={this.props.address} forPrinting />
-          </div>
-          <p style={styles.identiconText}>
-            Always look for this icon when sending to this wallet
-          </p>
-        </div>
-      </div>
-    );
-  }
-
   render() {
     return (
       <div>
-        {this._renderPaperWallet()}
+        <PaperWallet wallet={this.props.wallet} />
         <a
           role="button"
           aria-label={translate("x_Print")}

--- a/common/components/PrintableWallet/index.jsx
+++ b/common/components/PrintableWallet/index.jsx
@@ -1,14 +1,13 @@
-import React, { Component } from 'react';
-import { render } from 'react-dom';
-import PropTypes from 'prop-types';
-import translate from 'translations';
-import QRCode from 'qrcode';
-import { toDataUrl as makeIdenticon } from 'ethereum-blockies';
-import printElement from 'utils/printElement';
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import translate from "translations";
+import QRCode from "qrcode";
+import { toDataUrl as makeIdenticon } from "ethereum-blockies";
+import printElement from "utils/printElement";
 
-import ethLogo from 'assets/images/logo-ethereum-1.png';
-import sidebarImg from 'assets/images/print-sidebar.png';
-import notesBg from 'assets/images/notes-bg.png';
+import ethLogo from "assets/images/logo-ethereum-1.png";
+import sidebarImg from "assets/images/print-sidebar.png";
+import notesBg from "assets/images/notes-bg.png";
 
 const walletWidth = 680;
 const walletHeight = 280;
@@ -26,17 +25,17 @@ export default class PrintableWallet extends Component {
 
   componentDidMount() {
     // Start generating QR codes immediately
-    this._generateQrCode(this.props.privateKey, 'qrCodePkey');
-    this._generateQrCode(this.props.address, 'qrCodeAddress');
+    this._generateQrCode(this.props.privateKey, "qrCodePkey");
+    this._generateQrCode(this.props.address, "qrCodeAddress");
   }
 
   componentWillReceiveProps(nextProps) {
     // Regenerate QR codes if props change
     if (nextProps.privateKey !== this.props.privateKey) {
-      this._generateQrCode(nextProps.privateKey, 'qrCodePkey');
+      this._generateQrCode(nextProps.privateKey, "qrCodePkey");
     }
     if (nextProps.address !== this.props.address) {
-      this._generateQrCode(nextProps.address, 'qrCodeAddress');
+      this._generateQrCode(nextProps.address, "qrCodeAddress");
     }
   }
 
@@ -45,11 +44,11 @@ export default class PrintableWallet extends Component {
       value,
       {
         color: {
-          dark: '#000',
-          light: '#fff'
+          dark: "#000",
+          light: "#fff"
         },
         margin: 0,
-        errorCorrectionLevel: 'H'
+        errorCorrectionLevel: "H"
       },
       (err, url) => {
         this.setState({ [stateKey]: url });
@@ -62,7 +61,7 @@ export default class PrintableWallet extends Component {
       popupFeatures: {
         width: walletWidth + 60,
         height: walletHeight + 60,
-        scrollbars: 'no'
+        scrollbars: "no"
       },
       styles: `
         * {
@@ -84,66 +83,66 @@ export default class PrintableWallet extends Component {
     const { qrCodePkey, qrCodeAddress } = this.state;
     const styles = {
       container: {
-        position: 'relative',
-        margin: '0 auto',
+        position: "relative",
+        margin: "0 auto",
         width: `${walletWidth}px`,
         height: `${walletHeight}px`,
-        border: '1px solid #163151',
-        userSelect: 'none',
-        cursor: 'default'
+        border: "1px solid #163151",
+        userSelect: "none",
+        cursor: "default"
       },
 
       // Images
       sidebar: {
-        float: 'left',
-        height: '100%',
-        width: 'auto'
+        float: "left",
+        height: "100%",
+        width: "auto"
       },
       ethLogo: {
-        position: 'absolute',
-        left: '86px',
-        height: '100%',
-        width: 'auto',
-        zIndex: '-1'
+        position: "absolute",
+        left: "86px",
+        height: "100%",
+        width: "auto",
+        zIndex: "-1"
       },
 
       // Blocks / QR Codes
       block: {
-        position: 'relative',
-        float: 'left',
-        width: '27.5%',
-        padding: '20px'
+        position: "relative",
+        float: "left",
+        width: "27.5%",
+        padding: "20px"
       },
       blockText: {
-        position: 'absolute',
-        top: '50%',
-        left: '100%',
-        width: '100%',
+        position: "absolute",
+        top: "50%",
+        left: "100%",
+        width: "100%",
         margin: 0,
-        transform: 'translate(-50%, -50%) rotate(-90deg)',
-        fontSize: '13px',
-        fontWeight: '600',
-        color: '#0b7290',
-        textAlign: 'center',
-        textTransform: 'uppercase',
-        letterSpacing: '1px'
+        transform: "translate(-50%, -50%) rotate(-90deg)",
+        fontSize: "13px",
+        fontWeight: "600",
+        color: "#0b7290",
+        textAlign: "center",
+        textTransform: "uppercase",
+        letterSpacing: "1px"
       },
       qrCode: {
-        width: '150px',
-        height: '150px',
-        backgroundSize: '100%'
+        width: "150px",
+        height: "150px",
+        backgroundSize: "100%"
       },
 
       // Address / private key info
       infoContainer: {
-        float: 'left',
-        width: '85%',
-        padding: '0 20px'
+        float: "left",
+        width: "85%",
+        padding: "0 20px"
       },
       infoText: {
-        margin: '0 0 8px',
-        textAlign: 'left',
-        fontSize: '14px',
+        margin: "0 0 8px",
+        textAlign: "left",
+        fontSize: "14px",
         fontFamily: 'Menlo, Monaco, Consolas, "Courier New", monospace',
         fontWeight: 300
       },
@@ -152,28 +151,28 @@ export default class PrintableWallet extends Component {
       },
 
       identiconContainer: {
-        position: 'absolute',
-        right: '15px',
-        bottom: '45px'
+        position: "absolute",
+        right: "15px",
+        bottom: "45px"
       },
       identiconImg: {
-        float: 'left',
-        width: '42px',
-        height: '42px',
-        backgroundSize: '100%',
-        borderRadius: '50%',
+        float: "left",
+        width: "42px",
+        height: "42px",
+        backgroundSize: "100%",
+        borderRadius: "50%",
         boxShadow: `
           inset rgba(255, 255, 255, 0.5) 0 2px 2px,
           inset rgba(0, 0, 0, 0.6) 0 -1px 8px
         `
       },
       identiconText: {
-        float: 'left',
-        width: '130px',
-        padding: '0 5px',
-        margin: '12px 0 0',
-        fontSize: '9px',
-        textAlign: 'center'
+        float: "left",
+        width: "130px",
+        padding: "0 5px",
+        margin: "12px 0 0",
+        fontSize: "9px",
+        textAlign: "center"
       }
     };
 
@@ -223,20 +222,19 @@ export default class PrintableWallet extends Component {
 
   render() {
     const qrCodesReady = this.state.qrCodePkey && this.state.qrCodeAddress;
-    const btnDisabled = qrCodesReady ? '' : 'btn-disabled';
-    const walletContainerStyle = {};
+    const btnDisabled = qrCodesReady ? "" : "btn-disabled";
 
     return (
       <div>
         {this._renderPaperWallet()}
         <a
           role="button"
-          aria-label={translate('x_Print')}
+          aria-label={translate("x_Print")}
           aria-describedby="x_PrintDesc"
           className={`btn btn-lg btn-primary ${btnDisabled}`}
           onClick={this.print}
         >
-          {translate('x_Print')}
+          {translate("x_Print")}
         </a>
       </div>
     );

--- a/common/components/WalletDecrypt/PrivateKey.jsx
+++ b/common/components/WalletDecrypt/PrivateKey.jsx
@@ -1,7 +1,7 @@
 // @flow
-import React, { Component } from "react";
-import translate from "translations";
-import { isValidPrivKey } from "libs/validators";
+import React, { Component } from 'react';
+import translate from 'translations';
+import { isValidPrivKey } from 'libs/validators';
 
 export type PrivateKeyValue = {
   key: string,
@@ -10,7 +10,7 @@ export type PrivateKeyValue = {
 };
 
 function fixPkey(key) {
-  if (key.indexOf("0x") === 0) {
+  if (key.indexOf('0x') === 0) {
     return key.slice(2);
   }
   return key;
@@ -33,16 +33,16 @@ export default class PrivateKeyDecrypt extends Component {
       <section className="col-md-4 col-sm-6">
         <div id="selectedTypeKey">
           <h4>
-            {translate("ADD_Radio_3")}
+            {translate('ADD_Radio_3')}
           </h4>
           <div className="form-group">
             <textarea
               id="aria-private-key"
-              className={`form-control ${isValid ? "is-valid" : "is-invalid"}`}
+              className={`form-control ${isValid ? 'is-valid' : 'is-invalid'}`}
               value={key}
               onChange={this.onPkeyChange}
               onKeyDown={this.onKeyDown}
-              placeholder={translate("x_PrivKey2")}
+              placeholder={translate('x_PrivKey2')}
               rows="4"
             />
           </div>
@@ -50,16 +50,16 @@ export default class PrivateKeyDecrypt extends Component {
             isPassRequired &&
             <div className="form-group">
               <p>
-                {translate("ADD_Label_3")}
+                {translate('ADD_Label_3')}
               </p>
               <input
                 className={`form-control ${password.length > 0
-                  ? "is-valid"
-                  : "is-invalid"}`}
+                  ? 'is-valid'
+                  : 'is-invalid'}`}
                 value={password}
                 onChange={this.onPasswordChange}
                 onKeyDown={this.onKeyDown}
-                placeholder={translate("x_Password")}
+                placeholder={translate('x_Password')}
                 type="password"
               />
             </div>}

--- a/common/components/WalletDecrypt/PrivateKey.jsx
+++ b/common/components/WalletDecrypt/PrivateKey.jsx
@@ -1,15 +1,16 @@
 // @flow
-import React, { Component } from 'react';
-import translate from 'translations';
-import { isValidPrivKey } from 'libs/validators';
-import type { PrivateKeyUnlockParams } from 'libs/wallet/privkey';
+import React, { Component } from "react";
+import translate from "translations";
+import { isValidPrivKey } from "libs/validators";
 
-export type PrivateKeyValue = PrivateKeyUnlockParams & {
+export type PrivateKeyValue = {
+  key: string,
+  password: string,
   valid: boolean
 };
 
 function fixPkey(key) {
-  if (key.indexOf('0x') === 0) {
+  if (key.indexOf("0x") === 0) {
     return key.slice(2);
   }
   return key;
@@ -17,8 +18,8 @@ function fixPkey(key) {
 
 export default class PrivateKeyDecrypt extends Component {
   props: {
-    value: PrivateKeyUnlockParams,
-    onChange: (value: PrivateKeyUnlockParams) => void,
+    value: PrivateKeyValue,
+    onChange: (value: PrivateKeyValue) => void,
     onUnlock: () => void
   };
 
@@ -32,16 +33,16 @@ export default class PrivateKeyDecrypt extends Component {
       <section className="col-md-4 col-sm-6">
         <div id="selectedTypeKey">
           <h4>
-            {translate('ADD_Radio_3')}
+            {translate("ADD_Radio_3")}
           </h4>
           <div className="form-group">
             <textarea
               id="aria-private-key"
-              className={`form-control ${isValid ? 'is-valid' : 'is-invalid'}`}
+              className={`form-control ${isValid ? "is-valid" : "is-invalid"}`}
               value={key}
               onChange={this.onPkeyChange}
               onKeyDown={this.onKeyDown}
-              placeholder={translate('x_PrivKey2')}
+              placeholder={translate("x_PrivKey2")}
               rows="4"
             />
           </div>
@@ -49,16 +50,16 @@ export default class PrivateKeyDecrypt extends Component {
             isPassRequired &&
             <div className="form-group">
               <p>
-                {translate('ADD_Label_3')}
+                {translate("ADD_Label_3")}
               </p>
               <input
                 className={`form-control ${password.length > 0
-                  ? 'is-valid'
-                  : 'is-invalid'}`}
+                  ? "is-valid"
+                  : "is-invalid"}`}
                 value={password}
                 onChange={this.onPasswordChange}
                 onKeyDown={this.onKeyDown}
-                placeholder={translate('x_Password')}
+                placeholder={translate("x_Password")}
                 type="password"
               />
             </div>}

--- a/common/components/index.js
+++ b/common/components/index.js
@@ -1,6 +1,7 @@
 // @flow
 
-export { default as Header } from './Header';
-export { default as Footer } from './Footer';
-export { default as Root } from './Root';
-export { default as BalanceSidebar } from './BalanceSidebar';
+export { default as Header } from "./Header";
+export { default as Footer } from "./Footer";
+export { default as Root } from "./Root";
+export { default as BalanceSidebar } from "./BalanceSidebar";
+export { default as PaperWallet } from "./PaperWallet";

--- a/common/components/index.js
+++ b/common/components/index.js
@@ -1,7 +1,7 @@
 // @flow
 
-export { default as Header } from "./Header";
-export { default as Footer } from "./Footer";
-export { default as Root } from "./Root";
-export { default as BalanceSidebar } from "./BalanceSidebar";
-export { default as PaperWallet } from "./PaperWallet";
+export { default as Header } from './Header';
+export { default as Footer } from './Footer';
+export { default as Root } from './Root';
+export { default as BalanceSidebar } from './BalanceSidebar';
+export { default as PaperWallet } from './PaperWallet';

--- a/common/components/ui/Identicon.jsx
+++ b/common/components/ui/Identicon.jsx
@@ -1,8 +1,8 @@
 // @flow
 
-import React from "react";
-import { toDataUrl } from "ethereum-blockies";
-import { isValidETHAddress } from "libs/validators";
+import React from 'react';
+import { toDataUrl } from 'ethereum-blockies';
+import { isValidETHAddress } from 'libs/validators';
 
 type Props = {
   address: string,
@@ -11,14 +11,14 @@ type Props = {
 };
 
 export default function Identicon(props: Props) {
-  const identiconDataUrl = toDataUrl(props.address.toLowerCase()) || "";
+  const identiconDataUrl = toDataUrl(props.address.toLowerCase()) || '';
   // FIXME breaks on failed checksums
   const style = !isValidETHAddress(props.address)
     ? {}
     : { backgroundImage: `url(${identiconDataUrl})` };
   if (props.forPrinting) {
     return (
-      <img src={identiconDataUrl} style={{ width: "100%", height: "100%" }} />
+      <img src={identiconDataUrl} style={{ width: '100%', height: '100%' }} />
     );
   }
   return (

--- a/common/components/ui/Identicon.jsx
+++ b/common/components/ui/Identicon.jsx
@@ -1,18 +1,26 @@
 // @flow
 
-import React from 'react';
-import { toDataUrl } from 'ethereum-blockies';
-import { isValidETHAddress } from 'libs/validators';
+import React from "react";
+import { toDataUrl } from "ethereum-blockies";
+import { isValidETHAddress } from "libs/validators";
 
 type Props = {
-  address: string
+  address: string,
+  // FIXME move to styled img tag everywhere
+  forPrinting?: boolean
 };
 
 export default function Identicon(props: Props) {
+  const identiconDataUrl = toDataUrl(props.address.toLowerCase()) || "";
   // FIXME breaks on failed checksums
   const style = !isValidETHAddress(props.address)
     ? {}
-    : { backgroundImage: `url(${toDataUrl(props.address.toLowerCase())})` };
+    : { backgroundImage: `url(${identiconDataUrl})` };
+  if (props.forPrinting) {
+    return (
+      <img src={identiconDataUrl} style={{ width: "100%", height: "100%" }} />
+    );
+  }
   return (
     <div
       className="addressIdenticon"

--- a/common/components/ui/Identicon.jsx
+++ b/common/components/ui/Identicon.jsx
@@ -6,26 +6,44 @@ import { isValidETHAddress } from 'libs/validators';
 
 type Props = {
   address: string,
-  // FIXME move to styled img tag everywhere
-  forPrinting?: boolean
+  size?: string
 };
 
 export default function Identicon(props: Props) {
-  const identiconDataUrl = toDataUrl(props.address.toLowerCase()) || '';
+  const size = props.size || '4rem';
   // FIXME breaks on failed checksums
-  const style = !isValidETHAddress(props.address)
-    ? {}
-    : { backgroundImage: `url(${identiconDataUrl})` };
-  if (props.forPrinting) {
-    return (
-      <img src={identiconDataUrl} style={{ width: '100%', height: '100%' }} />
-    );
-  }
+  const identiconDataUrl = isValidETHAddress(props.address.toLowerCase())
+    ? toDataUrl(props.address.toLowerCase())
+    : '';
   return (
     <div
-      className="addressIdenticon"
-      style={style}
+      style={{ position: 'relative', width: size, height: size }}
       title="Address Indenticon"
-    />
+    >
+      <div
+        style={{
+          position: 'absolute',
+          left: 0,
+          right: 0,
+          top: 0,
+          bottom: 0,
+          borderRadius: '50%',
+
+          boxShadow: `
+                    inset rgba(255, 255, 255, 0.5) 0 2px 2px,
+                    inset rgba(0, 0, 0, 0.6) 0 -1px 8px
+                  `
+        }}
+      />
+      {identiconDataUrl &&
+        <img
+          src={identiconDataUrl}
+          style={{
+            borderRadius: '50%',
+            width: '100%',
+            height: '100%'
+          }}
+        />}
+    </div>
   );
 }

--- a/common/components/ui/QRCode.jsx
+++ b/common/components/ui/QRCode.jsx
@@ -1,0 +1,76 @@
+// @flow
+import React from "react";
+import QRCodeLib from "qrcode";
+
+// FIXME should store limited amount if history
+// data -> qr cache
+const cache: { [key: string]: string } = {};
+
+type Props = {
+  size: number,
+  data: string
+};
+
+type State = {
+  qr?: string
+};
+
+export default class QRCode extends React.Component {
+  props: Props;
+  state: State = {};
+
+  componentWillMount() {
+    // Start generating QR codes immediately
+    this._generateQrCode(this.props.data);
+  }
+
+  componentWillReceiveProps(nextProps: Props) {
+    // Regenerate QR codes if props change
+    if (
+      nextProps.data !== this.props.data ||
+      nextProps.size !== this.props.size
+    ) {
+      this._generateQrCode(nextProps.data);
+    }
+  }
+
+  _generateQrCode(value: string) {
+    if (cache[value]) {
+      this.setState({ qr: cache[value] });
+      return;
+    }
+    QRCodeLib.toDataURL(
+      value,
+      {
+        color: {
+          dark: "#000",
+          light: "#fff"
+        },
+        margin: 0,
+        errorCorrectionLevel: "H"
+      },
+      (err, qr) => {
+        if (err) return;
+        cache[value] = qr;
+        this.setState({ qr });
+      }
+    );
+  }
+
+  render() {
+    const { qr } = this.state;
+    if (!qr) {
+      return null;
+    }
+    return (
+      <img
+        src={qr}
+        style={{
+          width: this.props.size,
+          height: this.props.size,
+          backgroundSize: "100%"
+        }}
+      />
+    );
+  }
+}

--- a/common/components/ui/QRCode.jsx
+++ b/common/components/ui/QRCode.jsx
@@ -7,7 +7,6 @@ import QRCodeLib from "qrcode";
 const cache: { [key: string]: string } = {};
 
 type Props = {
-  size: number,
   data: string
 };
 
@@ -26,10 +25,7 @@ export default class QRCode extends React.Component {
 
   componentWillReceiveProps(nextProps: Props) {
     // Regenerate QR codes if props change
-    if (
-      nextProps.data !== this.props.data ||
-      nextProps.size !== this.props.size
-    ) {
+    if (nextProps.data !== this.props.data) {
       this._generateQrCode(nextProps.data);
     }
   }
@@ -66,9 +62,8 @@ export default class QRCode extends React.Component {
       <img
         src={qr}
         style={{
-          width: this.props.size,
-          height: this.props.size,
-          backgroundSize: "100%"
+          width: "100%",
+          height: "100%"
         }}
       />
     );

--- a/common/components/ui/QRCode.jsx
+++ b/common/components/ui/QRCode.jsx
@@ -1,6 +1,6 @@
 // @flow
-import React from "react";
-import QRCodeLib from "qrcode";
+import React from 'react';
+import QRCodeLib from 'qrcode';
 
 // FIXME should store limited amount if history
 // data -> qr cache
@@ -39,11 +39,11 @@ export default class QRCode extends React.Component {
       value,
       {
         color: {
-          dark: "#000",
-          light: "#fff"
+          dark: '#000',
+          light: '#fff'
         },
         margin: 0,
-        errorCorrectionLevel: "H"
+        errorCorrectionLevel: 'H'
       },
       (err, qr) => {
         if (err) return;
@@ -62,8 +62,8 @@ export default class QRCode extends React.Component {
       <img
         src={qr}
         style={{
-          width: "100%",
-          height: "100%"
+          width: '100%',
+          height: '100%'
         }}
       />
     );

--- a/common/components/ui/index.js
+++ b/common/components/ui/index.js
@@ -1,6 +1,7 @@
 // @flow
 
-export { default as Dropdown } from './Dropdown';
-export { default as Identicon } from './Identicon';
-export { default as Modal } from './Modal';
-export { default as UnlockHeader } from './UnlockHeader';
+export { default as Dropdown } from "./Dropdown";
+export { default as Identicon } from "./Identicon";
+export { default as Modal } from "./Modal";
+export { default as UnlockHeader } from "./UnlockHeader";
+export { default as QRCode } from "./QRCode";

--- a/common/components/ui/index.js
+++ b/common/components/ui/index.js
@@ -1,7 +1,7 @@
 // @flow
 
-export { default as Dropdown } from "./Dropdown";
-export { default as Identicon } from "./Identicon";
-export { default as Modal } from "./Modal";
-export { default as UnlockHeader } from "./UnlockHeader";
-export { default as QRCode } from "./QRCode";
+export { default as Dropdown } from './Dropdown';
+export { default as Identicon } from './Identicon';
+export { default as Modal } from './Modal';
+export { default as UnlockHeader } from './UnlockHeader';
+export { default as QRCode } from './QRCode';

--- a/common/containers/Tabs/GenerateWallet/components/EnterPassword.jsx
+++ b/common/containers/Tabs/GenerateWallet/components/EnterPassword.jsx
@@ -1,3 +1,4 @@
+// @flow
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { Field, reduxForm } from "redux-form";

--- a/common/containers/Tabs/GenerateWallet/components/EnterPassword.jsx
+++ b/common/containers/Tabs/GenerateWallet/components/EnterPassword.jsx
@@ -1,9 +1,9 @@
 // @flow
-import React, { Component } from "react";
-import PropTypes from "prop-types";
-import { Field, reduxForm } from "redux-form";
-import translate from "translations";
-import PasswordInput from "./PasswordInput";
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Field, reduxForm } from 'redux-form';
+import translate from 'translations';
+import PasswordInput from './PasswordInput';
 
 // VALIDATORS
 const minLength = min => value => {
@@ -12,7 +12,7 @@ const minLength = min => value => {
     : undefined;
 };
 const minLength9 = minLength(9);
-const required = value => (value ? undefined : "Required");
+const required = value => (value ? undefined : 'Required');
 
 class EnterPassword extends Component {
   static propTypes = {
@@ -44,12 +44,12 @@ class EnterPassword extends Component {
     return (
       <div>
         <h1 aria-live="polite">
-          {translate("NAV_GenerateWallet")}
+          {translate('NAV_GenerateWallet')}
         </h1>
 
         <div className="col-sm-8 col-sm-offset-2">
           <h4>
-            {translate("HELP_1_Desc_3")}
+            {translate('HELP_1_Desc_3')}
           </h4>
           <Field
             validate={[required, minLength9]}
@@ -67,7 +67,7 @@ class EnterPassword extends Component {
             }
             className="btn btn-primary btn-block"
           >
-            {translate("NAV_GenerateWallet")}
+            {translate('NAV_GenerateWallet')}
           </button>
         </div>
       </div>
@@ -76,5 +76,5 @@ class EnterPassword extends Component {
 }
 
 export default reduxForm({
-  form: "generateWalletPassword" // a unique name for this form
+  form: 'generateWalletPassword' // a unique name for this form
 })(EnterPassword);

--- a/common/containers/Tabs/GenerateWallet/components/EnterPassword.jsx
+++ b/common/containers/Tabs/GenerateWallet/components/EnterPassword.jsx
@@ -16,10 +16,10 @@ const required = value => (value ? undefined : 'Required');
 
 class EnterPassword extends Component {
   static propTypes = {
-    // state
+    // Store state
     generateWalletPassword: PropTypes.object,
     showPassword: PropTypes.bool,
-    // actions
+    // Actions
     showPasswordGenerateWallet: PropTypes.func,
     generateUTCGenerateWallet: PropTypes.func
   };
@@ -69,7 +69,6 @@ class EnterPassword extends Component {
           >
             {translate('NAV_GenerateWallet')}
           </button>
-
         </div>
       </div>
     );

--- a/common/containers/Tabs/GenerateWallet/components/EnterPassword.jsx
+++ b/common/containers/Tabs/GenerateWallet/components/EnterPassword.jsx
@@ -1,9 +1,8 @@
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { Field, reduxForm } from 'redux-form';
-import translate from 'translations';
-import { genNewKeystore } from 'libs/keystore';
-import PasswordInput from './PasswordInput';
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { Field, reduxForm } from "redux-form";
+import translate from "translations";
+import PasswordInput from "./PasswordInput";
 
 // VALIDATORS
 const minLength = min => value => {
@@ -12,7 +11,7 @@ const minLength = min => value => {
     : undefined;
 };
 const minLength9 = minLength(9);
-const required = value => (value ? undefined : 'Required');
+const required = value => (value ? undefined : "Required");
 
 class EnterPassword extends Component {
   static propTypes = {
@@ -44,12 +43,12 @@ class EnterPassword extends Component {
     return (
       <div>
         <h1 aria-live="polite">
-          {translate('NAV_GenerateWallet')}
+          {translate("NAV_GenerateWallet")}
         </h1>
 
         <div className="col-sm-8 col-sm-offset-2">
           <h4>
-            {translate('HELP_1_Desc_3')}
+            {translate("HELP_1_Desc_3")}
           </h4>
           <Field
             validate={[required, minLength9]}
@@ -67,7 +66,7 @@ class EnterPassword extends Component {
             }
             className="btn btn-primary btn-block"
           >
-            {translate('NAV_GenerateWallet')}
+            {translate("NAV_GenerateWallet")}
           </button>
         </div>
       </div>
@@ -76,5 +75,5 @@ class EnterPassword extends Component {
 }
 
 export default reduxForm({
-  form: 'generateWalletPassword' // a unique name for this form
+  form: "generateWalletPassword" // a unique name for this form
 })(EnterPassword);

--- a/common/containers/Tabs/GenerateWallet/components/PaperWallet.jsx
+++ b/common/containers/Tabs/GenerateWallet/components/PaperWallet.jsx
@@ -1,9 +1,9 @@
 // @flow
-import React, { Component } from "react";
-import PropTypes from "prop-types";
-import translate from "translations";
-import PrintableWallet from "components/PrintableWallet";
-import type PrivKeyWallet from "libs/wallet/privkey";
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import translate from 'translations';
+import PrintableWallet from 'components/PrintableWallet';
+import type PrivKeyWallet from 'libs/wallet/privkey';
 
 type Props = {
   wallet: PrivKeyWallet,
@@ -26,11 +26,11 @@ export default class PaperWallet extends Component {
       <div className="col-sm-8 col-sm-offset-2">
         {/* Private Key */}
         <h1>
-          {translate("GEN_Label_5")}
+          {translate('GEN_Label_5')}
         </h1>
         <input
           value={wallet.getPrivateKey()}
-          aria-label={translate("x_PrivKey")}
+          aria-label={translate('x_PrivKey')}
           aria-describedby="x_PrivKeyDesc"
           className="form-control"
           type="text"
@@ -40,7 +40,7 @@ export default class PaperWallet extends Component {
 
         {/* Download Paper Wallet */}
         <h1>
-          {translate("x_Print")}
+          {translate('x_Print')}
         </h1>
         <PrintableWallet wallet={wallet} />
         <br />
@@ -48,7 +48,7 @@ export default class PaperWallet extends Component {
 
         {/* Continue button */}
         <button className="btn btn-default" onClick={continueToUnlockWallet}>
-          {translate("GEN_Label_3")} →
+          {translate('GEN_Label_3')} →
         </button>
       </div>
     );

--- a/common/containers/Tabs/GenerateWallet/components/PaperWallet.jsx
+++ b/common/containers/Tabs/GenerateWallet/components/PaperWallet.jsx
@@ -1,29 +1,36 @@
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import translate from 'translations';
-import PrintableWallet from 'components/PrintableWallet';
+// @flow
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import translate from "translations";
+import PrintableWallet from "components/PrintableWallet";
+import type PrivKeyWallet from "libs/wallet/privkey";
+
+type Props = {
+  wallet: PrivKeyWallet,
+  continueToUnlockWallet: () => any
+};
 
 export default class PaperWallet extends Component {
+  props: Props;
   static propTypes = {
     // Store state
-    privateKey: PropTypes.string,
-    address: PropTypes.string,
+    wallet: PropTypes.object.isRequired,
     // Actions
     continueToUnlockWallet: PropTypes.func
   };
 
   render() {
-    const { privateKey, address, continueToUnlockWallet } = this.props;
+    const { wallet, continueToUnlockWallet } = this.props;
 
     return (
       <div className="col-sm-8 col-sm-offset-2">
         {/* Private Key */}
         <h1>
-          {translate('GEN_Label_5')}
+          {translate("GEN_Label_5")}
         </h1>
         <input
-          value={privateKey}
-          aria-label={translate('x_PrivKey')}
+          value={wallet.getPrivateKey()}
+          aria-label={translate("x_PrivKey")}
           aria-describedby="x_PrivKeyDesc"
           className="form-control"
           type="text"
@@ -33,15 +40,15 @@ export default class PaperWallet extends Component {
 
         {/* Download Paper Wallet */}
         <h1>
-          {translate('x_Print')}
+          {translate("x_Print")}
         </h1>
-        <PrintableWallet privateKey={privateKey} address={address} />
+        <PrintableWallet wallet={wallet} />
         <br />
         <br />
 
         {/* Continue button */}
         <button className="btn btn-default" onClick={continueToUnlockWallet}>
-          {translate('GEN_Label_3')} →
+          {translate("GEN_Label_3")} →
         </button>
       </div>
     );

--- a/common/containers/Tabs/GenerateWallet/components/PaperWallet.jsx
+++ b/common/containers/Tabs/GenerateWallet/components/PaperWallet.jsx
@@ -5,7 +5,7 @@ import PrintableWallet from 'components/PrintableWallet';
 
 export default class PaperWallet extends Component {
   static propTypes = {
-    // State
+    // Store state
     privateKey: PropTypes.string,
     address: PropTypes.string,
     // Actions

--- a/common/containers/Tabs/GenerateWallet/components/SaveWallet.jsx
+++ b/common/containers/Tabs/GenerateWallet/components/SaveWallet.jsx
@@ -4,10 +4,10 @@ import translate from 'translations';
 
 export default class SaveWallet extends Component {
   static propTypes = {
-    // state
+    // Store state
     walletFile: PropTypes.object.isRequired,
     hasDownloadedWalletFile: PropTypes.bool,
-    // actions
+    // Actions
     downloadUTCGenerateWallet: PropTypes.func,
     confirmContinueToPaperGenerateWallet: PropTypes.func
   };

--- a/common/containers/Tabs/GenerateWallet/components/SaveWallet.jsx
+++ b/common/containers/Tabs/GenerateWallet/components/SaveWallet.jsx
@@ -1,9 +1,9 @@
 // @flow
-import React, { Component } from "react";
-import PropTypes from "prop-types";
-import translate from "translations";
-import type PrivKeyWallet from "libs/wallet/privkey";
-import { makeBlob } from "libs/globalFuncs";
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import translate from 'translations';
+import type PrivKeyWallet from 'libs/wallet/privkey';
+import { makeBlob } from 'libs/globalFuncs';
 
 type Props = {
   wallet: PrivKeyWallet,
@@ -44,7 +44,7 @@ export default class SaveWallet extends Component {
     return (
       <div>
         <h1>
-          {translate("GEN_Label_2")}
+          {translate('GEN_Label_2')}
         </h1>
         <br />
         <div className="col-sm-8 col-sm-offset-2">
@@ -54,10 +54,10 @@ export default class SaveWallet extends Component {
               className="help-icon"
             />
             <p className="account-help-text">
-              {translate("x_KeystoreDesc")}
+              {translate('x_KeystoreDesc')}
             </p>
             <h4>
-              {translate("x_Keystore2")}
+              {translate('x_Keystore2')}
             </h4>
           </div>
           <a
@@ -69,10 +69,10 @@ export default class SaveWallet extends Component {
             href={this.getBlob()}
             onClick={downloadUTCGenerateWallet}
           >
-            {translate("x_Download")}
+            {translate('x_Download')}
           </a>
           <p className="sr-only" id="x_KeystoreDesc">
-            {translate("x_KeystoreDesc")}
+            {translate('x_KeystoreDesc')}
           </p>
           <br />
           <br />
@@ -95,8 +95,8 @@ export default class SaveWallet extends Component {
             <a
               role="button"
               className={`btn btn-info ${hasDownloadedWalletFile
-                ? ""
-                : "disabled"}`}
+                ? ''
+                : 'disabled'}`}
               onClick={confirmContinueToPaperGenerateWallet}
             >
               I understand. Continue.
@@ -108,16 +108,16 @@ export default class SaveWallet extends Component {
   }
 
   getBlob() {
-    return makeBlob("text/json;charset=UTF-8", this.keystore);
+    return makeBlob('text/json;charset=UTF-8', this.keystore);
   }
 
   getFilename() {
     const ts = new Date();
     return [
-      "UTC--",
-      ts.toJSON().replace(/:/g, "-"),
-      "--",
+      'UTC--',
+      ts.toJSON().replace(/:/g, '-'),
+      '--',
       this.props.wallet.getAddress()
-    ].join("");
+    ].join('');
   }
 }

--- a/common/containers/Tabs/GenerateWallet/components/SaveWallet.jsx
+++ b/common/containers/Tabs/GenerateWallet/components/SaveWallet.jsx
@@ -1,20 +1,41 @@
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import translate from 'translations';
+// @flow
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import translate from "translations";
+import type PrivKeyWallet from "libs/wallet/privkey";
+import { makeBlob } from "libs/globalFuncs";
+
+type Props = {
+  wallet: PrivKeyWallet,
+  password: string,
+  hasDownloadedWalletFile: boolean,
+  downloadUTCGenerateWallet: () => any,
+  confirmContinueToPaperGenerateWallet: () => any
+};
 
 export default class SaveWallet extends Component {
+  props: Props;
+  keystore: Object;
   static propTypes = {
     // Store state
-    walletFile: PropTypes.object.isRequired,
+    wallet: PropTypes.object.isRequired,
+    password: PropTypes.string.isRequired,
     hasDownloadedWalletFile: PropTypes.bool,
     // Actions
     downloadUTCGenerateWallet: PropTypes.func,
     confirmContinueToPaperGenerateWallet: PropTypes.func
   };
+  componentWillMount() {
+    this.keystore = this.props.wallet.toKeystore(this.props.password);
+  }
+  componentWillUpdate(nextProps: Props) {
+    if (this.props.wallet !== nextProps.wallet) {
+      this.keystore = nextProps.wallet.toKeystore(nextProps.password);
+    }
+  }
 
   render() {
     const {
-      walletFile,
       hasDownloadedWalletFile,
       downloadUTCGenerateWallet,
       confirmContinueToPaperGenerateWallet
@@ -23,7 +44,7 @@ export default class SaveWallet extends Component {
     return (
       <div>
         <h1>
-          {translate('GEN_Label_2')}
+          {translate("GEN_Label_2")}
         </h1>
         <br />
         <div className="col-sm-8 col-sm-offset-2">
@@ -33,10 +54,10 @@ export default class SaveWallet extends Component {
               className="help-icon"
             />
             <p className="account-help-text">
-              {translate('x_KeystoreDesc')}
+              {translate("x_KeystoreDesc")}
             </p>
             <h4>
-              {translate('x_Keystore2')}
+              {translate("x_Keystore2")}
             </h4>
           </div>
           <a
@@ -44,14 +65,14 @@ export default class SaveWallet extends Component {
             className="btn btn-primary btn-block"
             aria-label="Download Keystore File (UTC / JSON · Recommended · Encrypted)"
             aria-describedby="x_KeystoreDesc"
-            download={walletFile.fileName}
-            href={walletFile.blobURI}
+            download={this.getFilename()}
+            href={this.getBlob()}
             onClick={downloadUTCGenerateWallet}
           >
-            {translate('x_Download')}
+            {translate("x_Download")}
           </a>
           <p className="sr-only" id="x_KeystoreDesc">
-            {translate('x_KeystoreDesc')}
+            {translate("x_KeystoreDesc")}
           </p>
           <br />
           <br />
@@ -74,9 +95,9 @@ export default class SaveWallet extends Component {
             <a
               role="button"
               className={`btn btn-info ${hasDownloadedWalletFile
-                ? ''
-                : 'disabled'}`}
-              onClick={() => confirmContinueToPaperGenerateWallet()}
+                ? ""
+                : "disabled"}`}
+              onClick={confirmContinueToPaperGenerateWallet}
             >
               I understand. Continue.
             </a>
@@ -84,5 +105,19 @@ export default class SaveWallet extends Component {
         </div>
       </div>
     );
+  }
+
+  getBlob() {
+    return makeBlob("text/json;charset=UTF-8", this.keystore);
+  }
+
+  getFilename() {
+    const ts = new Date();
+    return [
+      "UTC--",
+      ts.toJSON().replace(/:/g, "-"),
+      "--",
+      this.props.wallet.getAddress()
+    ].join("");
   }
 }

--- a/common/containers/Tabs/GenerateWallet/index.js
+++ b/common/containers/Tabs/GenerateWallet/index.js
@@ -1,23 +1,31 @@
-import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import * as generateWalletActions from 'actions/generateWallet';
-import PropTypes from 'prop-types';
-import EnterPassword from './components/EnterPassword';
-import SaveWallet from './components/SaveWallet';
-import PaperWallet from './components/PaperWallet';
-import UnlockWallet from './components/UnlockWallet';
+// @flow
+import React, { Component } from "react";
+import { connect } from "react-redux";
+import * as generateWalletActions from "actions/generateWallet";
+import PropTypes from "prop-types";
+import EnterPassword from "./components/EnterPassword";
+import SaveWallet from "./components/SaveWallet";
+import PaperWallet from "./components/PaperWallet";
+import UnlockWallet from "./components/UnlockWallet";
+import type PrivKeyWallet from "libs/wallet/privkey";
+import type { State } from "reducers";
+
+type Props = {
+  // FIXME union actual steps
+  activeStep: string,
+  password: string,
+  hasDownloadedWalletFile: boolean,
+  wallet: ?PrivKeyWallet
+} & typeof generateWalletActions;
 
 class GenerateWallet extends Component {
-  constructor(props) {
-    super(props);
-  }
-
+  props: Props;
   static propTypes = {
     // Store state
     activeStep: PropTypes.string,
-    walletFile: PropTypes.object,
-    privateKey: PropTypes.string,
-    address: PropTypes.string,
+    wallet: PropTypes.object,
+    password: PropTypes.string,
+    hasDownloadedWalletFile: PropTypes.boolean,
     // Actions
     showPasswordGenerateWallet: PropTypes.func,
     generateUTCGenerateWallet: PropTypes.func,
@@ -27,23 +35,44 @@ class GenerateWallet extends Component {
   };
 
   render() {
-    const { activeStep } = this.props;
+    const { activeStep, wallet, password } = this.props;
     let content;
 
     switch (activeStep) {
-      case 'password':
+      case "password":
         content = <EnterPassword {...this.props} />;
         break;
 
-      case 'download':
-        content = <SaveWallet {...this.props} />;
+      case "download":
+        if (wallet) {
+          content = (
+            <SaveWallet
+              hasDownloadedWalletFile={this.props.hasDownloadedWalletFile}
+              wallet={wallet}
+              password={password}
+              downloadUTCGenerateWallet={this.props.downloadUTCGenerateWallet}
+              confirmContinueToPaperGenerateWallet={
+                this.props.confirmContinueToPaperGenerateWallet
+              }
+            />
+          );
+        }
         break;
 
-      case 'paper':
-        content = <PaperWallet {...this.props} />;
+      case "paper":
+        if (wallet) {
+          content = (
+            <PaperWallet
+              wallet={wallet}
+              continueToUnlockWallet={this.props.continueToUnlockWallet}
+            />
+          );
+        } else {
+          content = <h1>Uh oh. Not sure how you got here.</h1>;
+        }
         break;
 
-      case 'unlock':
+      case "unlock":
         content = <UnlockWallet {...this.props} />;
         break;
 
@@ -52,7 +81,7 @@ class GenerateWallet extends Component {
     }
 
     return (
-      <section className="container" style={{ minHeight: '50%' }}>
+      <section className="container" style={{ minHeight: "50%" }}>
         <div className="tab-content">
           <main className="tab-pane active text-center" role="main">
             <section role="main" className="row">
@@ -66,13 +95,13 @@ class GenerateWallet extends Component {
   }
 }
 
-function mapStateToProps(state) {
+function mapStateToProps(state: State) {
   return {
     generateWalletPassword: state.form.generateWalletPassword,
     activeStep: state.generateWallet.activeStep,
+    password: state.generateWallet.password,
     hasDownloadedWalletFile: state.generateWallet.hasDownloadedWalletFile,
-    privateKey: state.generateWallet.privateKey,
-    address: state.generateWallet.address,
+    wallet: state.generateWallet.wallet,
     walletFile: state.generateWallet.walletFile
   };
 }

--- a/common/containers/Tabs/GenerateWallet/index.js
+++ b/common/containers/Tabs/GenerateWallet/index.js
@@ -13,12 +13,12 @@ class GenerateWallet extends Component {
   }
 
   static propTypes = {
-    // state
+    // Store state
     activeStep: PropTypes.string,
     walletFile: PropTypes.object,
     privateKey: PropTypes.string,
     address: PropTypes.string,
-    // actions
+    // Actions
     showPasswordGenerateWallet: PropTypes.func,
     generateUTCGenerateWallet: PropTypes.func,
     downloadUTCGenerateWallet: PropTypes.func,

--- a/common/containers/Tabs/GenerateWallet/index.js
+++ b/common/containers/Tabs/GenerateWallet/index.js
@@ -1,14 +1,14 @@
 // @flow
-import React, { Component } from "react";
-import { connect } from "react-redux";
-import * as generateWalletActions from "actions/generateWallet";
-import PropTypes from "prop-types";
-import EnterPassword from "./components/EnterPassword";
-import SaveWallet from "./components/SaveWallet";
-import PaperWallet from "./components/PaperWallet";
-import UnlockWallet from "./components/UnlockWallet";
-import type PrivKeyWallet from "libs/wallet/privkey";
-import type { State } from "reducers";
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import * as generateWalletActions from 'actions/generateWallet';
+import PropTypes from 'prop-types';
+import EnterPassword from './components/EnterPassword';
+import SaveWallet from './components/SaveWallet';
+import PaperWallet from './components/PaperWallet';
+import UnlockWallet from './components/UnlockWallet';
+import type PrivKeyWallet from 'libs/wallet/privkey';
+import type { State } from 'reducers';
 
 type Props = {
   // FIXME union actual steps
@@ -39,11 +39,11 @@ class GenerateWallet extends Component {
     let content;
 
     switch (activeStep) {
-      case "password":
+      case 'password':
         content = <EnterPassword {...this.props} />;
         break;
 
-      case "download":
+      case 'download':
         if (wallet) {
           content = (
             <SaveWallet
@@ -59,7 +59,7 @@ class GenerateWallet extends Component {
         }
         break;
 
-      case "paper":
+      case 'paper':
         if (wallet) {
           content = (
             <PaperWallet
@@ -72,7 +72,7 @@ class GenerateWallet extends Component {
         }
         break;
 
-      case "unlock":
+      case 'unlock':
         content = <UnlockWallet {...this.props} />;
         break;
 
@@ -81,7 +81,7 @@ class GenerateWallet extends Component {
     }
 
     return (
-      <section className="container" style={{ minHeight: "50%" }}>
+      <section className="container" style={{ minHeight: '50%' }}>
         <div className="tab-content">
           <main className="tab-pane active text-center" role="main">
             <section role="main" className="row">

--- a/common/libs/keystore.js
+++ b/common/libs/keystore.js
@@ -1,33 +1,28 @@
 // @flow
-import { randomBytes, createCipheriv } from 'crypto';
-import { privateToPublic, publicToAddress, sha3 } from 'ethereumjs-util';
-import scrypt from 'scryptsy';
-import uuid from 'uuid';
-import { makeBlob } from 'libs/globalFuncs';
+import { randomBytes, createCipheriv } from "crypto";
+import { sha3 } from "ethereumjs-util";
+import scrypt from "scryptsy";
+import uuid from "uuid";
 
 export const scryptSettings = {
   n: 1024
 };
 
-export const kdf = 'scrypt';
+export const kdf = "scrypt";
 
-export function genNewPkey(): Buffer {
-  return randomBytes(32);
-}
-
-export function pkeyToAddress(pkey: Buffer): string {
-  return publicToAddress(privateToPublic(pkey)).toString('hex');
-}
-
-export function pkeyToKeystore(pkey: Buffer, password: string) {
+export function pkeyToKeystore(
+  pkey: Buffer,
+  address: string,
+  password: string
+) {
   const salt = randomBytes(32);
   const iv = randomBytes(16);
   let derivedKey;
   const kdfparams: Object = {
     dklen: 32,
-    salt: salt.toString('hex')
+    salt: salt.toString("hex")
   };
-  if (kdf === 'scrypt') {
+  if (kdf === "scrypt") {
     // FIXME: support progress reporting callback
     kdfparams.n = 1024;
     kdfparams.r = 8;
@@ -41,58 +36,31 @@ export function pkeyToKeystore(pkey: Buffer, password: string) {
       kdfparams.dklen
     );
   } else {
-    throw new Error('Unsupported kdf');
+    throw new Error("Unsupported kdf");
   }
-  const cipher = createCipheriv('aes-128-ctr', derivedKey.slice(0, 16), iv);
+  const cipher = createCipheriv("aes-128-ctr", derivedKey.slice(0, 16), iv);
   if (!cipher) {
-    throw new Error('Unsupported cipher');
+    throw new Error("Unsupported cipher");
   }
   const ciphertext = Buffer.concat([cipher.update(pkey), cipher.final()]);
   const mac = sha3(
-    Buffer.concat([derivedKey.slice(16, 32), new Buffer(ciphertext, 'hex')])
+    Buffer.concat([derivedKey.slice(16, 32), new Buffer(ciphertext, "hex")])
   );
   return {
     version: 3,
     id: uuid.v4({
       random: randomBytes(16)
     }),
-    address: pkeyToAddress(pkey),
+    address,
     Crypto: {
-      ciphertext: ciphertext.toString('hex'),
+      ciphertext: ciphertext.toString("hex"),
       cipherparams: {
-        iv: iv.toString('hex')
+        iv: iv.toString("hex")
       },
-      cipher: 'aes-128-ctr',
+      cipher: "aes-128-ctr",
       kdf,
       kdfparams,
-      mac: mac.toString('hex')
+      mac: mac.toString("hex")
     }
-  };
-}
-
-export function getV3Filename(pkey: Buffer) {
-  const ts = new Date();
-  return [
-    'UTC--',
-    ts.toJSON().replace(/:/g, '-'),
-    '--',
-    pkeyToAddress(pkey)
-  ].join('');
-}
-
-export type WalletFile = {
-  fileName: string,
-  blobURI: string
-};
-
-export function genNewKeystore(pkey: Buffer, password: string): WalletFile {
-  let blobEnc = makeBlob(
-    'text/json;charset=UTF-8',
-    pkeyToKeystore(pkey, password)
-  );
-  const encFileName = getV3Filename(pkey);
-  return {
-    fileName: encFileName,
-    blobURI: blobEnc
   };
 }

--- a/common/libs/keystore.js
+++ b/common/libs/keystore.js
@@ -1,14 +1,14 @@
 // @flow
-import { randomBytes, createCipheriv } from "crypto";
-import { sha3 } from "ethereumjs-util";
-import scrypt from "scryptsy";
-import uuid from "uuid";
+import { randomBytes, createCipheriv } from 'crypto';
+import { sha3 } from 'ethereumjs-util';
+import scrypt from 'scryptsy';
+import uuid from 'uuid';
 
 export const scryptSettings = {
   n: 1024
 };
 
-export const kdf = "scrypt";
+export const kdf = 'scrypt';
 
 export function pkeyToKeystore(
   pkey: Buffer,
@@ -20,9 +20,9 @@ export function pkeyToKeystore(
   let derivedKey;
   const kdfparams: Object = {
     dklen: 32,
-    salt: salt.toString("hex")
+    salt: salt.toString('hex')
   };
-  if (kdf === "scrypt") {
+  if (kdf === 'scrypt') {
     // FIXME: support progress reporting callback
     kdfparams.n = 1024;
     kdfparams.r = 8;
@@ -36,15 +36,15 @@ export function pkeyToKeystore(
       kdfparams.dklen
     );
   } else {
-    throw new Error("Unsupported kdf");
+    throw new Error('Unsupported kdf');
   }
-  const cipher = createCipheriv("aes-128-ctr", derivedKey.slice(0, 16), iv);
+  const cipher = createCipheriv('aes-128-ctr', derivedKey.slice(0, 16), iv);
   if (!cipher) {
-    throw new Error("Unsupported cipher");
+    throw new Error('Unsupported cipher');
   }
   const ciphertext = Buffer.concat([cipher.update(pkey), cipher.final()]);
   const mac = sha3(
-    Buffer.concat([derivedKey.slice(16, 32), new Buffer(ciphertext, "hex")])
+    Buffer.concat([derivedKey.slice(16, 32), new Buffer(ciphertext, 'hex')])
   );
   return {
     version: 3,
@@ -53,14 +53,14 @@ export function pkeyToKeystore(
     }),
     address,
     Crypto: {
-      ciphertext: ciphertext.toString("hex"),
+      ciphertext: ciphertext.toString('hex'),
       cipherparams: {
-        iv: iv.toString("hex")
+        iv: iv.toString('hex')
       },
-      cipher: "aes-128-ctr",
+      cipher: 'aes-128-ctr',
       kdf,
       kdfparams,
-      mac: mac.toString("hex")
+      mac: mac.toString('hex')
     }
   };
 }

--- a/common/libs/nodes/base.js
+++ b/common/libs/nodes/base.js
@@ -1,8 +1,8 @@
 // @flow
-import Big from 'big.js';
+import Big from "big.js";
 
 export default class BaseNode {
-  async getBalance(address: string): Promise<Big> {
-    throw new Error('Implement me');
+  async getBalance(_address: string): Promise<Big> {
+    throw new Error("Implement me");
   }
 }

--- a/common/libs/nodes/base.js
+++ b/common/libs/nodes/base.js
@@ -1,8 +1,8 @@
 // @flow
-import Big from "big.js";
+import Big from 'big.js';
 
 export default class BaseNode {
   async getBalance(_address: string): Promise<Big> {
-    throw new Error("Implement me");
+    throw new Error('Implement me');
   }
 }

--- a/common/libs/nodes/rpc.js
+++ b/common/libs/nodes/rpc.js
@@ -1,7 +1,7 @@
 // @flow
-import BaseNode from './base';
-import { randomBytes } from 'crypto';
-import Big from 'big.js';
+import BaseNode from "./base";
+import { randomBytes } from "crypto";
+import Big from "big.js";
 
 type JsonRpcSuccess = {|
   id: string,
@@ -21,8 +21,6 @@ type JsonRpcResponse = JsonRpcSuccess | JsonRpcError;
 // FIXME
 type EthCall = any;
 
-function isError(response) {}
-
 export default class RPCNode extends BaseNode {
   endpoint: string;
   constructor(endpoint: string) {
@@ -31,7 +29,7 @@ export default class RPCNode extends BaseNode {
   }
 
   async getBalance(address: string): Promise<Big> {
-    return this.post('eth_getBalance', [address, 'pending']).then(response => {
+    return this.post("eth_getBalance", [address, "pending"]).then(response => {
       if (response.error) {
         throw new Error(response.error.message);
       }
@@ -45,10 +43,10 @@ export default class RPCNode extends BaseNode {
     return this.batchPost(
       calls.map(params => {
         return {
-          id: randomBytes(16).toString('hex'),
-          jsonrpc: '2.0',
-          method: 'eth_call',
-          params: [params, 'pending']
+          id: randomBytes(16).toString("hex"),
+          jsonrpc: "2.0",
+          method: "eth_call",
+          params: [params, "pending"]
         };
       })
     );
@@ -56,13 +54,13 @@ export default class RPCNode extends BaseNode {
 
   async post(method: string, params: string[]): Promise<JsonRpcResponse> {
     return fetch(this.endpoint, {
-      method: 'POST',
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json'
+        "Content-Type": "application/json"
       },
       body: JSON.stringify({
-        id: randomBytes(16).toString('hex'),
-        jsonrpc: '2.0',
+        id: randomBytes(16).toString("hex"),
+        jsonrpc: "2.0",
         method,
         params
       })
@@ -72,9 +70,9 @@ export default class RPCNode extends BaseNode {
   // FIXME
   async batchPost(requests: any[]): Promise<JsonRpcResponse[]> {
     return fetch(this.endpoint, {
-      method: 'POST',
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json'
+        "Content-Type": "application/json"
       },
       body: JSON.stringify(requests)
     }).then(r => r.json());

--- a/common/libs/nodes/rpc.js
+++ b/common/libs/nodes/rpc.js
@@ -1,7 +1,7 @@
 // @flow
-import BaseNode from "./base";
-import { randomBytes } from "crypto";
-import Big from "big.js";
+import BaseNode from './base';
+import { randomBytes } from 'crypto';
+import Big from 'big.js';
 
 type JsonRpcSuccess = {|
   id: string,
@@ -29,7 +29,7 @@ export default class RPCNode extends BaseNode {
   }
 
   async getBalance(address: string): Promise<Big> {
-    return this.post("eth_getBalance", [address, "pending"]).then(response => {
+    return this.post('eth_getBalance', [address, 'pending']).then(response => {
       if (response.error) {
         throw new Error(response.error.message);
       }
@@ -43,10 +43,10 @@ export default class RPCNode extends BaseNode {
     return this.batchPost(
       calls.map(params => {
         return {
-          id: randomBytes(16).toString("hex"),
-          jsonrpc: "2.0",
-          method: "eth_call",
-          params: [params, "pending"]
+          id: randomBytes(16).toString('hex'),
+          jsonrpc: '2.0',
+          method: 'eth_call',
+          params: [params, 'pending']
         };
       })
     );
@@ -54,13 +54,13 @@ export default class RPCNode extends BaseNode {
 
   async post(method: string, params: string[]): Promise<JsonRpcResponse> {
     return fetch(this.endpoint, {
-      method: "POST",
+      method: 'POST',
       headers: {
-        "Content-Type": "application/json"
+        'Content-Type': 'application/json'
       },
       body: JSON.stringify({
-        id: randomBytes(16).toString("hex"),
-        jsonrpc: "2.0",
+        id: randomBytes(16).toString('hex'),
+        jsonrpc: '2.0',
         method,
         params
       })
@@ -70,9 +70,9 @@ export default class RPCNode extends BaseNode {
   // FIXME
   async batchPost(requests: any[]): Promise<JsonRpcResponse[]> {
     return fetch(this.endpoint, {
-      method: "POST",
+      method: 'POST',
       headers: {
-        "Content-Type": "application/json"
+        'Content-Type': 'application/json'
       },
       body: JSON.stringify(requests)
     }).then(r => r.json());

--- a/common/libs/wallet/privkey.js
+++ b/common/libs/wallet/privkey.js
@@ -1,12 +1,12 @@
 // @flow
-import BaseWallet from "./base";
+import BaseWallet from './base';
 import {
   privateToPublic,
   publicToAddress,
   toChecksumAddress
-} from "ethereumjs-util";
-import { randomBytes } from "crypto";
-import { pkeyToKeystore } from "libs/keystore";
+} from 'ethereumjs-util';
+import { randomBytes } from 'crypto';
+import { pkeyToKeystore } from 'libs/keystore';
 
 export default class PrivKeyWallet extends BaseWallet {
   privKey: Buffer;
@@ -20,11 +20,11 @@ export default class PrivKeyWallet extends BaseWallet {
   }
 
   getAddress() {
-    return toChecksumAddress(`0x${this.address.toString("hex")}`);
+    return toChecksumAddress(`0x${this.address.toString('hex')}`);
   }
 
   getPrivateKey() {
-    return this.privKey.toString("hex");
+    return this.privKey.toString('hex');
   }
 
   static generate() {

--- a/common/libs/wallet/privkey.js
+++ b/common/libs/wallet/privkey.js
@@ -1,28 +1,37 @@
 // @flow
-import BaseWallet from './base';
+import BaseWallet from "./base";
 import {
   privateToPublic,
   publicToAddress,
   toChecksumAddress
-} from 'ethereumjs-util';
-
-export type PrivateKeyUnlockParams = {
-  key: string,
-  password: string
-};
+} from "ethereumjs-util";
+import { randomBytes } from "crypto";
+import { pkeyToKeystore } from "libs/keystore";
 
 export default class PrivKeyWallet extends BaseWallet {
   privKey: Buffer;
   pubKey: Buffer;
   address: Buffer;
-  constructor(params: PrivateKeyUnlockParams) {
+  constructor(privkey: Buffer) {
     super();
-    this.privKey = Buffer.from(params.key, 'hex');
+    this.privKey = privkey;
     this.pubKey = privateToPublic(this.privKey);
     this.address = publicToAddress(this.pubKey);
   }
 
   getAddress() {
-    return toChecksumAddress(`0x${this.address.toString('hex')}`);
+    return toChecksumAddress(`0x${this.address.toString("hex")}`);
+  }
+
+  getPrivateKey() {
+    return this.privKey.toString("hex");
+  }
+
+  static generate() {
+    return new PrivKeyWallet(randomBytes(32));
+  }
+
+  toKeystore(password: string): Object {
+    return pkeyToKeystore(this.privKey, this.getNakedAddress(), password);
   }
 }

--- a/common/reducers/generateWallet.js
+++ b/common/reducers/generateWallet.js
@@ -5,8 +5,8 @@ import {
   GENERATE_WALLET_DOWNLOAD_FILE,
   GENERATE_WALLET_CONFIRM_CONTINUE_TO_PAPER,
   GENERATE_WALLET_CONTINUE_TO_UNLOCK
-} from 'actions/generateWalletConstants';
-import { WalletFile } from 'libs/keystore';
+} from "actions/generateWalletConstants";
+import type { WalletFile } from "libs/keystore";
 
 export type State = {
   activeStep: string,
@@ -17,7 +17,7 @@ export type State = {
 };
 
 const initialState: State = {
-  activeStep: 'password',
+  activeStep: "password",
   hasDownloadedWalletFile: false,
   privateKey: null,
   address: null,
@@ -29,7 +29,7 @@ export function generateWallet(state: State = initialState, action): State {
     case GENERATE_WALLET_SHOW_PASSWORD: {
       return {
         ...state,
-        activeStep: 'password'
+        activeStep: "password"
       };
     }
 
@@ -39,7 +39,7 @@ export function generateWallet(state: State = initialState, action): State {
         privateKey: action.privateKey,
         address: action.address,
         walletFile: action.walletFile,
-        activeStep: 'download'
+        activeStep: "download"
       };
     }
 
@@ -53,14 +53,14 @@ export function generateWallet(state: State = initialState, action): State {
     case GENERATE_WALLET_CONFIRM_CONTINUE_TO_PAPER: {
       return {
         ...state,
-        activeStep: 'paper'
+        activeStep: "paper"
       };
     }
 
     case GENERATE_WALLET_CONTINUE_TO_UNLOCK: {
       return {
         ...state,
-        activeStep: 'unlock'
+        activeStep: "unlock"
       };
     }
 

--- a/common/reducers/generateWallet.js
+++ b/common/reducers/generateWallet.js
@@ -6,22 +6,20 @@ import {
   GENERATE_WALLET_CONFIRM_CONTINUE_TO_PAPER,
   GENERATE_WALLET_CONTINUE_TO_UNLOCK
 } from "actions/generateWalletConstants";
-import type { WalletFile } from "libs/keystore";
+import type PrivateKeyWallet from "libs/wallet/privkey";
 
 export type State = {
   activeStep: string,
   hasDownloadedWalletFile: boolean,
-  privateKey: string,
-  address: string,
-  walletFile: WalletFile
+  wallet: ?PrivateKeyWallet,
+  password: ?string
 };
 
 const initialState: State = {
   activeStep: "password",
   hasDownloadedWalletFile: false,
-  privateKey: null,
-  address: null,
-  walletFile: null
+  wallet: null,
+  password: null
 };
 
 export function generateWallet(state: State = initialState, action): State {
@@ -36,9 +34,8 @@ export function generateWallet(state: State = initialState, action): State {
     case GENERATE_WALLET_FILE: {
       return {
         ...state,
-        privateKey: action.privateKey,
-        address: action.address,
-        walletFile: action.walletFile,
+        wallet: action.wallet,
+        password: action.password,
         activeStep: "download"
       };
     }

--- a/common/reducers/generateWallet.js
+++ b/common/reducers/generateWallet.js
@@ -5,8 +5,8 @@ import {
   GENERATE_WALLET_DOWNLOAD_FILE,
   GENERATE_WALLET_CONFIRM_CONTINUE_TO_PAPER,
   GENERATE_WALLET_CONTINUE_TO_UNLOCK
-} from "actions/generateWalletConstants";
-import type PrivateKeyWallet from "libs/wallet/privkey";
+} from 'actions/generateWalletConstants';
+import type PrivateKeyWallet from 'libs/wallet/privkey';
 
 export type State = {
   activeStep: string,
@@ -16,7 +16,7 @@ export type State = {
 };
 
 const initialState: State = {
-  activeStep: "password",
+  activeStep: 'password',
   hasDownloadedWalletFile: false,
   wallet: null,
   password: null
@@ -27,7 +27,7 @@ export function generateWallet(state: State = initialState, action): State {
     case GENERATE_WALLET_SHOW_PASSWORD: {
       return {
         ...state,
-        activeStep: "password"
+        activeStep: 'password'
       };
     }
 
@@ -36,7 +36,7 @@ export function generateWallet(state: State = initialState, action): State {
         ...state,
         wallet: action.wallet,
         password: action.password,
-        activeStep: "download"
+        activeStep: 'download'
       };
     }
 
@@ -50,14 +50,14 @@ export function generateWallet(state: State = initialState, action): State {
     case GENERATE_WALLET_CONFIRM_CONTINUE_TO_PAPER: {
       return {
         ...state,
-        activeStep: "paper"
+        activeStep: 'paper'
       };
     }
 
     case GENERATE_WALLET_CONTINUE_TO_UNLOCK: {
       return {
         ...state,
-        activeStep: "unlock"
+        activeStep: 'unlock'
       };
     }
 

--- a/common/sagas/bity.js
+++ b/common/sagas/bity.js
@@ -1,18 +1,17 @@
 // @flow
 
-import { call, put, fork, take, cancel, cancelled } from 'redux-saga/effects';
+import { call, put, fork, take, cancel, cancelled } from "redux-saga/effects";
 
-import type { Effect } from 'redux-saga/effects';
-import { delay } from 'redux-saga';
-import { updateBityRatesSwap } from 'actions/swap';
+import type { Effect } from "redux-saga/effects";
+import { delay } from "redux-saga";
+import { updateBityRatesSwap } from "actions/swap";
 import {
   SWAP_LOAD_BITY_RATES,
   SWAP_STOP_LOAD_BITY_RATES
-} from 'actions/swapConstants';
-import type { UnlockPrivateKeyAction } from 'actions/wallet';
-import { getAllRates } from 'api/bity';
+} from "actions/swapConstants";
+import { getAllRates } from "api/bity";
 
-export function* loadBityRates(action?: any): Generator<Effect, void, any> {
+export function* loadBityRates(_action?: any): Generator<Effect, void, any> {
   try {
     while (true) {
       // TODO - yield put(actions.requestStart()) if we want to display swap refresh status

--- a/common/sagas/bity.js
+++ b/common/sagas/bity.js
@@ -1,15 +1,15 @@
 // @flow
 
-import { call, put, fork, take, cancel, cancelled } from "redux-saga/effects";
+import { call, put, fork, take, cancel, cancelled } from 'redux-saga/effects';
 
-import type { Effect } from "redux-saga/effects";
-import { delay } from "redux-saga";
-import { updateBityRatesSwap } from "actions/swap";
+import type { Effect } from 'redux-saga/effects';
+import { delay } from 'redux-saga';
+import { updateBityRatesSwap } from 'actions/swap';
 import {
   SWAP_LOAD_BITY_RATES,
   SWAP_STOP_LOAD_BITY_RATES
-} from "actions/swapConstants";
-import { getAllRates } from "api/bity";
+} from 'actions/swapConstants';
+import { getAllRates } from 'api/bity';
 
 export function* loadBityRates(_action?: any): Generator<Effect, void, any> {
   try {

--- a/common/sagas/wallet.js
+++ b/common/sagas/wallet.js
@@ -1,18 +1,18 @@
 // @flow
-import { takeEvery, call, apply, put, select, fork } from "redux-saga/effects";
-import type { Effect } from "redux-saga/effects";
-import { setWallet, setBalance, setTokenBalances } from "actions/wallet";
-import type { UnlockPrivateKeyAction } from "actions/wallet";
-import { showNotification } from "actions/notifications";
-import translate from "translations";
-import { PrivKeyWallet, BaseWallet } from "libs/wallet";
-import { BaseNode } from "libs/nodes";
-import { getNodeLib } from "selectors/config";
-import { getWalletInst, getTokens } from "selectors/wallet";
-import Big from "big.js";
+import { takeEvery, call, apply, put, select, fork } from 'redux-saga/effects';
+import type { Effect } from 'redux-saga/effects';
+import { setWallet, setBalance, setTokenBalances } from 'actions/wallet';
+import type { UnlockPrivateKeyAction } from 'actions/wallet';
+import { showNotification } from 'actions/notifications';
+import translate from 'translations';
+import { PrivKeyWallet, BaseWallet } from 'libs/wallet';
+import { BaseNode } from 'libs/nodes';
+import { getNodeLib } from 'selectors/config';
+import { getWalletInst, getTokens } from 'selectors/wallet';
+import Big from 'big.js';
 
 // FIXME MOVE ME
-function padLeft(n: string, width: number, z: string = "0"): string {
+function padLeft(n: string, width: number, z: string = '0'): string {
   return n.length >= width ? n : new Array(width - n.length + 1).join(z) + n;
 }
 
@@ -41,7 +41,7 @@ function* updateTokenBalances() {
     return;
   }
   const requests = tokens.map(token =>
-    getEthCallData(token.address, "0x70a08231", [wallet.getNakedAddress()])
+    getEthCallData(token.address, '0x70a08231', [wallet.getNakedAddress()])
   );
   // FIXME handle errors
   const tokenBalances = yield apply(node, node.ethCall, [requests]);
@@ -49,7 +49,7 @@ function* updateTokenBalances() {
     setTokenBalances(
       tokens.reduce((acc, t, i) => {
         // FIXME
-        if (tokenBalances[i].error || tokenBalances[i].result === "0x") {
+        if (tokenBalances[i].error || tokenBalances[i].result === '0x') {
           return acc;
         }
         let balance = Big(Number(tokenBalances[i].result)).div(
@@ -74,9 +74,9 @@ export function* unlockPrivateKey(
   let wallet = null;
 
   try {
-    wallet = new PrivKeyWallet(Buffer.from(action.payload.key, "hex"));
+    wallet = new PrivKeyWallet(Buffer.from(action.payload.key, 'hex'));
   } catch (e) {
-    yield put(showNotification("danger", translate("INVALID_PKEY")));
+    yield put(showNotification('danger', translate('INVALID_PKEY')));
     return;
   }
   yield put(setWallet(wallet));
@@ -87,7 +87,7 @@ export default function* walletSaga(): Generator<Effect | Effect[], void, any> {
   // useful for development
   yield call(updateBalances);
   yield [
-    takeEvery("WALLET_UNLOCK_PRIVATE_KEY", unlockPrivateKey),
-    takeEvery("CUSTOM_TOKEN_ADD", updateTokenBalances)
+    takeEvery('WALLET_UNLOCK_PRIVATE_KEY', unlockPrivateKey),
+    takeEvery('CUSTOM_TOKEN_ADD', updateTokenBalances)
   ];
 }

--- a/common/sagas/wallet.js
+++ b/common/sagas/wallet.js
@@ -1,18 +1,18 @@
 // @flow
-import { takeEvery, call, apply, put, select, fork } from 'redux-saga/effects';
-import type { Effect } from 'redux-saga/effects';
-import { setWallet, setBalance, setTokenBalances } from 'actions/wallet';
-import type { UnlockPrivateKeyAction } from 'actions/wallet';
-import { showNotification } from 'actions/notifications';
-import translate from 'translations';
-import { PrivKeyWallet, BaseWallet } from 'libs/wallet';
-import { BaseNode } from 'libs/nodes';
-import { getNodeLib } from 'selectors/config';
-import { getWalletInst, getTokens } from 'selectors/wallet';
-import Big from 'big.js';
+import { takeEvery, call, apply, put, select, fork } from "redux-saga/effects";
+import type { Effect } from "redux-saga/effects";
+import { setWallet, setBalance, setTokenBalances } from "actions/wallet";
+import type { UnlockPrivateKeyAction } from "actions/wallet";
+import { showNotification } from "actions/notifications";
+import translate from "translations";
+import { PrivKeyWallet, BaseWallet } from "libs/wallet";
+import { BaseNode } from "libs/nodes";
+import { getNodeLib } from "selectors/config";
+import { getWalletInst, getTokens } from "selectors/wallet";
+import Big from "big.js";
 
 // FIXME MOVE ME
-function padLeft(n: string, width: number, z: string = '0'): string {
+function padLeft(n: string, width: number, z: string = "0"): string {
   return n.length >= width ? n : new Array(width - n.length + 1).join(z) + n;
 }
 
@@ -41,7 +41,7 @@ function* updateTokenBalances() {
     return;
   }
   const requests = tokens.map(token =>
-    getEthCallData(token.address, '0x70a08231', [wallet.getNakedAddress()])
+    getEthCallData(token.address, "0x70a08231", [wallet.getNakedAddress()])
   );
   // FIXME handle errors
   const tokenBalances = yield apply(node, node.ethCall, [requests]);
@@ -49,7 +49,7 @@ function* updateTokenBalances() {
     setTokenBalances(
       tokens.reduce((acc, t, i) => {
         // FIXME
-        if (tokenBalances[i].error || tokenBalances[i].result === '0x') {
+        if (tokenBalances[i].error || tokenBalances[i].result === "0x") {
           return acc;
         }
         let balance = Big(Number(tokenBalances[i].result)).div(
@@ -74,9 +74,9 @@ export function* unlockPrivateKey(
   let wallet = null;
 
   try {
-    wallet = new PrivKeyWallet(action.payload);
+    wallet = new PrivKeyWallet(Buffer.from(action.payload.key, "hex"));
   } catch (e) {
-    yield put(showNotification('danger', translate('INVALID_PKEY')));
+    yield put(showNotification("danger", translate("INVALID_PKEY")));
     return;
   }
   yield put(setWallet(wallet));
@@ -87,7 +87,7 @@ export default function* walletSaga(): Generator<Effect | Effect[], void, any> {
   // useful for development
   yield call(updateBalances);
   yield [
-    takeEvery('WALLET_UNLOCK_PRIVATE_KEY', unlockPrivateKey),
-    takeEvery('CUSTOM_TOKEN_ADD', updateTokenBalances)
+    takeEvery("WALLET_UNLOCK_PRIVATE_KEY", unlockPrivateKey),
+    takeEvery("CUSTOM_TOKEN_ADD", updateTokenBalances)
   ];
 }

--- a/common/utils/printElement.js
+++ b/common/utils/printElement.js
@@ -1,6 +1,6 @@
 // @flow
-import React from "react";
-import { renderToString } from "react-dom/server";
+import React from 'react';
+import { renderToString } from 'react-dom/server';
 
 type PrintOptions = {
   styles?: string,
@@ -10,7 +10,7 @@ type PrintOptions = {
 
 export default function(element: React.Element<*>, opts: PrintOptions = {}) {
   const options = {
-    styles: "",
+    styles: '',
     printTimeout: 500,
     popupFeatures: {},
     ...opts
@@ -21,9 +21,9 @@ export default function(element: React.Element<*>, opts: PrintOptions = {}) {
   // for more information.
   const featuresStr = Object.keys(options.popupFeatures)
     .map(key => `${key}=${options.popupFeatures[key]}`)
-    .join(",");
+    .join(',');
 
-  const popup = window.open("about:blank", "printWindow", featuresStr);
+  const popup = window.open('about:blank', 'printWindow', featuresStr);
   popup.document.open();
   popup.document.write(`
   <html>

--- a/common/utils/printElement.js
+++ b/common/utils/printElement.js
@@ -1,15 +1,16 @@
-import React from 'react';
-import { renderToString } from 'react-dom/server';
+// @flow
+import React from "react";
+import { renderToString } from "react-dom/server";
 
 type PrintOptions = {
-  styles: string,
-  printTimeout: number,
-  popupFeatures: Object
+  styles?: string,
+  printTimeout?: number,
+  popupFeatures?: Object
 };
 
-export default function(element: React.Element, opts: PrintOptions = {}) {
+export default function(element: React.Element<*>, opts: PrintOptions = {}) {
   const options = {
-    styles: '',
+    styles: "",
     printTimeout: 500,
     popupFeatures: {},
     ...opts
@@ -20,24 +21,23 @@ export default function(element: React.Element, opts: PrintOptions = {}) {
   // for more information.
   const featuresStr = Object.keys(options.popupFeatures)
     .map(key => `${key}=${options.popupFeatures[key]}`)
-    .join(',');
+    .join(",");
 
-  console.log(featuresStr);
-  const popup = window.open('about:blank', 'printWindow', featuresStr);
+  const popup = window.open("about:blank", "printWindow", featuresStr);
   popup.document.open();
   popup.document.write(`
-		<html>
-			<head>
-				<style>${options.styles}</style>
-				<script>
-					setTimeout(function() {
-						window.print();
-					}, ${options.printTimeout});
-				</script>
-			</head>
-			<body>
-				${renderToString(element)}
-			</body>
-		</html>
+  <html>
+    <head>
+      <style>${options.styles}</style>
+      <script>
+        setTimeout(function() {
+          window.print();
+        }, ${options.printTimeout});
+      </script>
+    </head>
+    <body>
+      ${renderToString(element)}
+    </body>
+    </html>
 	`);
 }

--- a/common/utils/printElement.js
+++ b/common/utils/printElement.js
@@ -37,6 +37,14 @@ export default function(element: React.Element<*>, opts: PrintOptions = {}) {
     </head>
     <body>
       ${renderToString(element)}
+      <script>
+        // FIXME consider if we REALLY want it
+        var width = document.body.children[0].offsetWidth;
+        var height = document.body.children[0].offsetHeight;
+        window.moveTo(0, 0);
+        // FIXME Chrome could be larger (i guess?)
+        window.resizeTo(width + 60, height + 60);
+      </script>
     </body>
     </html>
 	`);

--- a/common/utils/printElement.js
+++ b/common/utils/printElement.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+
+type PrintOptions = {
+  styles: string,
+  printTimeout: number,
+  popupFeatures: Object
+};
+
+export default function(element: React.Element, opts: PrintOptions = {}) {
+  const options = {
+    styles: '',
+    printTimeout: 500,
+    popupFeatures: {},
+    ...opts
+  };
+
+  // Convert popupFeatures into a key=value,key=value string. See
+  // https://developer.mozilla.org/en-US/docs/Web/API/Window/open#Window_features
+  // for more information.
+  const featuresStr = Object.keys(options.popupFeatures)
+    .map(key => `${key}=${options.popupFeatures[key]}`)
+    .join(',');
+
+  console.log(featuresStr);
+  const popup = window.open('about:blank', 'printWindow', featuresStr);
+  popup.document.open();
+  popup.document.write(`
+		<html>
+			<head>
+				<style>${options.styles}</style>
+				<script>
+					setTimeout(function() {
+						window.print();
+					}, ${options.printTimeout});
+				</script>
+			</head>
+			<body>
+				${renderToString(element)}
+			</body>
+		</html>
+	`);
+}

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
   },
   "lint-staged": {
     "*.{js,jsx}": [
-      "prettier --write",
+      "prettier --write --single-quote",
       "git add"
     ]
   }


### PR DESCRIPTION
Addresses the following from #38:

* Generic print function for any react element
* Use ReactDOMServer renderToString instead of an element ref for printing
* Handle prop changes to regenerate QR codes for address / pkey in PrintableWallet component
* Reworded some comments for clarity

It does not address:

* Inline styles. I know this was contentious (And even I'm not thrilled with it) but reworking that to work with a proper stylesheet will take a long time of figuring out dev-specific issues for an isolated component that's finished.
* QR Code generic component. See https://github.com/MyEtherWallet/MyEtherWallet/pull/38#discussion_r127597274 for reasoning. There's also a lot to consider here that's print specific, such as needing to wait for it to be generated before allowing the print button to be clicked, and the inline styling.
* Splitting the wallet out into its own component. Not opposed, but there would be a lot to consider (Communicating size between components, not showing print button until QR codes are loaded etc.) This could be done later if there's a need for the paper wallet elsewhere.

Sorry for the issues I left behind. I appreciate all of the feedback, and agree with it as well. But the nature of making something printable really drags a lot of the standards down with it, to the point where I valued isolation of those component over good coding practice in a few places. I hope that's alright with y'all.

cc @dternyak @crptm @NessDan 