### PR TITLE
Remove non-Ethereum networks

### DIFF
--- a/common/config/data.ts
+++ b/common/config/data.ts
@@ -173,24 +173,6 @@ export const NETWORKS: { [key: string]: NetworkConfig } = {
     tokens: require('./tokens/rinkeby.json'),
     contracts: require('./contracts/rinkeby.json'),
     isTestnet: true
-  },
-  EXP: {
-    name: 'EXP',
-    unit: 'EXP',
-    chainId: 2,
-    color: '#673ab7',
-    blockExplorer: makeExplorer('http://www.gander.tech'),
-    tokens: require('./tokens/exp.json'),
-    contracts: require('./contracts/exp.json')
-  },
-  UBQ: {
-    name: 'UBQ',
-    unit: 'UBQ',
-    chainId: 8,
-    color: '#b37aff',
-    blockExplorer: makeExplorer('https://ubiqscan.io/en'),
-    tokens: require('./tokens/ubq.json'),
-    contracts: require('./contracts/ubq.json')
   }
 };
 
@@ -248,18 +230,6 @@ export const NODES: { [key: string]: NodeConfig } = {
     service: 'infura.io',
     lib: new InfuraNode('https://rinkeby.infura.io/mew'),
     estimateGas: false
-  },
-  exp: {
-    network: 'EXP',
-    service: 'Expanse.tech',
-    lib: new RPCNode('https://node.expanse.tech/'),
-    estimateGas: true
-  },
-  ubq: {
-    network: 'UBQ',
-    service: 'ubiqscan.io',
-    lib: new RPCNode('https://pyrus2.ubiqscan.io'),
-    estimateGas: true
   }
 };
 

--- a/common/config/data.ts
+++ b/common/config/data.ts
@@ -174,15 +174,6 @@ export const NETWORKS: { [key: string]: NetworkConfig } = {
     contracts: require('./contracts/rinkeby.json'),
     isTestnet: true
   },
-  RSK: {
-    name: 'RSK',
-    unit: 'RSK',
-    chainId: 31,
-    color: '#ff794f',
-    blockExplorer: makeExplorer('https://explorer.rsk.co'),
-    tokens: require('./tokens/rsk.json'),
-    contracts: require('./contracts/rsk.json')
-  },
   EXP: {
     name: 'EXP',
     unit: 'EXP',

--- a/common/config/data.ts
+++ b/common/config/data.ts
@@ -249,12 +249,6 @@ export const NODES: { [key: string]: NodeConfig } = {
     lib: new InfuraNode('https://rinkeby.infura.io/mew'),
     estimateGas: false
   },
-  rsk: {
-    network: 'RSK',
-    service: 'GK2.sk',
-    lib: new RPCNode('https://rsk-test.gk2.sk/'),
-    estimateGas: true
-  },
   exp: {
     network: 'EXP',
     service: 'Expanse.tech',

--- a/common/config/data.ts
+++ b/common/config/data.ts
@@ -135,15 +135,6 @@ export const NETWORKS: { [key: string]: NetworkConfig } = {
     tokens: require('./tokens/eth.json'),
     contracts: require('./contracts/eth.json')
   },
-  ETC: {
-    name: 'ETC',
-    unit: 'ETC',
-    chainId: 61,
-    color: '#669073',
-    blockExplorer: makeExplorer('https://gastracker.io'),
-    tokens: require('./tokens/etc.json'),
-    contracts: require('./contracts/etc.json')
-  },
   Ropsten: {
     name: 'Ropsten',
     unit: 'ETH',
@@ -193,12 +184,6 @@ export const NODES: { [key: string]: NodeConfig } = {
     network: 'ETH',
     service: 'infura.io',
     lib: new InfuraNode('https://mainnet.infura.io/mew'),
-    estimateGas: false
-  },
-  etc_epool: {
-    network: 'ETC',
-    service: 'Epool.io',
-    lib: new RPCNode('https://mewapi.epool.io'),
     estimateGas: false
   },
   rop_mew: {


### PR DESCRIPTION
As of https://github.com/kvhnuke/etherwallet/issues/1400, RSK node is no longer being maintained. 

It has been removed on V3, and we can follow suite on V4.

While we intend to support UBIQ, EXP, and ETC, the current integration is not robust enough for a release candidate (as seen in issues such as https://github.com/MyEtherWallet/MyEtherWallet/issues/814 and unhandled wallet format accessibility issues).

We also make assumptions about Ethereum as the network in the Payment request tab, and potentially other yet unknown areas.

After a more complete integration and testing we can re-enable these networks.