### PR TITLE
Bugfix: Invalid proptype in GenerateWallet

### DIFF
--- a/common/containers/Tabs/GenerateWallet/index.js
+++ b/common/containers/Tabs/GenerateWallet/index.js
@@ -24,7 +24,7 @@ class GenerateWallet extends Component {
     activeStep: PropTypes.string,
     wallet: PropTypes.object,
     password: PropTypes.string,
-    hasDownloadedWalletFile: PropTypes.boolean,
+    hasDownloadedWalletFile: PropTypes.bool,
     // Actions
     showPasswordGenerateWallet: PropTypes.func,
     generateUTCGenerateWallet: PropTypes.func,


### PR DESCRIPTION
Update GenerateWallet `hasDownloadedWalletFile` prop type from invalid `boolean` type to valid `bool` type.