### PR TITLE
Improve Build Speed

### DIFF
--- a/webpack_config/webpack.base.js
+++ b/webpack_config/webpack.base.js
@@ -31,12 +31,6 @@ module.exports = {
     loaders: [
       {
         test: /\.(js|jsx)$/,
-        enforce: 'pre',
-        loaders: ['eslint-loader'],
-        exclude: [/node_modules/]
-      },
-      {
-        test: /\.(js|jsx)$/,
         loaders: ['babel-loader'],
         exclude: [/node_modules\/(?!ethereum-blockies|idna-uts46)/]
       },

--- a/webpack_config/webpack.dev.js
+++ b/webpack_config/webpack.dev.js
@@ -5,7 +5,7 @@ const webpack = require('webpack');
 const base = require('./webpack.base');
 const FriendlyErrors = require('friendly-errors-webpack-plugin');
 
-base.devtool = 'source-map';
+base.devtool = 'cheap-module-eval-source-map';
 base.module.loaders.push(
   {
     test: /\.css$/,

--- a/webpack_config/webpack.dev.js
+++ b/webpack_config/webpack.dev.js
@@ -5,7 +5,10 @@ const webpack = require('webpack');
 const base = require('./webpack.base');
 const FriendlyErrors = require('friendly-errors-webpack-plugin');
 
-base.devtool = 'cheap-module-eval-source-map';
+base.devtool = process.env.SLOW_BUILD_SPEED
+  ? 'source-map'
+  : 'cheap-module-eval-source-map';
+
 base.module.loaders.push(
   {
     test: /\.css$/,

--- a/webpack_config/webpack.prod.js
+++ b/webpack_config/webpack.prod.js
@@ -11,9 +11,9 @@ const rimraf = require('rimraf');
 const distFolder = 'dist/';
 
 // Clear out build folder
-rimraf.sync(distFolder, {'rmdirSync': true});
+rimraf.sync(distFolder, { rmdirSync: true });
 
-base.devtool = 'cheap-source-map';
+base.devtool = 'source-map';
 base.module.loaders.push(
   {
     test: /\.css$/,


### PR DESCRIPTION
## What This Does

I was able to improve build speed by doing the following things:

* Removing eslint-loader. I think this should be a pre-commit hook to enforce (ala prettier) and should be handled by the user's IDE, rather than this slow-ish loader.
* Changing the development devtool. This was the biggest gain, and only results in some minor usability changes with sourcemaps.

| Config                                           | Avg build speed | Avg rebuild speed |
|--------------------------------------------------|-----------------|-------------------|
| Eslint Loader / source-map devtool (current)     | 33.81s          | 3.81s             |
| No Eslint / source-map devtool                   | 28.76s          | 3.51s             |
| No Eslint / cheap-module-eval-source-map devtool | 25.13s          | 1.99s             |

## Future Improvements

* Implement the CommonChunkPlugin, ala [this guide](https://webpack.js.org/guides/build-performance/#minimal-entry-chunk) or otherwise.
* Remove all references to `[hash]` or `[chunkhash]` in dev build