### PR TITLE
Add KeystoreWallet Class & Decrypt

### DIFF
--- a/common/libs/keystore.js
+++ b/common/libs/keystore.js
@@ -75,11 +75,11 @@ export function getV3Filename(address) {
   return ['UTC--', ts.toJSON().replace(/:/g, '-'), '--', address].join('');
 }
 
-//ported from v3 file 'myetherwallet.js', Wallet.fromV3, line 242
-//https://github.com/kvhnuke/etherwallet/blob/de536ffebb4f2d1af892a32697e89d1a0d906b01/app/scripts/myetherwallet.js
-//
-//WIP - still need to add flow types, create new flow type 'v3Keystore', etc
-export function fromV3KeystoreToPkey(input, password, nonStrict) {
+export function fromV3KeystoreToPkey(
+  input: string | Object,
+  password: string,
+  nonStrict: boolean
+): Buffer {
   let json =
     typeof input === 'object'
       ? input

--- a/common/libs/wallet/keystore.js
+++ b/common/libs/wallet/keystore.js
@@ -3,7 +3,7 @@ import PrivKeyWallet from './privkey';
 import { fromV3KeystoreToPkey } from 'libs/keystore';
 
 export default class KeystoreWallet extends PrivKeyWallet {
-  constructor(keystore: string | Object, password: string, nonStrict: boolean) {
-    super(fromV3KeystoreToPkey(keystore, password, nonStrict));
+  constructor(keystore: string, password: string) {
+    super(fromV3KeystoreToPkey(keystore, password));
   }
 }

--- a/common/libs/wallet/keystore.js
+++ b/common/libs/wallet/keystore.js
@@ -1,0 +1,9 @@
+// @flow
+import PrivKeyWallet from './privkey';
+import { fromV3KeystoreToPkey } from 'libs/keystore';
+
+export default class KeystoreWallet extends PrivKeyWallet {
+  constructor(keystore: string | Object, password: string, nonStrict: boolean) {
+    super(fromV3KeystoreToPkey(keystore, password, nonStrict));
+  }
+}


### PR DESCRIPTION
### What This PR Does

* Ports keystore decrypt function from v3
* Adds `KeystoreWallet` class

---

I've deviated slightly from the v3 keystore decrypt function. Here are some changes that I'd like to highlight for discussion:

* In v3, the keystore could be passed in as an object or a string. It can now only be a string.
* The v3 version accepted a boolean as a third argument that lowercased the keystore. This argument has been removed and the lowercasing now happens by default. 

I went this route because (1) stringified & lowercased keystores seem to be exclusively used in v3. I could not find instances where objects were passed in, nor where the third arg wasn't set to `true`. (2) Simple is often better, and this seems to be a good opportunity to standardize how we interact with keystore files.

[The function in v3 ](https://github.com/kvhnuke/etherwallet/blob/de536ffebb4f2d1af892a32697e89d1a0d906b01/app/scripts/myetherwallet.js#L242)for reference.

I'm totally down to do a 1:1 implementation here, I'm just not convinced it's necessary. Please let me know what you think :smile: 