### PR TITLE
Onboarding Style Improvements

### DIFF
--- a/common/components/ui/Modal.scss
+++ b/common/components/ui/Modal.scss
@@ -2,7 +2,8 @@
 @import 'common/sass/mixins';
 
 $m-background: #fff;
-$m-window-padding: 20px;
+$m-window-padding-w: 20px;
+$m-window-padding-h: 30px;
 $m-header-padding: 15px;
 $m-header-height: 62px;
 $m-content-padding: 20px;
@@ -49,12 +50,12 @@ $m-anim-speed: 400ms;
 
 .Modal {
   position: fixed;
-  top: 30px;
+  top: $m-window-padding-h;
   left: 50%;
   max-width: 95%;
-  max-width: calc(100% - #{$m-window-padding * 2});
+  max-width: calc(100% - #{$m-window-padding-w * 2});
   max-height: 95%;
-  max-height: calc(100% - #{$m-window-padding * 2});
+  max-height: calc(100% - #{$m-window-padding-h * 2});
   background: $m-background;
   border-radius: 4px;
   transform: translateX(-50%);

--- a/common/components/ui/Modal.tsx
+++ b/common/components/ui/Modal.tsx
@@ -18,6 +18,8 @@ interface Props {
 }
 
 export default class Modal extends Component<Props, {}> {
+  private modalContent: HTMLElement | null = null;
+
   public componentDidMount() {
     this.updateBodyClass();
     document.addEventListener('keydown', this.escapeListner);
@@ -53,12 +55,21 @@ export default class Modal extends Component<Props, {}> {
             </div>
           )}
 
-          <div className="Modal-content">{isOpen && children}</div>
+          <div className="Modal-content" ref={el => (this.modalContent = el)}>
+            {isOpen && children}
+          </div>
           {hasButtons && <div className="Modal-footer">{this.renderButtons()}</div>}
         </div>
       </div>
     );
   }
+
+  public scrollContentToTop = () => {
+    if (this.modalContent) {
+      this.modalContent.scrollTop = 0;
+    }
+  };
+
   private escapeListner = (ev: KeyboardEvent) => {
     // Don't trigger if they hit escape while on an input
     if (ev.target) {

--- a/common/containers/OnboardModal/components/BlockchainSlide.tsx
+++ b/common/containers/OnboardModal/components/BlockchainSlide.tsx
@@ -15,6 +15,8 @@ const BlockchainSlide = () => {
       <li>{translate('ONBOARD_blockchain_content__6')}</li>
     </ul>
   );
-  return <OnboardSlide header={header} content={content} slideImage={onboardIconFour} />;
+  return (
+    <OnboardSlide header={header} content={content} image={onboardIconFour} imageSide="right" />
+  );
 };
 export default BlockchainSlide;

--- a/common/containers/OnboardModal/components/FinalSlide.tsx
+++ b/common/containers/OnboardModal/components/FinalSlide.tsx
@@ -5,13 +5,8 @@ import OnboardSlide from './OnboardSlide';
 import onboardIconTen from 'assets/images/onboarding_icon-10.svg';
 
 const FinalSlide = ({ closeModal }) => {
-  const header = (
-    <div>
-      <span>{translate('ONBOARD_final_title')}</span>
-      <p>{translate('ONBOARD_final_subtitle')}</p>
-      <br />
-    </div>
-  );
+  const header = translate('ONBOARD_final_title');
+  const subheader = translate('ONBOARD_final_subtitle');
 
   const content = (
     <ul>
@@ -92,6 +87,14 @@ const FinalSlide = ({ closeModal }) => {
       </li>
     </ul>
   );
-  return <OnboardSlide header={header} content={content} slideImage={onboardIconTen} />;
+  return (
+    <OnboardSlide
+      header={header}
+      subheader={subheader}
+      content={content}
+      image={onboardIconTen}
+      imageSide="left"
+    />
+  );
 };
 export default FinalSlide;

--- a/common/containers/OnboardModal/components/InterfaceSlide.tsx
+++ b/common/containers/OnboardModal/components/InterfaceSlide.tsx
@@ -17,6 +17,8 @@ const InterfaceSlide = () => {
       <li>{translate('ONBOARD_interface_content__7')}</li>
     </ul>
   );
-  return <OnboardSlide header={header} content={content} slideImage={onboardIconThree} />;
+  return (
+    <OnboardSlide header={header} content={content} image={onboardIconThree} imageSide="left" />
+  );
 };
 export default InterfaceSlide;

--- a/common/containers/OnboardModal/components/NotABankSlide.tsx
+++ b/common/containers/OnboardModal/components/NotABankSlide.tsx
@@ -16,7 +16,7 @@ const NotABankSlide = () => {
     </ul>
   );
 
-  return <OnboardSlide header={header} content={content} slideImage={onboardIconTwo} />;
+  return <OnboardSlide header={header} content={content} image={onboardIconTwo} imageSide="left" />;
 };
 
 export default NotABankSlide;

--- a/common/containers/OnboardModal/components/OnboardSlide.scss
+++ b/common/containers/OnboardModal/components/OnboardSlide.scss
@@ -2,26 +2,59 @@
 @import 'common/sass/mixins';
 
 .OnboardSlide {
-  height: 400px;
-  width: 650px;
+  font-size: 1.15rem;
+
+  &-header {
+    text-align: center;
+    margin-bottom: $space * 2;
+    font-size: 1.65rem;
+    font-weight: bold;
+  }
+
+  &-subheader {
+    text-align: center;
+    margin-top: -$space * 1.5;
+    margin-bottom: $space * 2;
+    color: $gray;
+  }
 
   &-body {
     display: flex;
   }
 
   &-content {
-    flex: 0.7;
+    flex: 1;
+
+    > *:first-child,
+    > div > *:first-child {
+      margin-top: 0;
+    }
+
+    ul {
+      padding-left: 30px;
+    }
   }
 
   &-image {
-    flex: 0.3;
+    display: flex;
+    flex-flow: column;
+    justify-content: center;
+    min-width: 250px;
+
+    &.is-left {
+      padding-right: $space * 1.5;
+    }
+
+    &.is-right {
+      padding-left: $space * 1.5;
+    }
+
+    &-img {
+      width: 100%;
+    }
   }
 
-  &-header {
-    text-align: center;
-  }
-
-  @media screen and (max-width: $screen-xs) {
+  @media screen and (max-width: $screen-sm) {
     width: 100%;
 
     &-body {
@@ -35,8 +68,15 @@
     &-image {
       order: 1;
       align-self: center;
-      width: 130px;
-      max-height: 200px;
+      width: auto;
+      padding: 0;
+      height: 200px;
+      margin-bottom: $space * 1.5;
+
+      &-img {
+        width: auto;
+        height: 100%;
+      }
     }
   }
 }

--- a/common/containers/OnboardModal/components/OnboardSlide.scss
+++ b/common/containers/OnboardModal/components/OnboardSlide.scss
@@ -69,9 +69,13 @@
       order: 1;
       align-self: center;
       width: auto;
-      padding: 0;
-      height: 200px;
-      margin-bottom: $space * 1.5;
+      height: 180px;
+      margin-bottom: $space * 2;
+
+      &.is-left,
+      &.is-right {
+        padding: 0;
+      }
 
       &-img {
         width: auto;

--- a/common/containers/OnboardModal/components/OnboardSlide.tsx
+++ b/common/containers/OnboardModal/components/OnboardSlide.tsx
@@ -3,20 +3,31 @@ import './OnboardSlide.scss';
 
 interface Props {
   header: ReactElement<any> | string;
-  content: ReactElement<any>;
-  slideImage: string;
+  subheader?: ReactElement<any> | string;
+  content: ReactElement<any> | string;
+  image: string;
+  imageSide: 'left' | 'right';
 }
 
 class OnboardSlide extends React.Component<Props> {
   public render() {
+    const { header, subheader, content, image, imageSide } = this.props;
     return (
       <div className="OnboardSlide">
-        <h3 className="OnboardSlide-header">{this.props.header}</h3>
+        <h3 className="OnboardSlide-header">{header}</h3>
+        {subheader && <p className="OnboardSlide-subheader">{subheader}</p>}
         <div className="OnboardSlide-body">
-          <section className="OnboardSlide-content">{this.props.content}</section>
-          <div className="OnboardSlide-image">
-            <img src={this.props.slideImage} />
-          </div>
+          {imageSide === 'left' && (
+            <div className="OnboardSlide-image is-left">
+              <img className="OnboardSlide-image-img" src={image} />
+            </div>
+          )}
+          <section className="OnboardSlide-content">{content}</section>
+          {imageSide === 'right' && (
+            <div className="OnboardSlide-image is-right">
+              <img className="OnboardSlide-image-img" src={image} />
+            </div>
+          )}
         </div>
       </div>
     );

--- a/common/containers/OnboardModal/components/SecureSlideOne.tsx
+++ b/common/containers/OnboardModal/components/SecureSlideOne.tsx
@@ -4,11 +4,7 @@ import OnboardSlide from './OnboardSlide';
 import onboardIconSeven from 'assets/images/onboarding_icon-07.svg';
 
 const SecureSlideOne = () => {
-  const header = (
-    <div>
-      <span>{translate('ONBOARD_secure_1_title')}</span>
-    </div>
-  );
+  const header = translate('ONBOARD_secure_1_title');
 
   const content = (
     <div>
@@ -23,6 +19,8 @@ const SecureSlideOne = () => {
       </ul>
     </div>
   );
-  return <OnboardSlide header={header} content={content} slideImage={onboardIconSeven} />;
+  return (
+    <OnboardSlide header={header} content={content} image={onboardIconSeven} imageSide="right" />
+  );
 };
 export default SecureSlideOne;

--- a/common/containers/OnboardModal/components/SecureSlideThree.tsx
+++ b/common/containers/OnboardModal/components/SecureSlideThree.tsx
@@ -8,12 +8,8 @@ interface Props {
 }
 
 const SecureSlideThree: React.SFC<Props> = ({ site }) => {
-  const header = (
-    <div>
-      <span>{translate('ONBOARD_secure_3_title')}</span>
-      <p>{translate('ONBOARD_secure_3_content__1')}</p>
-    </div>
-  );
+  const header = translate('ONBOARD_secure_3_title');
+  const subheader = translate('ONBOARD_secure_3_content__1');
 
   const content = (
     <div>
@@ -27,6 +23,15 @@ const SecureSlideThree: React.SFC<Props> = ({ site }) => {
       <h5 className="text-center">{translate('ONBOARD_secure_3_content__6')} </h5>
     </div>
   );
-  return <OnboardSlide header={header} content={content} slideImage={onboardIconNine} />;
+
+  return (
+    <OnboardSlide
+      header={header}
+      subheader={subheader}
+      content={content}
+      image={onboardIconNine}
+      imageSide="right"
+    />
+  );
 };
 export default SecureSlideThree;

--- a/common/containers/OnboardModal/components/SecureSlideTwo.tsx
+++ b/common/containers/OnboardModal/components/SecureSlideTwo.tsx
@@ -4,13 +4,8 @@ import OnboardSlide from './OnboardSlide';
 import onboardIconEight from 'assets/images/onboarding_icon-08.svg';
 
 const SecureSlideTwo = () => {
-  const header = (
-    <div>
-      <span>{translate('ONBOARD_secure_2_title')}</span>
-      <p>{translate('ONBOARD_secure_2_content__1')}</p>
-      <br />
-    </div>
-  );
+  const header = translate('ONBOARD_secure_2_title');
+  const subheader = translate('ONBOARD_secure_2_content__1');
 
   const content = (
     <ul>
@@ -20,6 +15,15 @@ const SecureSlideTwo = () => {
       <li>{translate('ONBOARD_secure_2_content__5')}</li>
     </ul>
   );
-  return <OnboardSlide header={header} content={content} slideImage={onboardIconEight} />;
+
+  return (
+    <OnboardSlide
+      header={header}
+      subheader={subheader}
+      content={content}
+      image={onboardIconEight}
+      imageSide="right"
+    />
+  );
 };
 export default SecureSlideTwo;

--- a/common/containers/OnboardModal/components/WelcomeSlide.scss
+++ b/common/containers/OnboardModal/components/WelcomeSlide.scss
@@ -24,8 +24,4 @@
       color: $brand-danger;
     }
   }
-
-  .OnboardSlide-image {
-    width: 300px;
-  }
 }

--- a/common/containers/OnboardModal/components/WelcomeSlide.scss
+++ b/common/containers/OnboardModal/components/WelcomeSlide.scss
@@ -3,10 +3,29 @@
 
 .WelcomeSlide {
   &-alert {
+    display: flex;
+    border-top: 2px solid $brand-danger;
+    padding: $space-sm;
+    font-size: $font-size-base;
+    line-height: 1.5;
     font-weight: 500;
-    color: #e74c3c;
-    border-style: solid;
-    padding: 10px;
-    border-radius: 5px;
+    box-shadow: 0 1px 1px 1px rgba(#000, 0.12);
+    margin-bottom: $space;
+
+    &-icon {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      width: 32px;
+      margin-left: $space * 0.4;
+      margin-right: $space * 0.8;
+      text-align: center;
+      font-size: 32px;
+      color: $brand-danger;
+    }
+  }
+
+  .OnboardSlide-image {
+    width: 300px;
   }
 }

--- a/common/containers/OnboardModal/components/WelcomeSlide.tsx
+++ b/common/containers/OnboardModal/components/WelcomeSlide.tsx
@@ -6,20 +6,26 @@ import onboardIconOne from 'assets/images/onboarding_icon-01.svg';
 import './WelcomeSlide.scss';
 
 const WelcomeSlide = () => {
-  const header = (
-    <div>
-      <span>{translate('ONBOARD_welcome_title')}</span>
-      <br />
-      <small>{translate('ONBOARD_welcome_content__3')}</small>
-    </div>
-  );
+  const header = translate('ONBOARD_welcome_title');
+  const subheader = <small>{translate('ONBOARD_welcome_content__3')}</small>;
+
   const content = (
     <div>
-      <p className="WelcomeSlide-alert">
-        <span>{translate('ONBOARD_welcome_content__1')}</span>
-        <span>{translate('ONBOARD_welcome_content__2')}</span>
-      </p>
-      <p className="WelcomeSlide-alert">{translate('ONBOARD_welcome_content__8')}</p>
+      <div className="WelcomeSlide-alert">
+        <div className="WelcomeSlide-alert-icon">
+          <i className="fa fa-exclamation-triangle" />
+        </div>
+        <span>
+          {translate('ONBOARD_welcome_content__1')}
+          {translate('ONBOARD_welcome_content__2')}
+        </span>
+      </div>
+      <div className="WelcomeSlide-alert">
+        <div className="WelcomeSlide-alert-icon">
+          <i className="fa fa-exclamation-triangle" />
+        </div>
+        <span>{translate('ONBOARD_welcome_content__8')}</span>
+      </div>
       <h5>{translate('ONBOARD_welcome_content__4')}</h5>
       <ul>
         <li>{translate('ONBOARD_welcome_content__5')}</li>
@@ -28,7 +34,16 @@ const WelcomeSlide = () => {
       </ul>
     </div>
   );
-  return <OnboardSlide header={header} content={content} slideImage={onboardIconOne} />;
+
+  return (
+    <OnboardSlide
+      header={header}
+      subheader={subheader}
+      content={content}
+      image={onboardIconOne}
+      imageSide="right"
+    />
+  );
 };
 
 export default WelcomeSlide;

--- a/common/containers/OnboardModal/components/WhyMewSlide.tsx
+++ b/common/containers/OnboardModal/components/WhyMewSlide.tsx
@@ -16,6 +16,6 @@ const WhyMewSlide = () => {
       <li>{translate('ONBOARD_whymew_content__6')}</li>
     </ul>
   );
-  return <OnboardSlide header={header} content={content} slideImage={onboardIconSix} />;
+  return <OnboardSlide header={header} content={content} image={onboardIconSix} imageSide="left" />;
 };
 export default WhyMewSlide;

--- a/common/containers/OnboardModal/components/WhySlide.tsx
+++ b/common/containers/OnboardModal/components/WhySlide.tsx
@@ -24,7 +24,9 @@ const WhySlide = () => {
       </ul>
     </div>
   );
-  return <OnboardSlide header={header} content={content} slideImage={onboardIconFive} />;
+  return (
+    <OnboardSlide header={header} content={content} image={onboardIconFive} imageSide="left" />
+  );
 };
 
 export default WhySlide;

--- a/common/containers/OnboardModal/index.scss
+++ b/common/containers/OnboardModal/index.scss
@@ -10,9 +10,30 @@
       bottom: 3px;
     }
   }
-  @media screen and (max-width: $screen-xs) {
+  @media screen and (max-width: $screen-sm) {
     &-stepper {
-      display: none;
+      // The markup is inline style'd with no classes, so we're doing this in a
+      // horrible, horrible way
+      > div > div > div {
+        // Lines
+        > div {
+          opacity: 0;
+        }
+        // Circle
+        > div:nth-child(1) {
+          opacity: 1;
+          height: 8px !important;
+          width: 8px !important;
+          color: transparent !important;
+        }
+      }
+    }
+  }
+
+  @media screen and (min-width: $screen-sm) {
+    .Modal {
+      max-width: 800px;
+      width: 100%;
     }
   }
 }

--- a/common/containers/OnboardModal/index.tsx
+++ b/common/containers/OnboardModal/index.tsx
@@ -47,6 +47,8 @@ interface Props {
 }
 
 class OnboardModal extends React.Component<Props, State> {
+  private modal: Modal | null = null;
+
   constructor(props) {
     super(props);
     this.state = {
@@ -115,7 +117,7 @@ class OnboardModal extends React.Component<Props, State> {
 
     return (
       <div className="OnboardModal">
-        <Modal isOpen={isOpen} buttons={buttons}>
+        <Modal isOpen={isOpen} buttons={buttons} ref={el => (this.modal = el)}>
           <div className="OnboardModal-stepper">
             <Stepper
               steps={steps}
@@ -163,16 +165,20 @@ class OnboardModal extends React.Component<Props, State> {
 
   private handlePreviousSlide = () => {
     const prevSlideNum = this.props.slideNumber - 1;
-
     localStorage.setItem(ONBOARD_LOCAL_STORAGE_KEY, String(prevSlideNum));
     this.props.decrementSlide();
+    if (this.modal) {
+      this.modal.scrollContentToTop();
+    }
   };
 
   private handleNextSlide = () => {
     const nextSlideNum = this.props.slideNumber + 1;
-
     localStorage.setItem(ONBOARD_LOCAL_STORAGE_KEY, String(nextSlideNum));
     this.props.incrementSlide();
+    if (this.modal) {
+      this.modal.scrollContentToTop();
+    }
   };
 }
 

--- a/common/containers/OnboardModal/index.tsx
+++ b/common/containers/OnboardModal/index.tsx
@@ -76,7 +76,10 @@ class OnboardModal extends React.Component<Props, State> {
 
         const onboardResumeMessage = translate('ONBOARD_resume');
 
-        this.props.showNotification('info', onboardResumeMessage, 30000);
+        // Wait a sec so it doesn't get lost in the page-load
+        setTimeout(() => {
+          this.props.showNotification('info', onboardResumeMessage, 6000);
+        }, 1200);
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -129,8 +129,7 @@
     "db": "nodemon ./db",
     "build": "rimraf dist && webpack --config webpack_config/webpack.prod.js",
     "prebuild": "check-node-version --package",
-    "build:downloadable":
-      "BUILD_DOWNLOADABLE=true rimraf dist && webpack --config webpack_config/webpack.prod.js",
+    "build:downloadable": "BUILD_DOWNLOADABLE=true rimraf dist && webpack --config webpack_config/webpack.prod.js",
     "prebuild:demo": "check-node-version --package",
     "test:coverage": "jest --config=jest_config/jest.config.json --coverage",
     "test": "jest --config=jest_config/jest.config.json",
@@ -146,10 +145,8 @@
     "tscheck": "tsc --noEmit",
     "start": "npm run dev",
     "precommit": "lint-staged",
-    "formatAll":
-      "find ./common/ -name '*.ts*' | xargs prettier --write --config ./.prettierrc --config-precedence file-override",
-    "prettier:diff":
-      "prettier --write --config ./.prettierrc --list-different \"common/**/*.ts\" \"common/**/*.tsx\"",
+    "formatAll": "find ./common/ -name '*.ts*' | xargs prettier --write --config ./.prettierrc --config-precedence file-override",
+    "prettier:diff": "prettier --write --config ./.prettierrc --list-different \"common/**/*.ts\" \"common/**/*.tsx\"",
     "prepush": "npm run tslint && npm run tscheck"
   },
   "lint-staged": {


### PR DESCRIPTION
Onboarding is our first introduction to most users, so it's good to put our best foot forward. This PR revisits #611 and puts a bit of polish on it. The full list of changes are:

* Increases Modal's width to better fit in the content.
* Restore the image side behavior so that images are sometimes on the left, not always on the right
* Allows modal to dynamically size its height.
    * This reduces some awkward whitespace, and makes it so you can't just jam on the "Next" button since it moves a bit, should slow some people down to at least catch the headlines.
* Restore the alert style on the opening modal
* Provide a mobile-friendly progress stepper.
    * This module's markup kind of sucks, so the restyling code is heinous. Sorry.
* Scrolls the user to the top after hitting "Next" or "Previous"
    * On mobile, you would stay scrolled at the bottom. Much nicer feeling now.
* Tons of text and content spacing / color / size adjustments.

## Screenshots (They don't capture all changes)

<img width="851" alt="screen shot 2018-01-12 at 5 37 54 pm" src="https://user-images.githubusercontent.com/649992/34898312-7253034a-f7c0-11e7-8b65-da9fa676e79f.png">


<img width="309" alt="screen shot 2018-01-12 at 5 37 37 pm" src="https://user-images.githubusercontent.com/649992/34898322-7a5b4e58-f7c0-11e7-9bd8-37498021efb3.png">
