### PR TITLE
Disable mangle (temporarily?) to fix prod build

### DIFF
--- a/webpack_config/webpack.prod.js
+++ b/webpack_config/webpack.prod.js
@@ -61,7 +61,11 @@ base.plugins.push(
   new webpack.DefinePlugin({
     'process.env.NODE_ENV': JSON.stringify('production')
   }),
-  new BabelMinifyPlugin(),
+  new BabelMinifyPlugin({
+    mangle: false
+  }, {
+    comments: false
+  }),
   // extract vendor chunks
   new webpack.optimize.CommonsChunkPlugin({
     name: 'vendor',


### PR DESCRIPTION
When we have mangling enabled, we get the following error:

```
vendor.7f07fec2.js:15 uncaught at  at  
 at  
 SyntaxError: Identifier 'a' has already been declared
    at i (http://127.0.0.1:8080/vendor.7f07fec2.js:24:159237)
    at x (http://127.0.0.1:8080/vendor.7f07fec2.js:24:162288)
    at y (http://127.0.0.1:8080/vendor.7f07fec2.js:24:161048)
    at http://127.0.0.1:8080/vendor.7f07fec2.js:24:163141
    at Array.forEach (<anonymous>)
    at D (http://127.0.0.1:8080/vendor.7f07fec2.js:24:163114)
    at y (http://127.0.0.1:8080/vendor.7f07fec2.js:24:160951)
    at a (http://127.0.0.1:8080/vendor.7f07fec2.js:24:159881)
    at d (http://127.0.0.1:8080/vendor.7f07fec2.js:24:165548)
    at t.a (http://127.0.0.1:8080/vendor.7f07fec2.js:24:158234)
o @ vendor.7f07fec2.js:15
```

(The missing words, ` at at ` are what show up in console.)

This issue is extremely difficult to debug, so temporarily we should disable it so the build isn't erroring.