### PR TITLE
Fix flow errors

### DIFF
--- a/common/components/BalanceSidebar/BalanceSidebar.jsx
+++ b/common/components/BalanceSidebar/BalanceSidebar.jsx
@@ -28,8 +28,22 @@ type Props = {
 export class BalanceSidebar extends React.Component {
   props: Props;
   state = {
-    showLongBalance: false
+    showLongBalance: false,
+    address: ''
   };
+
+  componentDidMount() {
+    if (!this.props.wallet) return;
+    this.props.wallet
+      .getAddress()
+      .then(addr => {
+        this.setState({ address: addr });
+      })
+      .catch(err => {
+        //TODO: communicate error in UI
+        console.log(err);
+      });
+  }
 
   render() {
     const { wallet, balance, network, tokenBalances, rates } = this.props;
@@ -44,9 +58,9 @@ export class BalanceSidebar extends React.Component {
           {translate('sidebar_AccountAddr')}
         </h5>
         <ul className="account-info">
-          <Identicon address={wallet.getAddress()} />
+          <Identicon address={this.state.address} />
           <span className="mono wrap">
-            {wallet.getAddress()}
+            {this.state.address}
           </span>
         </ul>
         <hr />
@@ -84,7 +98,7 @@ export class BalanceSidebar extends React.Component {
                   <a
                     href={blockExplorer.address.replace(
                       '[[address]]',
-                      wallet.getAddress()
+                      this.state.address
                     )}
                     target="_blank"
                   >
@@ -96,7 +110,7 @@ export class BalanceSidebar extends React.Component {
                   <a
                     href={tokenExplorer.address.replace(
                       '[[address]]',
-                      wallet.getAddress()
+                      this.state.address
                     )}
                     target="_blank"
                   >

--- a/common/components/PaperWallet/index.jsx
+++ b/common/components/PaperWallet/index.jsx
@@ -101,15 +101,9 @@ export default class PaperWallet extends React.Component {
 
   componentDidMount() {
     if (!this.props.wallet) return;
-    this.props.wallet
-      .getAddress()
-      .then(addr => {
-        this.setState({ address: addr });
-      })
-      .catch(err => {
-        //TODO: communicate error in UI
-        console.log(err);
-      });
+    this.props.wallet.getAddress().then(addr => {
+      this.setState({ address: addr });
+    });
   }
 
   render() {

--- a/common/components/PaperWallet/index.jsx
+++ b/common/components/PaperWallet/index.jsx
@@ -97,8 +97,22 @@ type Props = {
 
 export default class PaperWallet extends React.Component {
   props: Props;
+  state = { address: '' };
+
+  componentDidMount() {
+    if (!this.props.wallet) return;
+    this.props.wallet
+      .getAddress()
+      .then(addr => {
+        this.setState({ address: addr });
+      })
+      .catch(err => {
+        //TODO: communicate error in UI
+        console.log(err);
+      });
+  }
+
   render() {
-    const address = this.props.wallet.getAddress();
     const privateKey = this.props.wallet.getPrivateKey();
 
     return (
@@ -108,7 +122,7 @@ export default class PaperWallet extends React.Component {
 
         <div style={styles.block}>
           <div style={styles.box}>
-            <QRCode data={address} />
+            <QRCode data={this.state.address} />
           </div>
           <p style={styles.blockText}>YOUR ADDRESS</p>
         </div>
@@ -129,7 +143,7 @@ export default class PaperWallet extends React.Component {
           <p style={styles.infoText}>
             <strong style={styles.infoLabel}>Your Address:</strong>
             <br />
-            {address}
+            {this.state.address}
           </p>
           <p style={styles.infoText}>
             <strong style={styles.infoLabel}>Your Private Key:</strong>
@@ -140,7 +154,7 @@ export default class PaperWallet extends React.Component {
 
         <div style={styles.identiconContainer}>
           <div style={{ float: 'left' }}>
-            <Identicon address={address} size={'42px'} />
+            <Identicon address={this.state.address} size={'42px'} />
           </div>
           <p style={styles.identiconText}>
             Always look for this icon when sending to this wallet

--- a/common/containers/Tabs/GenerateWallet/components/DownloadWallet.jsx
+++ b/common/containers/Tabs/GenerateWallet/components/DownloadWallet.jsx
@@ -15,8 +15,16 @@ export default class DownloadWallet extends Component {
   props: Props;
   keystore: Object;
   state = {
-    hasDownloadedWallet: false
+    hasDownloadedWallet: false,
+    address: ''
   };
+
+  componentDidMount() {
+    if (!this.props.wallet) return;
+    this.props.wallet.getAddress().then(addr => {
+      this.setState({ address: addr });
+    });
+  }
 
   componentWillMount() {
     this.keystore = this.props.wallet.toKeystore(this.props.password);
@@ -111,6 +119,6 @@ export default class DownloadWallet extends Component {
   }
 
   getFilename() {
-    return getV3Filename(this.props.wallet.getAddress());
+    return getV3Filename(this.state.address);
   }
 }

--- a/common/libs/wallet/base.js
+++ b/common/libs/wallet/base.js
@@ -8,7 +8,7 @@ export default class BaseWallet {
 
   getNakedAddress(): Promise<any> {
     return new Promise(resolve => {
-      this.getAddress.then(address => {
+      this.getAddress().then(address => {
         resolve(stripHex(address));
       });
     });

--- a/common/libs/wallet/privkey.js
+++ b/common/libs/wallet/privkey.js
@@ -22,9 +22,9 @@ export default class PrivKeyWallet extends BaseWallet {
   }
 
   getAddress(): Promise<any> {
-    return new Promise(resolve => {
-      resolve(toChecksumAddress(`0x${this.address.toString('hex')}`));
-    });
+    return Promise.resolve(
+      toChecksumAddress(`0x${this.address.toString('hex')}`)
+    );
   }
 
   getPrivateKey() {

--- a/common/sagas/wallet.js
+++ b/common/sagas/wallet.js
@@ -16,7 +16,8 @@ function* updateAccountBalance() {
   if (!wallet) {
     return;
   }
-  let balance = yield apply(node, node.getBalance, [wallet.getAddress()]);
+  const address = yield wallet.getAddress();
+  let balance = yield apply(node, node.getBalance, [address]);
   yield put(setBalance(balance));
 }
 
@@ -28,8 +29,9 @@ function* updateTokenBalances() {
     return;
   }
   // FIXME handle errors
+  const address = yield wallet.getAddress();
   const tokenBalances = yield apply(node, node.getTokenBalances, [
-    wallet.getAddress(),
+    address,
     tokens
   ]);
   yield put(


### PR DESCRIPTION
Addresses the flow type errors introduced by the previous wallet decrypt PR. Essentially moves component-based async calls to `componentDidMount` and sets `address` property in state. 

Stays clear of `SendTransaction/index.jsx` to avoid conflicts with @wbobeirne. 

As always, let me know if anything could be improved! :smile: 