### PR TITLE
Add Promises & Signing to Wallet Classes 

### DIFF
--- a/common/libs/signing.js
+++ b/common/libs/signing.js
@@ -3,8 +3,9 @@
 import EthTx from 'ethereumjs-tx';
 import { sha3, ecsign } from 'ethereumjs-util';
 import { isValidRawTx } from 'libs/validators';
+import type { RawTx } from 'libs/validators';
 
-export function signRawTxWithPrivKey(privKey: Buffer, rawTx: Object): string {
+export function signRawTxWithPrivKey(privKey: Buffer, rawTx: RawTx): string {
   if (!isValidRawTx(rawTx)) {
     throw new Error('Invalid raw transaction');
   }

--- a/common/libs/signing.js
+++ b/common/libs/signing.js
@@ -1,0 +1,39 @@
+// @flow
+
+import EthTx from 'ethereumjs-tx';
+import { sha3, ecsign } from 'ethereumjs-util';
+import { isValidRawTx } from 'libs/validators';
+
+export function signRawTxWithPrivKey(privKey: Buffer, rawTx: Object): string {
+  if (!isValidRawTx(rawTx)) {
+    throw new Error('Invalid raw transaction');
+  }
+
+  let eTx = new EthTx(rawTx);
+  eTx.sign(privKey);
+  return '0x' + eTx.serialize().toString('hex');
+}
+
+export function signMessageWithPrivKey(
+  privKey: Buffer,
+  msg: string,
+  address: string,
+  date: string
+): string {
+  let spacer = msg.length > 0 && date.length > 0 ? ' ' : '';
+  let fullMessage = msg + spacer + date;
+  let hash = sha3(fullMessage);
+  let signed = ecsign(hash, privKey);
+  let combined = Buffer.concat([
+    Buffer.from(signed.r),
+    Buffer.from(signed.s),
+    Buffer.from([signed.v])
+  ]);
+  let combinedHex = combined.toString('hex');
+
+  return JSON.stringify({
+    address: address,
+    msg: fullMessage,
+    sig: '0x' + combinedHex
+  });
+}

--- a/common/libs/validators.js
+++ b/common/libs/validators.js
@@ -85,7 +85,17 @@ export function isPositiveIntegerOrZero(number: number): boolean {
   return number >= 0 && parseInt(number) === number;
 }
 
-export function isValidRawTx(rawTx: Object): boolean {
+export type RawTx = {
+  nonce: string,
+  gasPrice: string,
+  gasLimit: string,
+  to: string,
+  value: string,
+  data: string,
+  chainId: number
+};
+
+export function isValidRawTx(rawTx: RawTx): boolean {
   const propReqs = [
     { name: 'nonce', type: 'string', lenReq: true },
     { name: 'gasPrice', type: 'string', lenReq: true },

--- a/common/libs/validators.js
+++ b/common/libs/validators.js
@@ -95,7 +95,6 @@ export function isValidRawTx(rawTx: Object): boolean {
     { name: 'data', type: 'string', lenReq: false },
     { name: 'chainId', type: 'number' }
   ];
-  let valid = true;
 
   //ensure rawTx has above properties
   //ensure all specified types match
@@ -105,24 +104,23 @@ export function isValidRawTx(rawTx: Object): boolean {
   //ensure valid address for 'to' prop
   //ensure rawTx only has above properties
 
-  propReqs.forEach(prop => {
-    if (!valid) return;
-
+  for (let i = 0; i < propReqs.length; i++) {
+    const prop = propReqs[i];
     const value = rawTx[prop.name];
 
-    if (!rawTx.hasOwnProperty(prop.name)) valid = false;
-    if (typeof value !== prop.type) valid = false;
+    if (!rawTx.hasOwnProperty(prop.name)) return false;
+    if (typeof value !== prop.type) return false;
     if (prop.type === 'string') {
-      if (prop.lenReq && value.length === 0) valid = false;
+      if (prop.lenReq && value.length === 0) return false;
       if (value.length && value.substring(0, 2) !== '0x') {
-        valid = false;
+        return false;
       }
-      if (!isValidHex(value)) valid = false;
+      if (!isValidHex(value)) return false;
     }
-  });
+  }
 
-  if (!isValidETHAddress(rawTx.to)) valid = false;
-  if (Object.keys(rawTx).length !== propReqs.length) valid = false;
+  if (!isValidETHAddress(rawTx.to)) return false;
+  if (Object.keys(rawTx).length !== propReqs.length) return false;
 
-  return valid;
+  return true;
 }

--- a/common/libs/validators.js
+++ b/common/libs/validators.js
@@ -84,3 +84,45 @@ export function isPositiveIntegerOrZero(number: number): boolean {
   }
   return number >= 0 && parseInt(number) === number;
 }
+
+export function isValidRawTx(rawTx: Object): boolean {
+  const propReqs = [
+    { name: 'nonce', type: 'string', lenReq: true },
+    { name: 'gasPrice', type: 'string', lenReq: true },
+    { name: 'gasLimit', type: 'string', lenReq: true },
+    { name: 'to', type: 'string', lenReq: true },
+    { name: 'value', type: 'string', lenReq: true },
+    { name: 'data', type: 'string', lenReq: false },
+    { name: 'chainId', type: 'number' }
+  ];
+  let valid = true;
+
+  //ensure rawTx has above properties
+  //ensure all specified types match
+  //ensure length !0 for strings where length is required
+  //ensure valid hex for strings
+  //ensure all strings begin with '0x'
+  //ensure valid address for 'to' prop
+  //ensure rawTx only has above properties
+
+  propReqs.forEach(prop => {
+    if (!valid) return;
+
+    const value = rawTx[prop.name];
+
+    if (!rawTx.hasOwnProperty(prop.name)) return (valid = false);
+    if (typeof value !== prop.type) return (valid = false);
+    if (prop.type === 'string') {
+      if (prop.lenReq && value.length === 0) return (valid = false);
+      if (value.length && value.substring(0, 2) !== '0x') {
+        return (valid = false);
+      }
+      if (!isValidHex(value)) return (valid = false);
+    }
+  });
+
+  if (!isValidETHAddress(rawTx.to)) valid = false;
+  if (Object.keys(rawTx).length !== propReqs.length) valid = false;
+
+  return valid;
+}

--- a/common/libs/validators.js
+++ b/common/libs/validators.js
@@ -110,14 +110,14 @@ export function isValidRawTx(rawTx: Object): boolean {
 
     const value = rawTx[prop.name];
 
-    if (!rawTx.hasOwnProperty(prop.name)) return (valid = false);
-    if (typeof value !== prop.type) return (valid = false);
+    if (!rawTx.hasOwnProperty(prop.name)) valid = false;
+    if (typeof value !== prop.type) valid = false;
     if (prop.type === 'string') {
-      if (prop.lenReq && value.length === 0) return (valid = false);
+      if (prop.lenReq && value.length === 0) valid = false;
       if (value.length && value.substring(0, 2) !== '0x') {
-        return (valid = false);
+        valid = false;
       }
-      if (!isValidHex(value)) return (valid = false);
+      if (!isValidHex(value)) valid = false;
     }
   });
 

--- a/common/libs/wallet/base.js
+++ b/common/libs/wallet/base.js
@@ -1,11 +1,15 @@
 // @flow
 
 export default class BaseWallet {
-  getAddress(): string {
+  getAddress(): Promise<any> {
     throw 'Implement me';
   }
 
-  getNakedAddress(): string {
-    return this.getAddress().replace('0x', '').toLowerCase();
+  getNakedAddress(): Promise<any> {
+    return new Promise(resolve => {
+      this.getAddress.then(address => {
+        resolve(address.replace('0x', '').toLowerCase());
+      });
+    });
   }
 }

--- a/common/libs/wallet/base.js
+++ b/common/libs/wallet/base.js
@@ -2,7 +2,7 @@
 
 export default class BaseWallet {
   getAddress(): Promise<any> {
-    throw 'Implement me';
+    return Promise.reject('Implement me');
   }
 
   getNakedAddress(): Promise<any> {

--- a/common/libs/wallet/privkey.js
+++ b/common/libs/wallet/privkey.js
@@ -7,6 +7,7 @@ import {
 } from 'ethereumjs-util';
 import { randomBytes } from 'crypto';
 import { pkeyToKeystore } from 'libs/keystore';
+import { signRawTxWithPrivKey, signMessageWithPrivKey } from 'libs/signing';
 
 export default class PrivKeyWallet extends BaseWallet {
   privKey: Buffer;
@@ -19,8 +20,10 @@ export default class PrivKeyWallet extends BaseWallet {
     this.address = publicToAddress(this.pubKey);
   }
 
-  getAddress() {
-    return toChecksumAddress(`0x${this.address.toString('hex')}`);
+  getAddress(): Promise<any> {
+    return new Promise(resolve => {
+      resolve(toChecksumAddress(`0x${this.address.toString('hex')}`));
+    });
   }
 
   getPrivateKey() {
@@ -31,7 +34,37 @@ export default class PrivKeyWallet extends BaseWallet {
     return new PrivKeyWallet(randomBytes(32));
   }
 
-  toKeystore(password: string): Object {
-    return pkeyToKeystore(this.privKey, this.getNakedAddress(), password);
+  toKeystore(password: string): Promise<any> {
+    return new Promise(resolve => {
+      this.getNakedAddress().then(address => {
+        resolve(pkeyToKeystore(this.privKey, address, password));
+      });
+    });
+  }
+
+  unlock(): Promise<any> {
+    return new Promise(resolve => {
+      resolve();
+    });
+  }
+
+  signRawTransaction(rawTx: Object): Promise<any> {
+    return new Promise((resolve, reject) => {
+      try {
+        resolve(signRawTxWithPrivKey(this.privKey, rawTx));
+      } catch (err) {
+        reject(err);
+      }
+    });
+  }
+
+  signMessage(msg: string, address: string, date: string): Promise<any> {
+    return new Promise((resolve, reject) => {
+      try {
+        resolve(signMessageWithPrivKey(this.privKey, msg, address, date));
+      } catch (err) {
+        reject(err);
+      }
+    });
   }
 }

--- a/common/libs/wallet/privkey.js
+++ b/common/libs/wallet/privkey.js
@@ -8,6 +8,7 @@ import {
 import { randomBytes } from 'crypto';
 import { pkeyToKeystore } from 'libs/keystore';
 import { signRawTxWithPrivKey, signMessageWithPrivKey } from 'libs/signing';
+import type { RawTx } from 'libs/validators';
 
 export default class PrivKeyWallet extends BaseWallet {
   privKey: Buffer;
@@ -48,7 +49,7 @@ export default class PrivKeyWallet extends BaseWallet {
     });
   }
 
-  signRawTransaction(rawTx: Object): Promise<any> {
+  signRawTransaction(rawTx: RawTx): Promise<any> {
     return new Promise((resolve, reject) => {
       try {
         resolve(signRawTxWithPrivKey(this.privKey, rawTx));

--- a/common/libs/wallet/privkey.js
+++ b/common/libs/wallet/privkey.js
@@ -44,9 +44,7 @@ export default class PrivKeyWallet extends BaseWallet {
   }
 
   unlock(): Promise<any> {
-    return new Promise(resolve => {
-      resolve();
-    });
+    return Promise.resolve();
   }
 
   signRawTransaction(rawTx: RawTx): Promise<any> {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "big.js": "^3.1.3",
     "ethereum-blockies": "git+https://github.com/MyEtherWallet/blockies.git",
+    "ethereumjs-tx": "^1.3.3",
     "ethereumjs-util": "^5.1.2",
     "ethereumjs-wallet": "^0.6.0",
     "font-awesome": "^4.7.0",


### PR DESCRIPTION
### What This PR Does

Inspired by the discussion from issue #103 a few days ago:

* Implements promise-based methods on the `BaseWallet` & `PrivKeyWallet` classes
* Creates new `signing.js` file that handles private key TX & message signing
* Adds raw TX validation to `validators.js`
* Implements `signRawTransaction` and `signMessage` methods on `PrivKeyWallet` class
* Adds dependency to `ethereumjs-tx` in `package.json` (used in v3)

Transaction signing was modeled from v3 file [uiFuncs.js](https://github.com/kvhnuke/etherwallet/blob/3ab97999a157b1e0410de49b40080bcd35a1f5b3/app/scripts/uiFuncs.js) (~line 96).

Message signing was modeled from v3 file [signMsgCtrl.js](https://github.com/kvhnuke/etherwallet/blob/75157b1279f31d13ab975af97eefbed098265990/app/scripts/controllers/signMsgCtrl.js) (~line 22).

### What It Doesn't Do

It does not update our `package-lock.json` file. Just doing a `npm install` after pulling down a completely fresh copy of the repo caused a few packages to bump up in version numbers. I'd like to first understand why, though can commit the changes if necessary.