### PR TITLE
Change network without window refresh

### DIFF
--- a/common/components/ui/UnlockHeader.tsx
+++ b/common/components/ui/UnlockHeader.tsx
@@ -20,7 +20,7 @@ export class UnlockHeader extends React.Component<Props, State> {
   };
 
   public componentDidUpdate(prevProps: Props) {
-    if (this.props.wallet && this.props.wallet !== prevProps.wallet) {
+    if (this.props.wallet !== prevProps.wallet) {
       this.setState({ isExpanded: !this.state.isExpanded });
     }
   }

--- a/common/sagas/config.ts
+++ b/common/sagas/config.ts
@@ -41,6 +41,8 @@ import { IWallet, Web3Wallet } from 'libs/wallet';
 import { getWalletInst } from 'selectors/wallet';
 import { TypeKeys as WalletTypeKeys } from 'actions/wallet/constants';
 import { State as ConfigState, INITIAL_STATE as configInitialState } from 'reducers/config';
+import { resetWallet } from 'actions/wallet';
+import { reset as resetTransaction } from 'actions/transaction';
 
 export const getConfig = (state: AppState): ConfigState => state.config;
 
@@ -173,7 +175,8 @@ export function* handleNodeChangeIntent(action: ChangeNodeIntentAction): SagaIte
 
   // if there's no wallet, do not reload as there's no component state to resync
   if (currentWallet && currentConfig.network !== actionConfig.network) {
-    yield call(reload);
+    yield put(resetWallet());
+    yield put(resetTransaction());
   }
 }
 

--- a/spec/sagas/config.spec.ts
+++ b/spec/sagas/config.spec.ts
@@ -7,7 +7,6 @@ import {
   pollOfflineStatus,
   handlePollOfflineStatus,
   handleNodeChangeIntent,
-  reload,
   unsetWeb3Node,
   unsetWeb3NodeOnWalletEvent,
   equivalentNodeOrDefault

--- a/spec/sagas/config.spec.ts
+++ b/spec/sagas/config.spec.ts
@@ -26,7 +26,8 @@ import { Web3Wallet } from 'libs/wallet';
 import { RPCNode } from 'libs/nodes';
 import { showNotification } from 'actions/notifications';
 import { translateRaw } from 'translations';
-
+import { resetWallet } from 'actions/wallet';
+import { reset as resetTransaction } from 'actions/transaction';
 // init module
 configuredStore.getState();
 
@@ -214,7 +215,8 @@ describe('handleNodeChangeIntent*', () => {
 
   it('should call reload if wallet exists and network is new', () => {
     data.clone2 = data.gen.clone();
-    expect(data.clone2.next(truthyWallet).value).toEqual(call(reload));
+    expect(data.clone2.next(truthyWallet).value).toEqual(put(resetWallet()));
+    expect(data.clone2.next(truthyWallet).value).toEqual(put(resetTransaction()));
     expect(data.clone2.next().done).toEqual(true);
   });
 


### PR DESCRIPTION
Closes https://github.com/MyEtherWallet/MyEtherWallet/issues/642

I believe wallet and transaction state is the only state that needs to get reset when changing networks. I couldn't think of any any other state that would be need to be reset during a network change, but please comment if you think there is.

Branched off of https://github.com/MyEtherWallet/MyEtherWallet/pull/813, will re-base branch after merge.