### PR TITLE
Remove Un-needed isBroadcasting Wallet State

### DIFF
--- a/common/reducers/wallet.js
+++ b/common/reducers/wallet.js
@@ -25,7 +25,6 @@ export const INITIAL_STATE: State = {
   inst: null,
   balance: null,
   tokens: {},
-  isBroadcasting: false,
   transactions: []
 };
 
@@ -118,7 +117,6 @@ export function wallet(
     case 'WALLET_BROADCAST_TX_REQUESTED':
       return {
         ...state,
-        isBroadcasting: true,
         transactions: handleBroadcastTxRequested(state, action.payload.signedTx)
       };
     case 'WALLET_BROADCAST_TX_SUCCEEDED':


### PR DESCRIPTION
Remove `isBroadcasting` from top-level wallet state. `isBroadcasting` is kept at the BroadcastTransactionStatus level, with a different state for each transaction.