### PR TITLE
Webpack Upgrade Freezer Fix

### DIFF
--- a/webpack_config/webpack.freezer.js
+++ b/webpack_config/webpack.freezer.js
@@ -8,8 +8,8 @@ const freezerConfig = Object.assign({}, baseConfig, {
   target: undefined,
   performance: undefined,
   module: {
-    // Typescript loader
-    loaders: [baseConfig.module.loaders[0]]
+    // Typescript loader    
+    loaders: [baseConfig.module.rules[0]]
   },
 
   // Point at freezer, make sure it's setup to run in node


### PR DESCRIPTION
Freezer will now compile, but we're running into another issue with webpack not exiting. This will probably cause Travis to stall out, so we'll either need to solve that bug or figure out a different way to run this program (perhaps through the `ts-node` package).

Also, the same fix will need to be applied to `webpack.derivation-checker.js`. I would have updated the file but am having issues with Docker and couldn't properly test the changes. 