### PR TITLE
Fix nonce field alignment

### DIFF
--- a/common/components/GasSlider/components/AdvancedGas.scss
+++ b/common/components/GasSlider/components/AdvancedGas.scss
@@ -28,4 +28,10 @@
       margin-top: 0;
     }
   }
+
+  &-nonce {
+    input {
+      margin-top: 0;
+    }
+  }
 }

--- a/common/components/GasSlider/components/AdvancedGas.tsx
+++ b/common/components/GasSlider/components/AdvancedGas.tsx
@@ -61,7 +61,7 @@ class AdvancedGas extends React.Component<Props> {
           <GasLimitField includeLabel={false} onlyIncludeLoader={false} />
         </div>
 
-        <div className="col-md-4 col-sm-12 col-xs-12">
+        <div className="col-md-4 col-sm-12 col-xs-12 AdvancedGas-nonce">
           <NonceField alwaysDisplay={true} />
         </div>
 


### PR DESCRIPTION
Closes #834 

Very small fix, aligns the nonce field with the gas price and gas limit fields in the advanced gas price selector.