### PR TITLE
Remove Bity Rates from Local Storage

### DIFF
--- a/common/store.ts
+++ b/common/store.ts
@@ -111,12 +111,13 @@ const configureStore = () => {
           languageSelection: state.config.languageSelection,
           customNodes: state.config.customNodes
         },
-        swap: state.swap,
+        swap: { ...state.swap, bityRates: {} },
         customTokens: state.customTokens
       });
     }),
     1000
   );
+
   return store;
 };
 

--- a/common/store.ts
+++ b/common/store.ts
@@ -111,7 +111,7 @@ const configureStore = () => {
           languageSelection: state.config.languageSelection,
           customNodes: state.config.customNodes
         },
-        swap: { ...state.swap, bityRates: swapInitialState.bityRates },
+        swap: { ...state.swap, bityRates: {} },
         customTokens: state.customTokens
       });
     }),

--- a/common/store.ts
+++ b/common/store.ts
@@ -111,7 +111,7 @@ const configureStore = () => {
           languageSelection: state.config.languageSelection,
           customNodes: state.config.customNodes
         },
-        swap: { ...state.swap, bityRates: {} },
+        swap: { ...state.swap, bityRates: swapInitialState.bityRates },
         customTokens: state.customTokens
       });
     }),


### PR DESCRIPTION
Closes https://github.com/MyEtherWallet/MyEtherWallet/issues/392
* Replace `swap.bityRates` with initial value when storing in local storage
* Change initial value of `state.bityRates` from `{}` to `null`

bityRates no longer persist in localstorage and are updated on each page load.