### PR TITLE
Fix deterministic modal token values

### DIFF
--- a/common/components/WalletDecrypt/components/DeterministicWalletsModal.tsx
+++ b/common/components/WalletDecrypt/components/DeterministicWalletsModal.tsx
@@ -30,8 +30,8 @@ interface Props {
   seed?: string;
 
   // Redux state
-  wallets: DeterministicWalletData[];
-  desiredToken: string;
+  wallets: AppState['deterministicWallets']['wallets'];
+  desiredToken: AppState['deterministicWallets']['desiredToken'];
   network: NetworkConfig;
   tokens: MergedToken[];
 
@@ -252,7 +252,7 @@ class DeterministicWalletsModalClass extends React.Component<Props, State> {
     const { selectedAddress } = this.state;
 
     // Get renderable values, but keep 'em short
-    const token = wallet.tokenValues[desiredToken];
+    const token = desiredToken ? wallet.tokenValues[desiredToken] : null;
 
     return (
       <tr

--- a/common/sagas/deterministicWallets.ts
+++ b/common/sagas/deterministicWallets.ts
@@ -96,18 +96,23 @@ export function* updateWalletTokenValues(): SagaIterator {
     const calls = wallets.map(w => {
       return apply(node, node.getTokenBalance, [w.address, token]);
     });
-    const tokenBalances: TokenValue[] = yield all(calls);
+    const tokenBalances: { balance: TokenValue; error: string | null } = yield all(calls);
 
     for (let i = 0; i < wallets.length; i++) {
-      yield put(
-        updateDeterministicWallet({
-          ...wallets[i],
-          tokenValues: {
-            ...wallets[i].tokenValues,
-            [desiredToken]: { value: tokenBalances[i], decimal: token.decimal }
-          }
-        })
-      );
+      if (!tokenBalances[i].error) {
+        yield put(
+          updateDeterministicWallet({
+            ...wallets[i],
+            tokenValues: {
+              ...wallets[i].tokenValues,
+              [desiredToken]: {
+                value: tokenBalances[i].balance,
+                decimal: token.decimal
+              }
+            }
+          })
+        );
+      }
     }
   } catch (err) {
     console.log(err);

--- a/spec/sagas/deterministicWallets.spec.ts
+++ b/spec/sagas/deterministicWallets.spec.ts
@@ -70,10 +70,8 @@ describe('getDeterministicWallets*', () => {
   describe('starting from publicKey & chainCode', () => {
     const dWallet = {
       dPath: '',
-      publicKey:
-        '02fcba7ecf41bc7e1be4ee122d9d22e3333671eb0a3a87b5cdf099d59874e1940f',
-      chainCode:
-        '180c998615636cd875aa70c71cfa6b7bf570187a56d8c6d054e60b644d13e9d3',
+      publicKey: '02fcba7ecf41bc7e1be4ee122d9d22e3333671eb0a3a87b5cdf099d59874e1940f',
+      chainCode: '180c998615636cd875aa70c71cfa6b7bf570187a56d8c6d054e60b644d13e9d3',
       limit: 10,
       offset: 0
     };
@@ -98,10 +96,7 @@ describe('getDeterministicWallets*', () => {
 describe('updateWalletValues*', () => {
   const walletData1 = genWalletData1();
   const walletData2 = genWalletData2();
-  const wallets: dWalletActions.DeterministicWalletData[] = [
-    walletData1,
-    walletData2
-  ];
+  const wallets: dWalletActions.DeterministicWalletData[] = [walletData1, walletData2];
   const balances = genBalances();
   const node: INode = new RpcNode('');
   const gen = updateWalletValues();
@@ -153,10 +148,7 @@ describe('updateWalletValues*', () => {
 describe('updateWalletTokenValues*', () => {
   const walletData1 = genWalletData1();
   const walletData2 = genWalletData2();
-  const wallets: dWalletActions.DeterministicWalletData[] = [
-    walletData1,
-    walletData2
-  ];
+  const wallets: dWalletActions.DeterministicWalletData[] = [walletData1, walletData2];
   const node: INode = new RpcNode('');
   const token1: Token = {
     address: '0x2',
@@ -169,7 +161,16 @@ describe('updateWalletTokenValues*', () => {
     decimal: 16
   };
   const tokens = [token1, token2];
-  const tokenBalances = [TokenValue('100'), TokenValue('200')];
+  const tokenBalances = [
+    {
+      balance: TokenValue('100'),
+      error: null
+    },
+    {
+      balance: TokenValue('200'),
+      error: null
+    }
+  ];
   const desiredToken = 'OMG';
   const data = {} as any;
   data.gen = cloneableGenerator(updateWalletTokenValues)();


### PR DESCRIPTION
Closes #692. Frustratingly, Typescript did not catch a change in types because of the way we type Redux Saga `yield call`s explicitly. There are also tests for this functionality, which I was surprised to see didn't catch this either. I'm not intimately familiar with saga testing, so maybe @skubakdj could shed some light on that bit of weirdness.

Either way, this fixes it up and tightens up some of the typing.