### PR TITLE
Fix Logout Prompt

### DIFF
--- a/common/Root.tsx
+++ b/common/Root.tsx
@@ -12,6 +12,8 @@ import SignAndVerifyMessage from 'containers/Tabs/SignAndVerifyMessage';
 import BroadcastTx from 'containers/Tabs/BroadcastTx';
 import ErrorScreen from 'components/ErrorScreen';
 import PageNotFound from 'components/PageNotFound';
+import LogOutPrompt from 'components/LogOutPrompt';
+import { Aux } from 'components/ui';
 import { Store } from 'redux';
 import { AppState } from 'reducers';
 
@@ -60,16 +62,20 @@ export default class Root extends Component<Props, State> {
         <Route path="/sign-and-verify-message" component={SignAndVerifyMessage} />
         <Route path="/pushTx" component={BroadcastTx} />
         <Route component={PageNotFound} />
-        <LegacyRoutes />
       </Switch>
     );
+
+    const Router = process.env.BUILD_DOWNLOADABLE ? HashRouter : BrowserRouter;
+
     return (
       <Provider store={store} key={Math.random()}>
-        {process.env.BUILD_DOWNLOADABLE ? (
-          <HashRouter key={Math.random()}>{routes}</HashRouter>
-        ) : (
-          <BrowserRouter key={Math.random()}>{routes}</BrowserRouter>
-        )}
+        <Router key={Math.random()}>
+          <Aux>
+            {routes}
+            <LegacyRoutes />
+            <LogOutPrompt />
+          </Aux>
+        </Router>
       </Provider>
     );
   }

--- a/common/components/WalletDecrypt/WalletDecrypt.tsx
+++ b/common/components/WalletDecrypt/WalletDecrypt.tsx
@@ -28,7 +28,6 @@ import {
   TrezorDecrypt,
   ViewOnlyDecrypt,
   Web3Decrypt,
-  NavigationPrompt,
   WalletButton
 } from './components';
 import { AppState } from 'reducers';
@@ -307,13 +306,11 @@ export class WalletDecrypt extends Component<Props, State> {
   };
 
   public render() {
-    const { wallet, hidden } = this.props;
+    const { hidden } = this.props;
     const selectedWallet = this.getSelectedWallet();
     const decryptionComponent = this.getDecryptionComponent();
-    const unlocked = !!wallet;
     return (
       <div>
-        <NavigationPrompt when={unlocked} onConfirm={this.props.resetWallet} />
         {!hidden && (
           <article className="Tab-content-pane">
             <div className="WalletDecrypt">

--- a/common/components/WalletDecrypt/components/index.tsx
+++ b/common/components/WalletDecrypt/components/index.tsx
@@ -3,7 +3,6 @@ export * from './DigitalBitbox';
 export * from './Keystore';
 export * from './LedgerNano';
 export * from './Mnemonic';
-export * from './NavigationPrompt';
 export * from './PrivateKey';
 export * from './Trezor';
 export * from './ViewOnly';


### PR DESCRIPTION
Closes #707. This splits out the NavigationPrompt component into a more self-sufficient connected LogOutPrompt component. Rendered at Root so it's always there, this checks if redux has a wallet whenever the base path changes. If so, it does the normal logout prompt thing.

I think this should be somewhat more robust, since we no longer have the implicit dependency on rendering DecryptWallet all the time to get the logout behavior. It should also allow for the logout prompt if we ever set the wallet state in a non-DecryptWallet way.

Let me know if I bastardized the component beyond recognition.