### PR TITLE
Fix Production Build

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,8 @@
     "url-search-params-polyfill": "2.0.1",
     "webpack": "3.9.1",
     "webpack-dev-middleware": "1.12.2",
-    "webpack-hot-middleware": "2.21.0"
+    "webpack-hot-middleware": "2.21.0",
+    "webpack-sources": "1.0.1"
   },
   "scripts": {
     "freezer": "webpack --config=./webpack_config/webpack.freezer.js && node ./dist/freezer.js",


### PR DESCRIPTION
Force downgrade `webpack-sources` (sup-dependency) to fix build error as described in https://github.com/webpack/webpack/issues/5931

closes https://github.com/MyEtherWallet/MyEtherWallet/issues/509