### PR TITLE
Fix Trezor throwing on connect

### DIFF
--- a/common/components/WalletDecrypt/Trezor.tsx
+++ b/common/components/WalletDecrypt/Trezor.tsx
@@ -125,7 +125,7 @@ export default class TrezorDecrypt extends Component<Props, State> {
     this.props.onUnlock(new TrezorWallet(address, this.state.dPath, index));
   };
 
-  private handleNullConnect(): void {
+  private handleNullConnect = (): void => {
     return this.handleConnect();
   }
 }


### PR DESCRIPTION
> `Cannot read property 'handleConnect' of undefined`

Was being thrown due to lack of arrow function. This is a quick fix.