### PR TITLE
Remove Digital Bitbox from account view

### DIFF
--- a/common/components/WalletDecrypt/WalletDecrypt.tsx
+++ b/common/components/WalletDecrypt/WalletDecrypt.tsx
@@ -98,7 +98,7 @@ const WEB3_TYPES = {
 const WEB3_TYPE: string | false =
   (window as any).web3 && (window as any).web3.currentProvider.constructor.name;
 
-const SECURE_WALLETS = ['web3', 'ledger-nano-s', 'trezor', 'digital-bitbox'];
+const SECURE_WALLETS = ['web3', 'ledger-nano-s', 'trezor'];
 const INSECURE_WALLETS = ['private-key', 'keystore-file', 'mnemonic-phrase'];
 
 export class WalletDecrypt extends Component<Props, State> {

--- a/common/components/WalletDecrypt/components/WalletButton.scss
+++ b/common/components/WalletDecrypt/components/WalletButton.scss
@@ -27,7 +27,7 @@
   flex: 1;
   height: 155px;
   max-width: 230px;
-  min-width: 300px;
+  min-width: 200px;
   padding: 25px 15px;
   margin: 0 $space-md $space;
 


### PR DESCRIPTION
Digital Bitbox is currently unsupported, so we can remove it from the account view until that functionality is developed.

I've made the simplest change to remove it while maintaining most of the existing configuration for an easy re-addition when it's ready.