### PR TITLE
Revert "Implement `offline-plugin` for Service Workers / App Cache"

### DIFF
--- a/common/index.tsx
+++ b/common/index.tsx
@@ -5,15 +5,13 @@ import 'sass/styles.scss';
 import 'babel-polyfill';
 import 'whatwg-fetch';
 import React from 'react';
-import OfflineRuntime from 'offline-plugin/runtime';
 import { render } from 'react-dom';
 import Root from './Root';
 import { configuredStore } from './store';
 import consoleAdvertisement from './utils/consoleAdvertisement';
 
-OfflineRuntime.install();
-
 const appEl = document.getElementById('app');
+
 render(<Root store={configuredStore} />, appEl);
 
 if (module.hot) {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "node-sass": "4.7.2",
     "nodemon": "1.14.9",
     "null-loader": "0.1.1",
-    "offline-plugin": "4.9.0",
     "prettier": "1.9.2",
     "progress": "2.0.0",
     "react-hot-loader": "3.1.3",

--- a/webpack_config/webpack.prod.js
+++ b/webpack_config/webpack.prod.js
@@ -6,7 +6,7 @@ const webpack = require('webpack');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const ProgressPlugin = require('webpack/lib/ProgressPlugin');
 const BabelMinifyPlugin = require('babel-minify-webpack-plugin');
-const OfflinePlugin = require('offline-plugin');
+// const OfflinePlugin = require('offline-plugin')
 const base = require('./webpack.base');
 const config = require('./config');
 const rimraf = require('rimraf');
@@ -75,10 +75,15 @@ base.plugins.push(
   new webpack.optimize.CommonsChunkPlugin({
     name: 'vendor',
     filename: 'vendor.[chunkhash:8].js'
-  }),
-  new OfflinePlugin({
-    appShell: '/'
   })
+  // For progressive web apps
+  // new OfflinePlugin({
+  //   relativePaths: false,
+  //   AppCache: false,
+  //   ServiceWorker: {
+  //     events: true
+  //   }
+  // })
 );
 
 // minimize webpack output


### PR DESCRIPTION
This reverts commit ef506c54d6ee94ec5756c8d403ffdbe9b94881d4. 

Cache invalidation issues discovered with testing in the wild and the general difficulties related to cache invalidation call for a temporary revert. 

When we have more resources to ensure that the optimizations related to app caching don't have unintended negative consequences, we can re-enable.
  