### PR TITLE
Fix Safari / iOS illegal character syntax error

### DIFF
--- a/webpack_config/webpack.prod.js
+++ b/webpack_config/webpack.prod.js
@@ -62,7 +62,8 @@ base.plugins.push(
     'process.env.NODE_ENV': JSON.stringify('production')
   }),
   new BabelMinifyPlugin({
-    mangle: false
+    mangle: false,
+    propertyLiterals: false
   }, {
     comments: false
   }),


### PR DESCRIPTION
Closes https://github.com/MyEtherWallet/MyEtherWallet/issues/512

Discovered it was a minifier rule + moment issue. Posted the fix here: https://github.com/webpack/webpack/issues/4510#issuecomment-355868894

>Confirmed that removing babel-minify-webpack-plugin stopped the error from showing up.
>
>EDIT: Turns out this is from the property literals minifier rule. I had moment locales in my build, and one of the properties was the Â character. Most browser could handle it, not Safari!
  