### PR TITLE
Replace Infura endpoint with core.poa.network for Core POA Network

### DIFF
--- a/src/networks/nodes/poa.js
+++ b/src/networks/nodes/poa.js
@@ -1,8 +1,8 @@
 import { POA } from '../types';
 export default {
   type: POA,
-  service: 'infura.io',
-  url: 'https://poa.infura.io',
+  service: 'core.poa.network',
+  url: 'https://core.poa.network',
   port: 443,
   auth: false,
   username: '',


### PR DESCRIPTION
### Bug

- [ ] Updated CHANGELOG.md
- [ ] Is this a user submitted bug?
  - [x] Link to issue:
- [ ] Add PR label

Relates to https://github.com/MyEtherWallet/MyEtherWallet/issues/762

Replace Infura endpoint with core.poa.network for Core POA Network due to [Infura’s POA Core nodes has been disabled on 2/1/19](https://forum.poa.network/t/infuras-poa-core-nodes-to-be-disabled-on-2-1-19/1881)

