### PR TITLE
Remove addProperties helper

### DIFF
--- a/common/containers/Tabs/Contracts/components/Deploy/index.tsx
+++ b/common/containers/Tabs/Contracts/components/Deploy/index.tsx
@@ -5,7 +5,6 @@ import { deployHOC } from './components/DeployHoc';
 import { TTxCompare } from '../TxCompare';
 import { TTxModal } from '../TxModal';
 import classnames from 'classnames';
-import { addProperties } from 'utils/helpers';
 import { isValidGasPrice, isValidByteCode } from 'libs/validators';
 
 export interface Props {
@@ -72,7 +71,7 @@ const Deploy = (props: Props) => {
           <button
             className="Sign-submit btn btn-primary"
             disabled={!showSignTxButton}
-            {...addProperties(showSignTxButton, { onClick: handleSignTx })}
+            onClick={handleSignTx}
           >
             {translate('DEP_signtx')}
           </button>

--- a/common/containers/Tabs/Contracts/components/Interact/components/InteractExplorer/index.tsx
+++ b/common/containers/Tabs/Contracts/components/Interact/components/InteractExplorer/index.tsx
@@ -8,7 +8,6 @@ import WalletDecrypt from 'components/WalletDecrypt';
 import { TShowNotification } from 'actions/notifications';
 import classnames from 'classnames';
 import { isValidGasPrice, isValidValue } from 'libs/validators';
-import { addProperties } from 'utils/helpers';
 
 export interface Props {
   contractFunctions: any;
@@ -157,7 +156,9 @@ export default class InteractExplorer extends Component<Props, State> {
                       className={classnames(
                         'InteractExplorer-field-input',
                         'form-control',
-                        { 'is-invalid': !validGasLimit }
+                        {
+                          'is-invalid': !validGasLimit
+                        }
                       )}
                     />
                   </label>
@@ -171,16 +172,16 @@ export default class InteractExplorer extends Component<Props, State> {
                       className={classnames(
                         'InteractExplorer-field-input',
                         'form-control',
-                        { 'is-invalid': !validValue }
+                        {
+                          'is-invalid': !validValue
+                        }
                       )}
                     />
                   </label>
                   <button
                     className="InteractExplorer-func-submit btn btn-primary"
                     disabled={!showContractWrite}
-                    {...addProperties(showContractWrite, {
-                      onClick: handleFunctionSend(selectedFunction, inputs)
-                    })}
+                    onClick={handleFunctionSend(selectedFunction, inputs)}
                   >
                     {translate('CONTRACT_Write')}
                   </button>

--- a/common/containers/Tabs/Contracts/components/Interact/components/InteractForm/index.tsx
+++ b/common/containers/Tabs/Contracts/components/Interact/components/InteractForm/index.tsx
@@ -6,7 +6,6 @@ import { getNetworkContracts } from 'selectors/config';
 import { connect } from 'react-redux';
 import { AppState } from 'reducers';
 import { isValidETHAddress, isValidAbiJson } from 'libs/validators';
-import { addProperties } from 'utils/helpers';
 import classnames from 'classnames';
 
 interface Props {
@@ -77,7 +76,9 @@ e":"a", "type":"uint256"}], "name":"foo", "outputs": [] }]';
               className={classnames(
                 'InteractForm-address-field-input',
                 'form-control',
-                { 'is-invalid': !validEthAddress }
+                {
+                  'is-invalid': !validEthAddress
+                }
               )}
               onChange={this.handleInput('address')}
             />
@@ -110,7 +111,9 @@ e":"a", "type":"uint256"}], "name":"foo", "outputs": [] }]';
               className={classnames(
                 'InteractForm-interface-field-input',
                 'form-control',
-                { 'is-invalid': !validAbiJson }
+                {
+                  'is-invalid': !validAbiJson
+                }
               )}
               onChange={this.handleInput('abiJson')}
               value={abiJson}
@@ -122,9 +125,7 @@ e":"a", "type":"uint256"}], "name":"foo", "outputs": [] }]';
         <button
           className="InteractForm-submit btn btn-primary"
           disabled={!showContractAccessButton}
-          {...addProperties(showContractAccessButton, {
-            onClick: accessContract(abiJson, address)
-          })}
+          onClick={accessContract(abiJson, address)}
         >
           {translate('x_Access')}
         </button>

--- a/common/utils/helpers.ts
+++ b/common/utils/helpers.ts
@@ -2,13 +2,6 @@ export function getKeyByValue(object, value) {
   return Object.keys(object).find(key => object[key] === value);
 }
 
-interface IKeyedObj {
-  [key: string]: any;
-}
-export const addProperties = (
-  truthy,
-  propertiesToAdd: IKeyedObj
-): {} | IKeyedObj => (truthy ? propertiesToAdd : {});
 export function getParam(query: { [key: string]: string }, key: string) {
   const keys = Object.keys(query);
   const index = keys.findIndex(k => k.toLowerCase() === key.toLowerCase());


### PR DESCRIPTION
addProperties was used before so that components would stop firing their event handlers even when they were disabled, turns out this was a React bug so it can be removed now.

https://github.com/facebook/react/issues/8308

Diff noise is due to the files being written with width 80 beforehand, when it should be 100 now. #314 