### PR TITLE
Implement `offline-plugin` for Service Workers / App Cache

### DIFF
--- a/common/index.tsx
+++ b/common/index.tsx
@@ -5,13 +5,15 @@ import 'sass/styles.scss';
 import 'babel-polyfill';
 import 'whatwg-fetch';
 import React from 'react';
+import OfflineRuntime from 'offline-plugin/runtime';
 import { render } from 'react-dom';
 import Root from './Root';
 import { configuredStore } from './store';
 import consoleAdvertisement from './utils/consoleAdvertisement';
 
-const appEl = document.getElementById('app');
+OfflineRuntime.install();
 
+const appEl = document.getElementById('app');
 render(<Root store={configuredStore} />, appEl);
 
 if (module.hot) {

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "node-sass": "4.7.2",
     "nodemon": "1.14.7",
     "null-loader": "0.1.1",
+    "offline-plugin": "4.9.0",
     "prettier": "1.9.2",
     "progress": "2.0.0",
     "react-hot-loader": "3.1.3",

--- a/webpack_config/webpack.prod.js
+++ b/webpack_config/webpack.prod.js
@@ -6,7 +6,7 @@ const webpack = require('webpack');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const ProgressPlugin = require('webpack/lib/ProgressPlugin');
 const BabelMinifyPlugin = require('babel-minify-webpack-plugin');
-// const OfflinePlugin = require('offline-plugin')
+const OfflinePlugin = require('offline-plugin');
 const base = require('./webpack.base');
 const config = require('./config');
 const rimraf = require('rimraf');
@@ -66,15 +66,10 @@ base.plugins.push(
   new webpack.optimize.CommonsChunkPlugin({
     name: 'vendor',
     filename: 'vendor.[chunkhash:8].js'
+  }),
+  new OfflinePlugin({
+    appShell: '/'
   })
-  // For progressive web apps
-  // new OfflinePlugin({
-  //   relativePaths: false,
-  //   AppCache: false,
-  //   ServiceWorker: {
-  //     events: true
-  //   }
-  // })
 );
 
 // minimize webpack output


### PR DESCRIPTION
Closes #570. This is probably the highest benefit to lowest effort PR I've ever made. Implements the [`offline-plugin`](https://github.com/NekR/offline-plugin) on the production build to cache assets via service workerss, or fallback to app cache. This is really cool for two reasons:

1) Subsequent visits the the site will not re-request assets, and will instead use a cache, resulting in hella fast page loads.
2) You can load myetherwallet.com even if you're offline.

This will be exceptionally good for Android phone users, but will still be great for anyone using Chrome or Firefox. It falls back to AppCache apparently, but I'm not really sure how that behaves.

Here's what a second page load looks like on a 3g connection today:

<img width="1440" alt="screen shot 2018-01-01 at 3 25 15 pm" src="https://user-images.githubusercontent.com/649992/34470929-06936942-ef0a-11e7-9d77-fb03fd50ead6.png">

Here's what it looks like with the service worker installed:

<img width="1440" alt="screen shot 2018-01-01 at 3 25 35 pm" src="https://user-images.githubusercontent.com/649992/34470933-12cab08a-ef0a-11e7-866a-4a12aac624d6.png">

From 27.2s to 2.22s

---

I think we should put this up on the next alpha release, so that we can do substantial testing on various devices more easily. I definitely want to make sure we're not going to get into a situation where we can't bust a cache.