### PR TITLE
Stop Timer when Swap Order is Received

### DIFF
--- a/common/sagas/swap/orders.ts
+++ b/common/sagas/swap/orders.ts
@@ -301,6 +301,9 @@ export function* shapeshiftOrderTimeRemaining(): SagaIterator {
               yield put(showNotification('danger', ORDER_TIMEOUT_MESSAGE, Infinity));
             }
             break;
+          case 'received':
+            yield put(stopOrderTimerSwap());
+            break;
           case 'complete':
             yield put(stopPollShapeshiftOrderStatus());
             yield put(stopLoadShapeshiftRatesSwap());


### PR DESCRIPTION
This PR closes #770 

- [x] Stop counting down when the transaction has been received, not when the the destination kind has been sent.

I did not remove the action dispatcher to stop the timer when the destination kind is sent. In the case that our network is slow and fails to catch the received order, I think it's fairly harmless to leave it in the completion of the order (when the destination kind is sent).