### PR TITLE
Make Husky use single quotes.

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,0 @@
-{
-  "printWidth": 80,
-  "parser": "flow",
-  "single-quote": true
-}

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
   },
   "lint-staged": {
     "*.{js,jsx}": [
-      "prettier --write",
+      "prettier --write --single-quote",
       "git add"
     ]
   }


### PR DESCRIPTION
- Adjust 'lint-staged' to pass single-quote via CLI
- remove unneeded .prettierrc (no longer needed)