### PR TITLE
Remove store2 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "redux-promise-middleware": "4.4.2",
     "redux-saga": "0.16.0",
     "scryptsy": "2.0.0",
-    "store2": "2.5.9",
     "uuid": "3.1.0",
     "wallet-address-validator": "0.1.1",
     "whatwg-fetch": "2.0.3"


### PR DESCRIPTION
We don't use `store2`, but it's listed in `package.json`.