### PR TITLE
Added missing qr code dependency to package lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1434,8 +1434,7 @@
     "colors": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
-      "dev": true
+      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
     },
     "combined-stream": {
       "version": "1.0.5",
@@ -1944,6 +1943,11 @@
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
       "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
       "dev": true
+    },
+    "dijkstrajs": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.1.tgz",
+      "integrity": "sha1-082BIh4+pAdCz83lVtTpnpjdxxs="
     },
     "doctrine": {
       "version": "2.0.0",
@@ -5947,6 +5951,11 @@
       "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
       "dev": true
     },
+    "pngjs": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-2.3.1.tgz",
+      "integrity": "sha1-EdHhK5y2TWPjDBQ6Mw9MH1Z9qF8="
+    },
     "pngquant-bin": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/pngquant-bin/-/pngquant-bin-3.1.1.tgz",
@@ -6407,6 +6416,18 @@
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
       "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE=",
       "dev": true
+    },
+    "qrcode": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-0.8.2.tgz",
+      "integrity": "sha1-SktN10rkO3sF1MxZi63BwDg3GJw=",
+      "dependencies": {
+        "isarray": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.2.tgz",
+          "integrity": "sha512-DKCXsIpN+352zm3Sd75dY9HyaIcxU6grh118GhTPXc85jJ5nEGKOsPQOwSuE7aRd+XVRcC/Em6W44onQEQ9RBg=="
+        }
+      }
     },
     "qs": {
       "version": "6.4.0",


### PR DESCRIPTION
Looks like this dependency didn't make it into package lock from the previous PR. My bad.