### PR TITLE
Error Screen on Exception

### DIFF
--- a/common/Root.tsx
+++ b/common/Root.tsx
@@ -37,30 +37,26 @@ export default class Root extends Component<Props, State> {
     const { store, history } = this.props;
     const { hasError } = this.state;
     // key={Math.random()} = hack for HMR from https://github.com/webpack/webpack-dev-server/issues/395
-    return (
-      <div>
-        {hasError ? (
-          <ErrorScreen />
-        ) : (
-          <Provider store={store} key={Math.random()}>
-            <Router history={history} key={Math.random()}>
-              <div>
-                <Route exact={true} path="/" component={GenerateWallet} />
-                <Route path="/view-wallet" component={ViewWallet} />
-                <Route path="/help" component={Help} />
-                <Route path="/swap" component={Swap} />
-                <Route path="/send-transaction" component={SendTransaction} />
-                <Route path="/contracts" component={Contracts} />
-                <Route path="/ens" component={ENS} />
-                <Route path="/utilities" component={RestoreKeystore} />
-                <Route path="/sign-and-verify-message" component={SignAndVerifyMessage} />
-                <Route path="/pushTx" component={BroadcastTx} />
-                <LegacyRoutes />
-              </div>
-            </Router>
-          </Provider>
-        )}
-      </div>
+    return hasError ? (
+      <ErrorScreen />
+    ) : (
+      <Provider store={store} key={Math.random()}>
+        <Router history={history} key={Math.random()}>
+          <div>
+            <Route exact={true} path="/" component={GenerateWallet} />
+            <Route path="/view-wallet" component={ViewWallet} />
+            <Route path="/help" component={Help} />
+            <Route path="/swap" component={Swap} />
+            <Route path="/send-transaction" component={SendTransaction} />
+            <Route path="/contracts" component={Contracts} />
+            <Route path="/ens" component={ENS} />
+            <Route path="/utilities" component={RestoreKeystore} />
+            <Route path="/sign-and-verify-message" component={SignAndVerifyMessage} />
+            <Route path="/pushTx" component={BroadcastTx} />
+            <LegacyRoutes />
+          </div>
+        </Router>
+      </Provider>
     );
   }
 }

--- a/common/Root.tsx
+++ b/common/Root.tsx
@@ -12,6 +12,7 @@ import ViewWallet from 'containers/Tabs/ViewWallet';
 import SignAndVerifyMessage from 'containers/Tabs/SignAndVerifyMessage';
 import BroadcastTx from 'containers/Tabs/BroadcastTx';
 import RestoreKeystore from 'containers/Tabs/RestoreKeystore';
+import ErrorScreen from 'components/ErrorScreen';
 
 // TODO: fix this
 interface Props {
@@ -19,31 +20,47 @@ interface Props {
   history: any;
 }
 
-export default class Root extends Component<Props, {}> {
+interface State {
+  hasError: boolean;
+}
+
+export default class Root extends Component<Props, State> {
+  public state = {
+    hasError: false
+  };
+
+  public componentDidCatch() {
+    this.setState({ hasError: true });
+  }
+
   public render() {
     const { store, history } = this.props;
+    const { hasError } = this.state;
     // key={Math.random()} = hack for HMR from https://github.com/webpack/webpack-dev-server/issues/395
     return (
-      <Provider store={store} key={Math.random()}>
-        <Router history={history} key={Math.random()}>
-          <div>
-            <Route exact={true} path="/" component={GenerateWallet} />
-            <Route path="/view-wallet" component={ViewWallet} />
-            <Route path="/help" component={Help} />
-            <Route path="/swap" component={Swap} />
-            <Route path="/send-transaction" component={SendTransaction} />
-            <Route path="/contracts" component={Contracts} />
-            <Route path="/ens" component={ENS} />
-            <Route path="/utilities" component={RestoreKeystore} />
-            <Route
-              path="/sign-and-verify-message"
-              component={SignAndVerifyMessage}
-            />
-            <Route path="/pushTx" component={BroadcastTx} />
-            <LegacyRoutes />
-          </div>
-        </Router>
-      </Provider>
+      <div>
+        {hasError ? (
+          <ErrorScreen />
+        ) : (
+          <Provider store={store} key={Math.random()}>
+            <Router history={history} key={Math.random()}>
+              <div>
+                <Route exact={true} path="/" component={GenerateWallet} />
+                <Route path="/view-wallet" component={ViewWallet} />
+                <Route path="/help" component={Help} />
+                <Route path="/swap" component={Swap} />
+                <Route path="/send-transaction" component={SendTransaction} />
+                <Route path="/contracts" component={Contracts} />
+                <Route path="/ens" component={ENS} />
+                <Route path="/utilities" component={RestoreKeystore} />
+                <Route path="/sign-and-verify-message" component={SignAndVerifyMessage} />
+                <Route path="/pushTx" component={BroadcastTx} />
+                <LegacyRoutes />
+              </div>
+            </Router>
+          </Provider>
+        )}
+      </div>
     );
   }
 }

--- a/common/components/ErrorScreen/index.scss
+++ b/common/components/ErrorScreen/index.scss
@@ -1,0 +1,8 @@
+@import 'common/sass/variables';
+@import 'common/sass/mixins';
+
+.ErrorScreen {
+  @include cover-message;
+  background: $brand-danger;
+
+}

--- a/common/components/ErrorScreen/index.tsx
+++ b/common/components/ErrorScreen/index.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import './index.scss';
+
+const SUBJECT = 'Error!';
+const DESCRIPTION =
+  'I encountered an error while using MyEtherWallet. Here are the steps to re-create the issue: ...';
+
+export default class ErrorScreen extends React.Component<{}, {}> {
+  public render() {
+    return (
+      <div className={`ErrorScreen`}>
+        <div className="ErrorScreen-content">
+          <h2>Oops!</h2>
+          <p>Something went really wrong, so we're showing you this red error page! 😱</p>
+          <p>
+            Please contact{' '}
+            <a
+              target="_blank"
+              rel="noopener"
+              href={`mailto:support@myetherwallet.com?Subject=${SUBJECT}&body=${DESCRIPTION}`}
+            >
+              support@myetherwallet.com
+            </a>{' '}
+            if a refresh doesn't fix it (or click it anyway to open a ticket 😊 ).
+          </p>
+        </div>
+      </div>
+    );
+  }
+}

--- a/common/components/ErrorScreen/index.tsx
+++ b/common/components/ErrorScreen/index.tsx
@@ -5,26 +5,26 @@ const SUBJECT = 'Error!';
 const DESCRIPTION =
   'I encountered an error while using MyEtherWallet. Here are the steps to re-create the issue: ...';
 
-export default class ErrorScreen extends React.Component<{}, {}> {
-  public render() {
-    return (
-      <div className={`ErrorScreen`}>
-        <div className="ErrorScreen-content">
-          <h2>Oops!</h2>
-          <p>Something went really wrong, so we're showing you this red error page! 😱</p>
-          <p>
-            Please contact{' '}
-            <a
-              target="_blank"
-              rel="noopener"
-              href={`mailto:support@myetherwallet.com?Subject=${SUBJECT}&body=${DESCRIPTION}`}
-            >
-              support@myetherwallet.com
-            </a>{' '}
-            if a refresh doesn't fix it (or click it anyway to open a ticket 😊 ).
-          </p>
-        </div>
+const ErrorScreen: React.SFC<{}> = () => {
+  return (
+    <div className={`ErrorScreen`}>
+      <div className="ErrorScreen-content">
+        <h2>Oops!</h2>
+        <p>Something went really wrong, so we're showing you this red error page! 😱</p>
+        <p>
+          Please contact{' '}
+          <a
+            target="_blank"
+            rel="noopener"
+            href={`mailto:support@myetherwallet.com?Subject=${SUBJECT}&body=${DESCRIPTION}`}
+          >
+            support@myetherwallet.com
+          </a>{' '}
+          if a refresh doesn't fix it (or click it anyway to open a ticket 😊 ).
+        </p>
       </div>
-    );
-  }
-}
+    </div>
+  );
+};
+
+export default ErrorScreen;

--- a/common/components/ErrorScreen/index.tsx
+++ b/common/components/ErrorScreen/index.tsx
@@ -7,7 +7,7 @@ const DESCRIPTION =
 
 const ErrorScreen: React.SFC<{}> = () => {
   return (
-    <div className={`ErrorScreen`}>
+    <div className="ErrorScreen">
       <div className="ErrorScreen-content">
         <h2>Oops!</h2>
         <p>Something went really wrong, so we're showing you this red error page! 😱</p>


### PR DESCRIPTION
closes https://github.com/MyEtherWallet/MyEtherWallet/issues/479

## Why?
Any runtime error that crashes a component will result in a white-screen with no addition details. 

## What?
This PR employs React 16's Error Boundary via `componentDidCatch`. We show an error screen when an exception bubbles up to the `Root` component. In the future, we can create more specific error boundaries at lower component to maintain application functionality in the case of an error.

![screen shot 2017-12-07 at 5 22 50 pm](https://user-images.githubusercontent.com/7861465/33747623-ce65aca0-db78-11e7-9ff6-d5a82147f512.png)
