### PR TITLE
Attempt Web3 Unlock OnClick

### DIFF
--- a/common/components/WalletDecrypt/WalletDecrypt.tsx
+++ b/common/components/WalletDecrypt/WalletDecrypt.tsx
@@ -69,6 +69,7 @@ interface BaseWalletInfo {
   unlock: any;
   helpLink?: string;
   isReadOnly?: boolean;
+  attemptUnlock?: boolean;
 }
 
 export interface SecureWalletInfo extends BaseWalletInfo {
@@ -105,6 +106,7 @@ export class WalletDecrypt extends Component<Props, State> {
       component: Web3Decrypt,
       initialParams: {},
       unlock: this.props.unlockWeb3,
+      attemptUnlock: true,
       helpLink: `${knowledgeBaseURL}/migration/moving-from-private-key-to-metamask`
     },
     'ledger-nano-s': {
@@ -282,10 +284,19 @@ export class WalletDecrypt extends Component<Props, State> {
       return;
     }
 
-    this.setState({
-      selectedWalletKey: walletType,
-      value: wallet.initialParams
-    });
+    let timeout = 0;
+
+    if (wallet.attemptUnlock) {
+      timeout = 250;
+      wallet.unlock();
+    }
+
+    setTimeout(() => {
+      this.setState({
+        selectedWalletKey: walletType,
+        value: wallet.initialParams
+      });
+    }, timeout);
   };
 
   public clearWalletChoice = () => {


### PR DESCRIPTION
## Why?
MEW + MetaMask is now single click in the happy path (🎉 to the UX) with no degradation to UX on the sad path.

## Happy
![2017-12-28 21 51 18](https://user-images.githubusercontent.com/7861465/34429174-167447a2-ec1a-11e7-8893-474d2120b5a5.gif)

## Sad
![2017-12-28 21 51 55](https://user-images.githubusercontent.com/7861465/34429161-f0dde1ce-ec19-11e7-9083-6e7881e12c17.gif)

## What could be better
- 250ms is chosen as the magical number to give time for web3 decryption. This works well enough on my machine, but time to unlock may (likely slightly) vary for others. If the unlock time exceeds 250ms, the secondary unlock screen will be shown and then disappear without user action as soon as the wallet is unlocked. I've found 250ms to work well on my testing, but open to feedback on how to increase robustness (hopefully without the corresponding increase in complexity). *This can be solved concretely by using sagas and dispatching state updates based on the web3 unlock response, and I may end up implementing that if this doesn't sit right after a night of sleep 😁)*

- (Minor) Notifications are currently broken (recently updated in https://github.com/MyEtherWallet/MyEtherWallet/issues/645), so the current build would have an unclose-able error notification until notifications are fixed. 
