### PR TITLE
Fix custom node form

### DIFF
--- a/common/components/Header/components/CustomNodeModal.tsx
+++ b/common/components/Header/components/CustomNodeModal.tsx
@@ -233,7 +233,7 @@ export default class CustomNodeModal extends React.Component<Props, State> {
           'form-control': true,
           'is-invalid': this.state[input.name] && invalids[input.name]
         })}
-        value={this.state.name}
+        value={this.state[input.name]}
         onChange={this.handleChange}
         {...input}
       />


### PR DESCRIPTION
https://github.com/MyEtherWallet/MyEtherWallet/commit/f39787152#diff-0fb63f2ecec1a1d8998af37ee70ac8e7R236 hard coded it, so all fields use the `name` field's value. This just undoes that.