### PR TITLE
Lower LocalStorage Store Throttle

### DIFF
--- a/common/store.ts
+++ b/common/store.ts
@@ -135,7 +135,7 @@ const configureStore = () => {
         },
         customTokens: state.customTokens
       });
-    }, 1000)
+    }, 50)
   );
 
   return store;


### PR DESCRIPTION
We want to prevent spamming the localStorage API during times of frequent store updates, but 1s is too large of a throttle (some parts of the application rely on refreshing directly after changing state).

This PR reduces the throttle to a *better* magical number, 50ms!
