### PR TITLE
Swap UX Cleanup

### DIFF
--- a/common/containers/Tabs/Swap/components/CurrencySwap.tsx
+++ b/common/containers/Tabs/Swap/components/CurrencySwap.tsx
@@ -7,12 +7,12 @@ import {
   TOriginKindSwap
 } from 'actions/swap';
 import SimpleButton from 'components/ui/SimpleButton';
-import SimpleSelect from 'components/ui/SimpleSelect';
 import bityConfig, { generateKindMax, generateKindMin } from 'config/bity';
 import React, { Component } from 'react';
 import translate from 'translations';
 import { combineAndUpper, toFixedIfLarger } from 'utils/formatters';
 import './CurrencySwap.scss';
+import { Dropdown } from 'components/ui';
 
 export interface StateProps {
   bityRates: any;
@@ -153,20 +153,6 @@ export default class CurrencySwap extends Component<
     }
   };
 
-  public onChangeDestinationKind = (
-    event: React.SyntheticEvent<HTMLInputElement>
-  ) => {
-    const newDestinationKind = (event.target as HTMLInputElement).value;
-    this.props.destinationKindSwap(newDestinationKind);
-  };
-
-  public onChangeOriginKind = (
-    event: React.SyntheticEvent<HTMLInputElement>
-  ) => {
-    const newOriginKind = (event.target as HTMLInputElement).value;
-    this.props.originKindSwap(newOriginKind);
-  };
-
   public render() {
     const {
       originAmount,
@@ -176,6 +162,13 @@ export default class CurrencySwap extends Component<
       destinationKindOptions,
       originKindOptions
     } = this.props;
+
+    const OriginKindDropDown = Dropdown as new () => Dropdown<
+      typeof originKind
+    >;
+    const DestinationKindDropDown = Dropdown as new () => Dropdown<
+      typeof destinationKind
+    >;
 
     return (
       <article className="CurrencySwap">
@@ -194,10 +187,13 @@ export default class CurrencySwap extends Component<
             onChange={this.onChangeOriginAmount}
           />
 
-          <SimpleSelect
-            value={originKind}
-            onChange={this.onChangeOriginKind}
+          <OriginKindDropDown
+            ariaLabel={`change origin kind. current origin kind ${originKind}`}
             options={originKindOptions}
+            value={originKind}
+            onChange={this.props.originKindSwap}
+            size="smr"
+            color="default"
           />
 
           <h1 className="CurrencySwap-divider">{translate('SWAP_init_2')}</h1>
@@ -218,10 +214,13 @@ export default class CurrencySwap extends Component<
             onChange={this.onChangeDestinationAmount}
           />
 
-          <SimpleSelect
-            value={destinationKind}
-            onChange={this.onChangeDestinationKind}
+          <DestinationKindDropDown
+            ariaLabel={`change destination kind. current destination kind ${destinationKind}`}
             options={destinationKindOptions}
+            value={destinationKind}
+            onChange={this.props.destinationKindSwap}
+            size="smr"
+            color="default"
           />
         </div>
 

--- a/common/containers/Tabs/Swap/components/PaymentInfo.scss
+++ b/common/containers/Tabs/Swap/components/PaymentInfo.scss
@@ -10,6 +10,7 @@
     max-width: 620px;
     width: 100%;
     font-size: $font-size-medium-bump;
+    text-align: center;
     @include mono;
   }
 


### PR DESCRIPTION
Fixes https://github.com/MyEtherWallet/MyEtherWallet/issues/259

- center align payment address in payment info
- use updated DropDown component instead of SimpleSelect

(Dropdown) Before
<img width="400
" alt="screen shot 2017-10-03 at 8 02 33 pm" src="https://user-images.githubusercontent.com/7861465/31158333-dd9386d8-a875-11e7-8821-fd603071ed80.png">
(Dropdown) After
<img width="400" alt="screen shot 2017-10-03 at 8 02 13 pm" src="https://user-images.githubusercontent.com/7861465/31158337-e2edab0e-a875-11e7-9843-d4fc102ba318.png">

Payment Address (Before)
<img width="400" alt="screen shot 2017-10-03 at 8 04 17 pm" src="https://user-images.githubusercontent.com/7861465/31158363-14114dd0-a876-11e7-9861-9d0bceef7a0b.png">

Payment Address (After)
<img width="400" alt="screen shot 2017-10-03 at 8 04 05 pm" src="https://user-images.githubusercontent.com/7861465/31158365-1919a66a-a876-11e7-802a-2b345b554c4d.png">






