### PR TITLE
Fix EquivalentValue.tsx crash on invalid tokens

### DIFF
--- a/common/actions/rates/actionPayloads.ts
+++ b/common/actions/rates/actionPayloads.ts
@@ -36,10 +36,12 @@ export const fetchRates = (symbols: string[] = []): Promise<CCResponse> =>
       // to their respective rates via ETH.
       return symbols.reduce(
         (eqRates, sym) => {
-          eqRates[sym] = rateSymbols.reduce((symRates, rateSym) => {
-            symRates[rateSym] = 1 / rates[sym] * rates[rateSym];
-            return symRates;
-          }, {});
+          if (rates[sym]) {
+            eqRates[sym] = rateSymbols.reduce((symRates, rateSym) => {
+              symRates[rateSym] = 1 / rates[sym] * rates[rateSym];
+              return symRates;
+            }, {});
+          }
           return eqRates;
         },
         {

--- a/common/components/BalanceSidebar/EquivalentValues.tsx
+++ b/common/components/BalanceSidebar/EquivalentValues.tsx
@@ -110,7 +110,7 @@ export default class EquivalentValues extends React.Component<Props, CmpState> {
             <option value="ETH">ETH</option>
             {tokenBalances &&
               tokenBalances.map(tk => {
-                if (!tk.balance || tk.balance.isZero()) {
+                if (!tk.balance || tk.balance.isZero() || !rates[tk.symbol]) {
                   return;
                 }
                 const sym = tk.symbol;


### PR DESCRIPTION
Closes #510. The fix made on CryptoCompare's side from #462 led to tokens that weren't recognized (Ala beercoin, unicorn etc.) to end up with bogus NaN rates objects. It didn't get caught in testing as this wasn't a change to the code, but to the API instead.

This fix simply excludes them from the rates object, and from the select list of equivalent values.