### PR TITLE
Lite Send Test Fix

### DIFF
--- a/spec/sagas/swap/liteSend.spec.ts
+++ b/spec/sagas/swap/liteSend.spec.ts
@@ -1,9 +1,13 @@
+import { configuredStore } from 'store';
 import { cloneableGenerator, createMockTask } from 'redux-saga/utils';
 import { take, race, fork } from 'redux-saga/effects';
 import { TypeKeys as TransactionTK } from 'actions/transaction';
 import { TypeKeys as WalletTK } from 'actions/wallet';
 import { TypeKeys as SwapTK } from 'actions/swap/constants';
 import { configureLiteSend, handleConfigureLiteSend } from 'sagas/swap/liteSend';
+
+// init module
+configuredStore.getState();
 
 describe('Testing handle configure lite send', () => {
   const generators = {


### PR DESCRIPTION
Quick fix to make `npm test -- liteSend.spec` pass.