### PR TITLE
Remove Redux-Form in Generate Wallet

### DIFF
--- a/common/containers/Tabs/GenerateWallet/components/PasswordInput.tsx
+++ b/common/containers/Tabs/GenerateWallet/components/PasswordInput.tsx
@@ -2,27 +2,35 @@ import React, { Component } from 'react';
 import { translateRaw } from 'translations';
 
 interface Props {
+  password: string;
+  onPasswordChange: any;
   togglePassword: any;
   isPasswordVisible?: boolean;
-  input: any;
-  meta: any;
+  isPasswordValid: boolean;
 }
 
 export default class PasswordInput extends Component<Props, {}> {
   public render() {
-    const { input, meta, isPasswordVisible, togglePassword } = this.props;
+    const {
+      password,
+      isPasswordValid,
+      isPasswordVisible,
+      togglePassword,
+      onPasswordChange
+    } = this.props;
 
     return (
       <div>
         <div>
           <div className="input-group" style={{ width: '100%' }}>
             <input
-              {...input}
+              value={password}
               name="password"
-              className={`form-control ${meta.error ? 'is-invalid' : ''}`}
+              className={`form-control ${!isPasswordValid ? 'is-invalid' : ''}`}
               type={isPasswordVisible ? 'text' : 'password'}
               placeholder={translateRaw('GEN_Placeholder_1')}
               aria-label={translateRaw('GEN_Aria_1')}
+              onChange={onPasswordChange}
             />
             <span
               onClick={togglePassword}

--- a/common/reducers/index.ts
+++ b/common/reducers/index.ts
@@ -1,6 +1,5 @@
 import { routerReducer } from 'react-router-redux';
 import { combineReducers } from 'redux';
-import { reducer as formReducer } from 'redux-form';
 import { config, State as ConfigState } from './config';
 import { customTokens, State as CustomTokensState } from './customTokens';
 import {
@@ -39,6 +38,5 @@ export default combineReducers({
   customTokens,
   rates,
   deterministicWallets,
-  form: formReducer,
   routing: routerReducer
 });

--- a/common/vendors.js
+++ b/common/vendors.js
@@ -11,7 +11,6 @@ require('react-redux');
 require('react-router');
 require('react-router-redux');
 require('redux');
-require('redux-form');
 require('redux-logger');
 require('redux-saga');
 require('wallet-address-validator');

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "react-router-redux": "4.0.8",
     "react-transition-group": "2.2.1",
     "redux": "3.7.2",
-    "redux-form": "7.1.2",
     "redux-logger": "3.0.6",
     "redux-promise-middleware": "4.4.2",
     "redux-saga": "0.16.0",


### PR DESCRIPTION
Refactors `redux-form` dependency out of `Generate Wallet` tab and removes package from app. Closes #345.