### PR TITLE
Fix generate in safari / get rid of flex behavior

### DIFF
--- a/common/containers/Tabs/GenerateWallet/components/Template.scss
+++ b/common/containers/Tabs/GenerateWallet/components/Template.scss
@@ -1,19 +1,7 @@
 @import "common/sass/variables";
 
 .GenerateWallet {
-  display: flex;
-  flex-wrap: wrap;
-
   &-column {
-    display: flex;
-    flex-direction: column;
-
-    &-content,
-    &-help {
-      width: 100%;
-      height: 100%;
-    }
-
     &-content {
       text-align: center;
     }


### PR DESCRIPTION
Closes #592. I just got rid of the equal height column behavior, it was always kind of janky anyway.