### PR TITLE
Fix Send Regressions

### DIFF
--- a/common/components/ui/SimpleDropDown.jsx
+++ b/common/components/ui/SimpleDropDown.jsx
@@ -1,0 +1,62 @@
+// @flow
+import React, { Component } from 'react';
+
+type Props = {
+  value?: string,
+  options: string[],
+  onChange: (value: string) => void
+};
+
+export default class SimpleDropDown extends Component {
+  props: Props;
+  state: {
+    expanded: boolean
+  } = {
+    expanded: false
+  };
+
+  toggleExpanded = () => {
+    this.setState(state => {
+      return { expanded: !state.expanded };
+    });
+  };
+
+  onClick = (event: SyntheticInputEvent) => {
+    this.props.onChange(event.target.value);
+  };
+
+  render() {
+    const { options, value } = this.props;
+    const { expanded } = this.state;
+    return (
+      <span className={`dropdown ${expanded ? 'open' : ''}`}>
+        <a
+          className="btn btn-default dropdown-toggle"
+          onClick={this.toggleExpanded}
+        >
+          {value}
+          <i className="caret" />
+        </a>
+
+        {expanded &&
+          <ul
+            className="dropdown-menu dropdown-menu-right"
+            style={{ marginTop: '15px' }}
+          >
+            {options.map((option, i) => {
+              return (
+                <li value={option} key={i}>
+                  <a
+                    className={option === value ? 'active' : ''}
+                    onClick={this.onClick}
+                  >
+                    {option}
+                  </a>
+                </li>
+              );
+            })}
+          </ul>}
+      </span>
+    );
+  }
+}

--- a/common/components/ui/SimpleDropDown.jsx
+++ b/common/components/ui/SimpleDropDown.jsx
@@ -22,14 +22,16 @@ export default class SimpleDropDown extends Component {
   };
 
   onClick = (event: SyntheticInputEvent) => {
-    this.props.onChange(event.target.value);
+    const value = event.target.getAttribute('data-value') || '';
+    this.props.onChange(value);
+    this.setState({ expanded: false });
   };
 
   render() {
     const { options, value } = this.props;
     const { expanded } = this.state;
     return (
-      <span className={`dropdown ${expanded ? 'open' : ''}`}>
+      <div className={`dropdown ${expanded ? 'open' : ''}`}>
         <a
           className="btn btn-default dropdown-toggle"
           onClick={this.toggleExpanded}
@@ -39,16 +41,14 @@ export default class SimpleDropDown extends Component {
         </a>
 
         {expanded &&
-          <ul
-            className="dropdown-menu dropdown-menu-right"
-            style={{ marginTop: '15px' }}
-          >
+          <ul className="dropdown-menu dropdown-menu-right">
             {options.map((option, i) => {
               return (
-                <li value={option} key={i}>
+                <li key={i}>
                   <a
                     className={option === value ? 'active' : ''}
                     onClick={this.onClick}
+                    data-value={option}
                   >
                     {option}
                   </a>
@@ -56,7 +56,7 @@ export default class SimpleDropDown extends Component {
               );
             })}
           </ul>}
-      </span>
+      </div>
     );
   }
 }

--- a/common/components/ui/SimpleDropdown.jsx
+++ b/common/components/ui/SimpleDropdown.jsx
@@ -1,15 +1,15 @@
 // @flow
 import React, { Component } from 'react';
 
-type Props<T> = {
-  value?: T,
-  options: Array<T>,
+type Props = {
+  value?: string,
+  options: string[],
   onChange: (event: SyntheticInputEvent) => void,
   className?: string
 };
 
-export default class SimpleDropDown<T: *> extends Component {
-  props: Props<T>;
+export default class SimpleDropDown extends Component {
+  props: Props;
 
   render() {
     return (

--- a/common/components/ui/SimpleDropdown.jsx
+++ b/common/components/ui/SimpleDropdown.jsx
@@ -4,7 +4,8 @@ import React, { Component } from 'react';
 type Props<T> = {
   value?: T,
   options: Array<T>,
-  onChange: (event: SyntheticInputEvent) => void
+  onChange: (event: SyntheticInputEvent) => void,
+  className?: string
 };
 
 export default class SimpleDropDown<T: *> extends Component {
@@ -14,7 +15,7 @@ export default class SimpleDropDown<T: *> extends Component {
     return (
       <select
         value={this.props.value || this.props.options[0]}
-        className="form-control"
+        className={this.props.className || 'form-control'}
         onChange={this.props.onChange}
       >
         {this.props.options.map((obj, i) => {

--- a/common/components/ui/SimpleSelect.jsx
+++ b/common/components/ui/SimpleSelect.jsx
@@ -4,18 +4,17 @@ import React, { Component } from 'react';
 type Props = {
   value?: string,
   options: string[],
-  onChange: (event: SyntheticInputEvent) => void,
-  className?: string
+  onChange: (event: SyntheticInputEvent) => void
 };
 
-export default class SimpleDropDown extends Component {
+export default class SimpleSelect extends Component {
   props: Props;
 
   render() {
     return (
       <select
         value={this.props.value || this.props.options[0]}
-        className={this.props.className || 'form-control'}
+        className={'form-control'}
         onChange={this.props.onChange}
       >
         {this.props.options.map((obj, i) => {

--- a/common/containers/Tabs/GenerateWallet/components/EnterPassword.jsx
+++ b/common/containers/Tabs/GenerateWallet/components/EnterPassword.jsx
@@ -93,7 +93,7 @@ class EnterPassword extends Component {
             <span>
               {' '}{translate('GEN_Help_2')}
             </span>
-            <span translate="GEN_Help_3" className="ng-scope">
+            <span>
               {' '}{translate('GEN_Help_3')}
             </span>
           </li>
@@ -129,9 +129,7 @@ class EnterPassword extends Component {
           </li>
         </ul>
 
-        <h4 translate="GEN_Help_4" className="ng-scope">
-          Guides & FAQ
-        </h4>
+        <h4>Guides & FAQ</h4>
         <ul>
           <li>
             <strong>

--- a/common/containers/Tabs/SendTransaction/components/UnitDropdown.jsx
+++ b/common/containers/Tabs/SendTransaction/components/UnitDropdown.jsx
@@ -1,34 +1,16 @@
 // @flow
 import React from 'react';
+import SimpleDropDown from 'components/ui/SimpleDropdown';
 
-class Option extends React.Component {
-  props: {
-    value: string,
-    active: boolean,
-    onChange: (value: string) => void
-  };
-  render() {
-    const { value, active } = this.props;
-    return (
-      <li>
-        <a className={active ? 'active' : ''} onClick={this.onChange}>
-          {value}
-        </a>
-      </li>
-    );
-  }
-
-  onChange = () => {
-    this.props.onChange(this.props.value);
-  };
-}
+type UnitDropdownProps = {
+  value: string,
+  options: string[],
+  onChange?: (value: string) => void
+};
 
 export default class UnitDropdown extends React.Component {
-  props: {
-    value: string,
-    options: string[],
-    onChange?: (value: string) => void
-  };
+  props: UnitDropdownProps;
+
   state: {
     expanded: boolean
   } = {
@@ -36,52 +18,23 @@ export default class UnitDropdown extends React.Component {
   };
 
   render() {
-    const { value, options, onChange } = this.props;
-    const isReadonly = !onChange;
+    const { value, options } = this.props;
 
     return (
       <div className="input-group-btn">
-        <a
-          style={{ minWidth: 170 }}
+        <SimpleDropDown
           className="btn btn-default dropdown-toggle"
-          onClick={this.onToggleExpand}
-        >
-          <strong>
-            {value}
-            <i className="caret" />
-          </strong>
-        </a>
-        {this.state.expanded &&
-          !isReadonly &&
-          <ul className="dropdown-menu dropdown-menu-right">
-            {options.map(o =>
-              <Option
-                key={o}
-                active={value === o}
-                value={o}
-                onChange={this.onChange}
-              />
-            )}
-          </ul>}
+          value={value}
+          onChange={this.onChange}
+          options={options}
+        />
       </div>
     );
   }
 
-  onToggleExpand = () => {
-    this.setState(state => {
-      return {
-        expanded: !state.expanded
-      };
-    });
-  };
-
-  onChange = (value: string) => {
-    this.setState({
-      expanded: false
-    });
-
+  onChange = (e: SyntheticInputEvent) => {
     if (this.props.onChange) {
-      this.props.onChange(value);
+      this.props.onChange(e.target.value);
     }
   };
 }

--- a/common/containers/Tabs/SendTransaction/components/UnitDropdown.jsx
+++ b/common/containers/Tabs/SendTransaction/components/UnitDropdown.jsx
@@ -1,6 +1,6 @@
 // @flow
 import React from 'react';
-import SimpleDropDown from 'components/ui/SimpleDropdown';
+import SimpleDropDown from 'components/ui/SimpleDropDown';
 
 type UnitDropdownProps = {
   value: string,
@@ -23,7 +23,6 @@ export default class UnitDropdown extends React.Component {
     return (
       <div className="input-group-btn">
         <SimpleDropDown
-          className="btn btn-default dropdown-toggle"
           value={value}
           onChange={this.onChange}
           options={options}

--- a/common/containers/Tabs/SendTransaction/components/UnitDropdown.jsx
+++ b/common/containers/Tabs/SendTransaction/components/UnitDropdown.jsx
@@ -31,9 +31,9 @@ export default class UnitDropdown extends React.Component {
     );
   }
 
-  onChange = (e: SyntheticInputEvent) => {
+  onChange = (value: string) => {
     if (this.props.onChange) {
-      this.props.onChange(e.target.value);
+      this.props.onChange(value);
     }
   };
 }

--- a/common/containers/Tabs/SendTransaction/index.jsx
+++ b/common/containers/Tabs/SendTransaction/index.jsx
@@ -412,7 +412,7 @@ export class SendTransaction extends React.Component {
         const weiBalance = toWei(balance, 'ether');
         value = getBalanceMinusGasCosts(
           new Big(gasLimit),
-          gasPrice,
+          new Big(gasPrice),
           weiBalance
         );
       } else {

--- a/common/containers/Tabs/Swap/components/CurrencySwap.jsx
+++ b/common/containers/Tabs/Swap/components/CurrencySwap.jsx
@@ -2,7 +2,7 @@ import './CurrencySwap.scss';
 import React, { Component } from 'react';
 import translate from 'translations';
 import { combineAndUpper } from 'utils/formatters';
-import SimpleDropDown from 'components/ui/SimpleDropdown';
+import SimpleSelect from 'components/ui/SimpleSelect';
 import SimpleButton from 'components/ui/SimpleButton';
 import type {
   OriginKindSwapAction,
@@ -183,7 +183,7 @@ export default class CurrencySwap extends Component {
             onChange={this.onChangeOriginAmount}
           />
 
-          <SimpleDropDown
+          <SimpleSelect
             value={originKind}
             onChange={this.onChangeOriginKind.bind(this)}
             options={originKindOptions}
@@ -208,7 +208,7 @@ export default class CurrencySwap extends Component {
             onChange={this.onChangeDestinationAmount}
           />
 
-          <SimpleDropDown
+          <SimpleSelect
             value={destinationKind}
             onChange={this.onChangeDestinationKind}
             options={destinationKindOptions}

--- a/common/sass/styles/overrides.scss
+++ b/common/sass/styles/overrides.scss
@@ -3,6 +3,7 @@
 @import "./overrides/alerts";
 @import "./overrides/buttons";
 @import "./overrides/button-groups";
+@import "./overrides/dropdowns";
 @import "./overrides/forms";
 @import "./overrides/grid";
 @import "./overrides/input-groups";

--- a/common/sass/styles/overrides/dropdowns.scss
+++ b/common/sass/styles/overrides/dropdowns.scss
@@ -2,32 +2,32 @@
 @import "common/sass/variables";
 
 .dropdown {
-	.caret {
-		margin-left: $space-sm;
-	}
+  .caret {
+    margin-left: $space-sm;
+  }
 }
 
 .dropdown-menu {
-	padding: 0;
-	border: none;
+  padding: 0;
+  border: none;
 
-	> li {
+  > li {
     margin: 0;
 
-		&:first-child {
-	    padding-top: 4px;
-	  }
+    &:first-child {
+      padding-top: 4px;
+    }
 
-		&:last-child {
-	    padding-bottom: 4px;
-	  }
+    &:last-child {
+      padding-bottom: 4px;
+    }
 
-		> a {
-			font-weight: 300;
+    > a {
+      font-weight: 300;
 
-			&.active {
-				color: $link-color;
-			}
-		}
+      &.active {
+        color: $link-color;
+      }
+    }
   }
 }

--- a/common/sass/styles/overrides/dropdowns.scss
+++ b/common/sass/styles/overrides/dropdowns.scss
@@ -1,0 +1,33 @@
+// Button overrides
+@import "common/sass/variables";
+
+.dropdown {
+	.caret {
+		margin-left: $space-sm;
+	}
+}
+
+.dropdown-menu {
+	padding: 0;
+	border: none;
+
+	> li {
+    margin: 0;
+
+		&:first-child {
+	    padding-top: 4px;
+	  }
+
+		&:last-child {
+	    padding-bottom: 4px;
+	  }
+
+		> a {
+			font-weight: 300;
+
+			&.active {
+				color: $link-color;
+			}
+		}
+  }
+}

--- a/common/sass/styles/overrides/input-groups.scss
+++ b/common/sass/styles/overrides/input-groups.scss
@@ -19,7 +19,7 @@
 }
 
 .input-group-btn {
-  > .btn {
+  .btn {
     margin-bottom: 0;
     margin-top: 0;
     font-size: $font-size-base;


### PR DESCRIPTION
As I was playing with the latest develop, I noticed we had encountered several regressions (listed here https://github.com/MyEtherWallet/MyEtherWallet/issues/169).

This PR fixes both of these regressions, while also simplifying the unit dropdown by making use of the `SimpleDropdown` component.

It also clears out a javascript warning in the console for using the `translate` prop incorrectly.