### PR TITLE
update to trezor-connect@7

### DIFF
--- a/src/wallets/hardware/trezor/index.js
+++ b/src/wallets/hardware/trezor/index.js
@@ -89,7 +89,7 @@ const createWallet = async basePath => {
 };
 createWallet.errorHandler = errorHandler;
 const getRootPubKey = async _path => {
-  const result = await Trezor.ethereumGetPublicKey({ path: _path });
+  const result = await Trezor.getPublicKey({ path: _path });
   if (!result.success) throw new Error(result.payload.error);
   return {
     publicKey: result.payload.publicKey,

--- a/src/wallets/hardware/trezor/index.js
+++ b/src/wallets/hardware/trezor/index.js
@@ -16,6 +16,10 @@ const NEED_PASSWORD = false;
 
 class TrezorWallet {
   constructor() {
+    Trezor.manifest({
+      email: 'info@myetherwallet.com',
+      appUrl: 'https://www.myetherwallet.com'
+    });
     this.identifier = trezorType;
     this.isHardware = true;
     this.needPassword = NEED_PASSWORD;
@@ -85,7 +89,7 @@ const createWallet = async basePath => {
 };
 createWallet.errorHandler = errorHandler;
 const getRootPubKey = async _path => {
-  const result = await Trezor.getPublicKey({ path: _path });
+  const result = await Trezor.ethereumGetPublicKey({ path: _path });
   if (!result.success) throw new Error(result.payload.error);
   return {
     publicKey: result.payload.publicKey,


### PR DESCRIPTION
Hi,
I would like to ask you to update trezor-connect version to 7.0.1
There were some major changes in ethereum protobuf messages in new Trezor firmware (1.8.0/2.1.0) and connect@6 will probably fail on "signTransaction" and "getAddress" methods.
There is also a new, required method "manifest" which needs to be added. We would like you to provide a contact to reach you in case of any required maintenance.
```javascript
Trezor.manifest({
      email: 'info@myetherwallet.com',
      appUrl: 'https://www.myetherwallet.com'
});
```
you can read more here:
https://github.com/trezor/connect/blob/develop/docs/index.md#trezor-connect-manifest


I was trying to install and build this app with multiple configurations (node 8, 9, 10; npm 5, 6) but i'm always failing on:
```javascript
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! canvas@1.6.13 install: `node-gyp rebuild`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the canvas@1.6.13 install script.
```

That's why i'm only providing code but i'm not able to test it properly or even bump this version in package.json because of "gitHooks"