### PR TITLE
Change EOSC Chainid

### DIFF
--- a/src/networks/types/EOSC.js
+++ b/src/networks/types/EOSC.js
@@ -9,7 +9,7 @@ export default {
   homePage: 'https://eos-classic.io/',
   blockExplorerTX: 'https://explorer.eos-classic.io/tx/[[txHash]]',
   blockExplorerAddr: 'https://explorer.eos-classic.io/addr/[[address]]',
-  chainID: 20,
+  chainID: 2018,
   tokens: tokens,
   contracts: contracts,
   ensResolver: '',


### PR DESCRIPTION
EOS Classic is going to swtich the mainnet according to this announcement

https://medium.com/@eoscio/closing-pre-mainnet-and-mainnet-upgrade-announcement-3c0b9ac8912a

Chainid value will be changed to 2018

Other value will remain the same