### PR TITLE
Minimize CI Failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ dist: trusty
 sudo: required
 language: node_js
 
+cache:
+  directories:
+    - node_modules
+
 services:
   - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ jobs:
     - stage: test
       script: npm run test
     - stage: test
-      script: npm run test:int
-    - stage: test
       script: npm run tslint
     - stage: test
       script: npm run tscheck


### PR DESCRIPTION
Currently CI is failing on most builds due to external service issues related to integration testing.

The long-term fix is described in https://github.com/MyEtherWallet/MyEtherWallet/issues/549, but in the meantime I'd like to disable integration testing in CI to prevent frequent CI failures.

Additionally, I've enabled node_module caching in an attempt to reduce npm install failures breaking CI