### PR TITLE
Trezor DPath Fix

### DIFF
--- a/common/components/WalletDecrypt/Trezor.jsx
+++ b/common/components/WalletDecrypt/Trezor.jsx
@@ -65,8 +65,8 @@ export default class TrezorDecrypt extends Component {
     });
   };
 
-  _handleUnlock = (address: string) => {
-    this.props.onUnlock(new TrezorWallet(address, this.state.dPath));
+  _handleUnlock = (address: string, index: number) => {
+    this.props.onUnlock(new TrezorWallet(address, this.state.dPath, index));
   };
 
   render() {

--- a/common/libs/decrypt.js
+++ b/common/libs/decrypt.js
@@ -3,7 +3,7 @@
 import { createHash, createDecipheriv } from 'crypto';
 import { validateMnemonic, mnemonicToSeed } from 'bip39';
 import { fromMasterSeed } from 'hdkey';
-import { stripHex } from 'libs/values';
+import { stripHexPrefixAndLower } from 'libs/values';
 
 import { privateToAddress } from 'ethereumjs-util';
 
@@ -79,7 +79,7 @@ export function decryptMnemonicToPrivKey(
   address: string
 ): Buffer {
   phrase = phrase.trim();
-  address = stripHex(address);
+  address = stripHexPrefixAndLower(address);
 
   if (!validateMnemonic(phrase)) {
     throw new Error('Invalid mnemonic');

--- a/common/libs/transaction.js
+++ b/common/libs/transaction.js
@@ -137,7 +137,7 @@ export async function generateCompleteTransactionFromRawTransaction(
     nonce: cleanHex(nonce),
     gasPrice: cleanHex(gasPrice.toString(16)),
     gasLimit: cleanHex(gasLimit.toString(16)),
-    to: cleanHex(to),
+    to: toChecksumAddress(cleanHex(to)),
     value: token ? '0x00' : cleanHex(value.toString(16)),
     data: data ? cleanHex(data) : '',
     chainId: chainId || 1

--- a/common/libs/transaction.js
+++ b/common/libs/transaction.js
@@ -4,7 +4,7 @@ import translate from 'translations';
 import { padToEven, addHexPrefix, toChecksumAddress } from 'ethereumjs-util';
 import { isValidETHAddress } from 'libs/validators';
 import ERC20 from 'libs/erc20';
-import { stripHex, valueToHex } from 'libs/values';
+import { stripHexPrefixAndLower, valueToHex } from 'libs/values';
 import { Wei, Ether, toTokenUnit } from 'libs/units';
 import { RPCNode } from 'libs/nodes';
 import { TransactionWithoutGas } from 'libs/messages';
@@ -132,7 +132,7 @@ export async function generateCompleteTransactionFromRawTransaction(
   }
   // Taken from v3's `sanitizeHex`, ensures that the value is a %2 === 0
   // prefix'd hex value.
-  const cleanHex = hex => addHexPrefix(padToEven(stripHex(hex)));
+  const cleanHex = hex => addHexPrefix(padToEven(stripHexPrefixAndLower(hex)));
   const cleanedRawTx = {
     nonce: cleanHex(nonce),
     gasPrice: cleanHex(gasPrice.toString(16)),

--- a/common/libs/values.js
+++ b/common/libs/values.js
@@ -1,7 +1,7 @@
 // @flow
 import { Ether } from 'libs/units';
 
-export function stripHex(address: string): string {
+export function stripHexPrefixAndLower(address: string): string {
   return address.replace('0x', '').toLowerCase();
 }
 

--- a/common/libs/wallet/deterministic.js
+++ b/common/libs/wallet/deterministic.js
@@ -4,10 +4,12 @@ import type { IWallet } from './IWallet';
 export default class DeterministicWallet implements IWallet {
   address: string;
   dPath: string;
+  index: number;
 
-  constructor(address: string, dPath: string) {
+  constructor(address: string, dPath: string, index: number) {
     this.address = address;
     this.dPath = dPath;
+    this.index = index;
   }
 
   getAddress(): Promise<string> {
@@ -15,6 +17,6 @@ export default class DeterministicWallet implements IWallet {
   }
 
   getPath(): string {
-    return this.dPath;
+    return `${this.dPath}/${this.index}`;
   }
 }

--- a/common/libs/wallet/privkey.js
+++ b/common/libs/wallet/privkey.js
@@ -11,7 +11,7 @@ import { signRawTxWithPrivKey, signMessageWithPrivKey } from 'libs/signing';
 import { isValidPrivKey } from 'libs/validators';
 import type { RawTransaction } from 'libs/transaction';
 import type { UtcKeystore } from 'libs/keystore';
-import { stripHex } from 'libs/values';
+import { stripHexPrefixAndLower } from 'libs/values';
 
 export default class PrivKeyWallet implements IWallet {
   privKey: Buffer;
@@ -43,7 +43,7 @@ export default class PrivKeyWallet implements IWallet {
   getNakedAddress(): Promise<string> {
     return new Promise(resolve => {
       this.getAddress().then(address => {
-        resolve(stripHex(address));
+        resolve(stripHexPrefixAndLower(address));
       });
     });
   }

--- a/common/libs/wallet/trezor.js
+++ b/common/libs/wallet/trezor.js
@@ -5,8 +5,12 @@ import Big from 'bignumber.js';
 import { addHexPrefix } from 'ethereumjs-util';
 import DeterministicWallet from './deterministic';
 import { stripHex } from 'libs/values';
-
 import type { RawTransaction } from 'libs/transaction';
+
+// Identical to ethFuncs.getNakedAddress
+function stripAndLower(str) {
+  return stripHex(str).toLowerCase();
+}
 
 export default class TrezorWallet extends DeterministicWallet {
   signRawTransaction(tx: RawTransaction): Promise<string> {
@@ -14,12 +18,12 @@ export default class TrezorWallet extends DeterministicWallet {
       TrezorConnect.ethereumSignTx(
         // Args
         this.getPath(),
-        stripHex(tx.nonce),
-        stripHex(tx.gasPrice.toString()),
-        stripHex(tx.gasLimit.toString()),
-        stripHex(tx.to),
-        stripHex(tx.value),
-        stripHex(tx.data),
+        stripAndLower(tx.nonce),
+        stripAndLower(tx.gasPrice.toString()),
+        stripAndLower(tx.gasLimit.toString()),
+        stripAndLower(tx.to),
+        stripAndLower(tx.value),
+        stripAndLower(tx.data),
         tx.chainId,
         // Callback
         result => {

--- a/common/libs/wallet/trezor.js
+++ b/common/libs/wallet/trezor.js
@@ -4,13 +4,8 @@ import EthTx from 'ethereumjs-tx';
 import Big from 'bignumber.js';
 import { addHexPrefix } from 'ethereumjs-util';
 import DeterministicWallet from './deterministic';
-import { stripHex } from 'libs/values';
+import { stripHexPrefixAndLower } from 'libs/values';
 import type { RawTransaction } from 'libs/transaction';
-
-// Identical to ethFuncs.getNakedAddress
-function stripAndLower(str) {
-  return stripHex(str).toLowerCase();
-}
 
 export default class TrezorWallet extends DeterministicWallet {
   signRawTransaction(tx: RawTransaction): Promise<string> {
@@ -18,12 +13,13 @@ export default class TrezorWallet extends DeterministicWallet {
       TrezorConnect.ethereumSignTx(
         // Args
         this.getPath(),
-        stripAndLower(tx.nonce),
-        stripAndLower(tx.gasPrice.toString()),
-        stripAndLower(tx.gasLimit.toString()),
-        stripAndLower(tx.to),
-        stripAndLower(tx.value),
-        stripAndLower(tx.data),
+        // stripHexPrefixAndLower identical to ethFuncs.getNakedAddress
+        stripHexPrefixAndLower(tx.nonce),
+        stripHexPrefixAndLower(tx.gasPrice.toString()),
+        stripHexPrefixAndLower(tx.gasLimit.toString()),
+        stripHexPrefixAndLower(tx.to),
+        stripHexPrefixAndLower(tx.value),
+        stripHexPrefixAndLower(tx.data),
         tx.chainId,
         // Callback
         result => {


### PR DESCRIPTION
This fixes Trezor (And any deterministic wallet that extends that class) to use the index of the wallet as a part of the dpath. This was causing Trezor sends to fail.

In the process of debugging, I also trued up a few spots in the send process to better match v3. I'll drop notes linking to where they exist in v3.