### PR TITLE
Prefer to reference build tools in node_modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,18 +91,18 @@
     "webpack-hot-middleware": "^2.18.2"
   },
   "scripts": {
-    "db": "nodemon ./db",
-    "build": "webpack --config webpack_config/webpack.prod.js",
-    "prebuild": "check-node-version --package",
-    "build:demo": "BUILD_GH_PAGES=true webpack --config webpack_config/webpack.prod.js",
-    "prebuild:demo": "check-node-version --package",
-    "test": "jest --config=jest_config/jest.config.json --coverage",
-    "pretest": "check-node-version --package",
+    "db": "./node_modules/nodemon/bin/nodemon.js ./db",
+    "build": "./node_modules/webpack/bin/webpack.js --config webpack_config/webpack.prod.js",
+    "prebuild": "./node_modules/check-node-version/bin.js --package",
+    "build:demo": "BUILD_GH_PAGES=true /node_modules/webpack/bin/webpack.js --config webpack_config/webpack.prod.js",
+    "prebuild:demo": "./node_modules/check-node-version/bin.js --package",
+    "test": "./node_modules/jest/bin/jest.js --config=jest_config/jest.config.json --coverage",
+    "pretest": "./node_modules/check-node-version/bin.js --package",
     "dev": "node webpack_config/server.js",
-    "predev": "check-node-version --package",
-    "flow": "flow",
+    "predev": "./node_modules/check-node-version/bin.js --package",
+    "flow": "./node_modules/flow-bin/cli.js",
     "start": "npm run dev",
-    "precommit": "lint-staged"
+    "precommit": "./node_modules/lint-staged/index.js"
   },
   "lint-staged": {
     "*.{js,jsx}": [


### PR DESCRIPTION
After running `npm install && npm run build` I was getting an error where `lint-staged` was not available in my `PATH`.

This PR changes all npm scripts to reference dependencies that are already in `node_modules` so that all scripts should work after an `npm install`