### PR TITLE
Fix Safari / iOS illegal character error (forreal this time)

### DIFF
--- a/webpack_config/webpack.prod.js
+++ b/webpack_config/webpack.prod.js
@@ -62,8 +62,12 @@ base.plugins.push(
     'process.env.NODE_ENV': JSON.stringify('production')
   }),
   new BabelMinifyPlugin({
+    // Mangle seems to be reusing variable identifiers, causing errors
     mangle: false,
-    propertyLiterals: false
+    // These two on top of a lodash file are causing illegal characters for
+    // safari and ios browsers
+    evaluate: false,
+    propertyLiterals: false,
   }, {
     comments: false
   }),


### PR DESCRIPTION
Closes #512 (No, really.)

I was on the right track before, but missed the right fix due to caching. Unfortunately file hashes come _before_ minification, not after, so altering the uglifier doesn't bust cache.

It turns out it's a _combination_ of `evaluate` and `propertyLiterals`. [This line in Lodash](https://github.com/lodash/lodash/blob/6cb3460fcefe66cb96e55b82c6febd2153c992cc/.internal/deburrLetter.js#L6) was getting eval'd from `\xc2` to `Â`. You can actually try it in your browser if you want.

### Steps to Test

```
npm run build
http-server dist # or whatever your server of choice is
```

Open in Safari or iOS simulator. Make sure you clear the cache (In safari it's Develop -> Empty Cache) and completely restart the browser, otherwise you may be loading cached JS.