### PR TITLE
Web3 Improvements

### DIFF
--- a/common/components/WalletDecrypt/WalletDecrypt.tsx
+++ b/common/components/WalletDecrypt/WalletDecrypt.tsx
@@ -31,7 +31,7 @@ import {
   WalletButton
 } from './components';
 import { AppState } from 'reducers';
-import { knowledgeBaseURL } from 'config/data';
+import { knowledgeBaseURL, isWeb3NodeAvailable } from 'config/data';
 import { IWallet } from 'libs/wallet';
 import DigitalBitboxIcon from 'assets/images/wallets/digital-bitbox.svg';
 import LedgerIcon from 'assets/images/wallets/ledger.svg';
@@ -39,7 +39,6 @@ import MetamaskIcon from 'assets/images/wallets/metamask.svg';
 import MistIcon from 'assets/images/wallets/mist.svg';
 import TrezorIcon from 'assets/images/wallets/trezor.svg';
 import './WalletDecrypt.scss';
-import { isWeb3NodeAvailable } from 'config/data';
 type UnlockParams = {} | PrivateKeyValue;
 
 interface Props {

--- a/common/components/WalletDecrypt/WalletDecrypt.tsx
+++ b/common/components/WalletDecrypt/WalletDecrypt.tsx
@@ -39,7 +39,7 @@ import MetamaskIcon from 'assets/images/wallets/metamask.svg';
 import MistIcon from 'assets/images/wallets/mist.svg';
 import TrezorIcon from 'assets/images/wallets/trezor.svg';
 import './WalletDecrypt.scss';
-
+import { isWeb3NodeAvailable } from 'config/data';
 type UnlockParams = {} | PrivateKeyValue;
 
 interface Props {
@@ -277,7 +277,7 @@ export class WalletDecrypt extends Component<Props, State> {
     );
   }
 
-  public handleWalletChoice = (walletType: string) => {
+  public handleWalletChoice = async (walletType: string) => {
     const wallet = this.WALLETS[walletType];
     if (!wallet) {
       return;
@@ -285,8 +285,8 @@ export class WalletDecrypt extends Component<Props, State> {
 
     let timeout = 0;
 
-    if (wallet.attemptUnlock) {
-      timeout = 250;
+    if (wallet.attemptUnlock && isWeb3NodeAvailable()) {
+      timeout = 500;
       wallet.unlock();
     }
 

--- a/common/components/WalletDecrypt/WalletDecrypt.tsx
+++ b/common/components/WalletDecrypt/WalletDecrypt.tsx
@@ -284,9 +284,11 @@ export class WalletDecrypt extends Component<Props, State> {
     }
 
     let timeout = 0;
-
-    if (wallet.attemptUnlock && isWeb3NodeAvailable()) {
-      timeout = 500;
+    const web3Available = await isWeb3NodeAvailable();
+    if (wallet.attemptUnlock && web3Available) {
+      // timeout is only the maximum wait time before secondary view is shown
+      // send view will be shown immediately on web3 resolve
+      timeout = 1000;
       wallet.unlock();
     }
 

--- a/common/config/data.ts
+++ b/common/config/data.ts
@@ -278,7 +278,12 @@ export const NODES: { [key: string]: NodeConfig } = {
   }
 };
 
-export async function initWeb3Node(): Promise<void> {
+interface Web3NodeInfo {
+  networkId: string;
+  lib: Web3Node;
+}
+
+export async function setupWeb3Node(): Promise<Web3NodeInfo> {
   const { web3 } = window as any;
 
   if (!web3 || !web3.currentProvider || !web3.currentProvider.sendAsync) {
@@ -299,6 +304,20 @@ export async function initWeb3Node(): Promise<void> {
     throw new Error('MetaMask / Mist is still loading. Please refresh the page and try again.');
   }
 
+  return { networkId, lib };
+}
+
+export async function isWeb3NodeAvailable(): Promise<boolean> {
+  try {
+    await setupWeb3Node();
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+export async function initWeb3Node(): Promise<void> {
+  const { networkId, lib } = await setupWeb3Node();
   NODES.web3 = {
     network: networkIdToName(networkId),
     service: 'MetaMask / Mist',


### PR DESCRIPTION
- Increase timeout for web3 auto-login to 1s.
     - NOTE: timeout is only the maximum wait time before secondary view is shown. Send view will be shown immediately on web3 resolve, so 1s is the upper-bound on how long the UI will be unresponsive while web3 is resolving. On a fast connection, I get a resolution in < 250ms, but we can opt to show a loading indicator and a higher upper-bound if we discover that the user experience is poor in practice.
- Don't attempt login when web3 provider is not available

![2018-01-07 19 00 40](https://user-images.githubusercontent.com/7861465/34656292-1764aef2-f3dd-11e7-8a75-ce5637928836.gif)