### PR TITLE
Display less than for low balances

### DIFF
--- a/common/components/ui/UnitDisplay.tsx
+++ b/common/components/ui/UnitDisplay.tsx
@@ -54,7 +54,7 @@ const UnitDisplay: React.SFC<EthProps | TokenProps> = params => {
 
   if (displayShortBalance) {
     const digits =
-      typeof displayShortBalance === 'number' ? displayShortBalance : 3;
+      typeof displayShortBalance === 'number' ? displayShortBalance : 4;
     formattedValue = format(convertedValue, digits);
     // If the formatted value was too low, display something like < 0.01
     if (parseFloat(formattedValue) === 0 && parseFloat(convertedValue) !== 0) {

--- a/common/components/ui/UnitDisplay.tsx
+++ b/common/components/ui/UnitDisplay.tsx
@@ -54,10 +54,13 @@ const UnitDisplay: React.SFC<EthProps | TokenProps> = params => {
 
   if (displayShortBalance) {
     const digits =
-      typeof displayShortBalance === 'number' && displayShortBalance;
-    formattedValue = digits
-      ? format(convertedValue, digits)
-      : format(convertedValue);
+      typeof displayShortBalance === 'number' ? displayShortBalance : 3;
+    formattedValue = format(convertedValue, digits);
+    // If the formatted value was too low, display something like < 0.01
+    if (parseFloat(formattedValue) === 0 && parseFloat(convertedValue) !== 0) {
+      const padding = digits !== 0 ? `.${'0'.repeat(digits - 1)}1` : '';
+      formattedValue = `< 0${padding}`;
+    }
   } else {
     formattedValue = convertedValue;
   }


### PR DESCRIPTION
Pretty simple one that closes #425. Some balances if they were smaller than the digit count would display `0`. Now they'll show `< 0.001`, where the number of sigdigs matches the max digits. I did this at the `UnitDisplay` component level rather than the `formatNumber` util function level since I wasn't sure of all of the use cases for that one. We can move it back if need be.

<img width="403" alt="screen shot 2017-11-28 at 5 05 40 pm" src="https://user-images.githubusercontent.com/649992/33346672-8c458104-d45e-11e7-80dc-b37b85983ecf.png">
