### PR TITLE
Sign Message v3 compatibility

### DIFF
--- a/common/containers/Tabs/SignAndVerifyMessage/components/SignMessage/SignButton.tsx
+++ b/common/containers/Tabs/SignAndVerifyMessage/components/SignMessage/SignButton.tsx
@@ -26,8 +26,8 @@ export default class SignMessageButton extends React.Component<Props, {}> {
     try {
       const signedMessage: ISignedMessage = {
         address: await wallet.getAddressString(),
-        message,
-        signature: await wallet.signMessage(message),
+        msg: message,
+        sig: await wallet.signMessage(message),
         version: '2'
       };
 

--- a/common/containers/Tabs/SignAndVerifyMessage/components/VerifyMessage/index.tsx
+++ b/common/containers/Tabs/SignAndVerifyMessage/components/VerifyMessage/index.tsx
@@ -20,8 +20,13 @@ const initialState: State = {
   signature: ''
 };
 
-const signaturePlaceholder =
-  '{"address":"0x7cB57B5A97eAbe94205C07890BE4c1aD31E486A8","message":"asdfasdfasdf","signature":"0x4771d78f13ba8abf608457f12471f427ca8f2fb046c1acb3f5969eefdfe452a10c9154136449f595a654b44b3b0163e86dd099beaca83bfd52d64c21da2221bb1c","version":"2"}';
+const signatureExample: ISignedMessage = {
+  address: '0x7cB57B5A97eAbe94205C07890BE4c1aD31E486A8',
+  msg: 'asdfasdfasdf',
+  sig: '0x4771d78f13ba...',
+  version: '2'
+};
+const signaturePlaceholder = JSON.stringify(signatureExample, null, 2);
 
 export class VerifyMessage extends Component<Props, State> {
   public state: State = initialState;
@@ -82,10 +87,10 @@ export class VerifyMessage extends Component<Props, State> {
         throw Error();
       }
 
-      const { address, message } = parsedSignature;
+      const { address, msg } = parsedSignature;
       this.setState({
         verifiedAddress: address,
-        verifiedMessage: message
+        verifiedMessage: msg
       });
       this.props.showNotification('success', translate('SUCCESS_7'));
     } catch (err) {

--- a/common/containers/Tabs/SignAndVerifyMessage/index.tsx
+++ b/common/containers/Tabs/SignAndVerifyMessage/index.tsx
@@ -26,11 +26,11 @@ export default class SignAndVerifyMessage extends Component<RouteComponentProps<
     const tabs = [
       {
         path: 'sign',
-        name: translate('Sign')
+        name: translate('NAV_SignMsg')
       },
       {
         path: 'verify',
-        name: translate('Verify')
+        name: translate('MSG_verify')
       }
     ];
 

--- a/common/libs/signing.ts
+++ b/common/libs/signing.ts
@@ -32,22 +32,22 @@ export function signMessageWithPrivKeyV2(privKey: Buffer, msg: string): string {
 
 export interface ISignedMessage {
   address: string;
-  message: string;
-  signature: string;
+  msg: string;
+  sig: string;
   version: string;
 }
 
 // adapted from:
 // https://github.com/kvhnuke/etherwallet/blob/2a5bc0db1c65906b14d8c33ce9101788c70d3774/app/scripts/controllers/signMsgCtrl.js#L118
-export function verifySignedMessage({ address, message, signature, version }: ISignedMessage) {
-  const sig = new Buffer(stripHexPrefixAndLower(signature), 'hex');
-  if (sig.length !== 65) {
+export function verifySignedMessage({ address, msg, sig, version }: ISignedMessage) {
+  const sigb = new Buffer(stripHexPrefixAndLower(sig), 'hex');
+  if (sigb.length !== 65) {
     return false;
   }
   //TODO: explain what's going on here
-  sig[64] = sig[64] === 0 || sig[64] === 1 ? sig[64] + 27 : sig[64];
-  const hash = version === '2' ? hashPersonalMessage(toBuffer(message)) : sha3(message);
-  const pubKey = ecrecover(hash, sig[64], sig.slice(0, 32), sig.slice(32, 64));
+  sigb[64] = sigb[64] === 0 || sigb[64] === 1 ? sigb[64] + 27 : sigb[64];
+  const hash = version === '2' ? hashPersonalMessage(toBuffer(msg)) : sha3(msg);
+  const pubKey = ecrecover(hash, sigb[64], sigb.slice(0, 32), sigb.slice(32, 64));
 
   return stripHexPrefixAndLower(address) === pubToAddress(pubKey).toString('hex');
 }

--- a/spec/libs/signing.spec.ts
+++ b/spec/libs/signing.spec.ts
@@ -1,0 +1,25 @@
+import { getPrivKeyWallet } from 'libs/wallet';
+import { signMessageWithPrivKeyV2, verifySignedMessage } from 'libs/signing';
+
+describe('lib/signing', () => {
+  const msgToSign = 'Testing your code is great!';
+  const msgToVerify = {
+    address: '0x6980ba0ab378c2ed0efccd7ea6ab84d54615a2de',
+    msg: msgToSign,
+    sig:
+      '0xf08688e9dddbb5e4e0d1fb685ee9f693accb3c9aac84fdcf327423ca4a1c50463ef7aeb70be3221fe028bc752e210a4c377db8090bc4efa5ea7d391049c3a4771c',
+    version: '2'
+  };
+  const msgWallet = getPrivKeyWallet(
+    '05fb863d5da01481d52a629b7d07ee0b50c394503567318f2801cbac1901113b',
+    ''
+  );
+
+  it('signMessageWithPrivKeyV2 properly signs a message', () => {
+    expect(signMessageWithPrivKeyV2(msgWallet.getPrivateKey(), msgToSign)).toEqual(msgToVerify.sig);
+  });
+
+  it('verifySignedMessage properly verifies a signed message', () => {
+    expect(verifySignedMessage(msgToVerify)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Closes #869 

### What This Does

* Renames fields on the signed message object to match V3, so that messages are compatible
* Adds unit tests for signing
* (Subjective) Renames subtabs from "Sign" and "Verify" to "Sign Message" and "Verify Message"
    * OK, I kind of slipped this one in there. Those strings are already translated, and the single words alone had a small click target and looked kind of awkward IMO. Will revert if this is undesirable.

### How To Test

1. Go to /sign-and-verify-message/sign and sign a message
2. Go to /sign-and-verify-message/verify and verify that message
3. Go to https://www.myetherwallet.com/signmsg.html and verify the same message
4. Go to https://www.myetherwallet.com/signmsg.html and sign a new message
5. Go back to /sign-and-verify-message/verify and verify the new message