### PR TITLE
Chrome 72 compatibility for Secalot.

### DIFF
--- a/src/translations/errors-secalot/en_US.json
+++ b/src/translations/errors-secalot/en_US.json
@@ -1,4 +1,10 @@
 {
   "signFailed": "Sign failed",
-  "notConnected": "Cannot read property 'requestId' of null"
+  "notConnected": "Cannot read property 'requestId' of null",
+  "updateFirmwareToV4": "Please update your Secalot firmware to version 4 or greater.",
+  "walletNotInitialized": "Ethereum wallet on your Secalot is not initialized.",
+  "lastPinTry": "Invalid PIN-code. Be careful, after entering a wrong PIN-code three times in a row, your Secalot Ethereum wallet would be permanently wiped.",
+  "invalidPinCode": "PIN-code not verified.",
+  "invalidPinCodeLength": "Invalid PIN-code length.",
+  "timeout": "Operation timed out."
 }

--- a/src/translations/errors-secalot/es_ES.json
+++ b/src/translations/errors-secalot/es_ES.json
@@ -1,4 +1,10 @@
 {
   "signFailed": "Sign failed",
-  "notConnected": "Cannot read property 'requestId' of null"
+  "notConnected": "Cannot read property 'requestId' of null",
+  "updateFirmwareToV5": "Please update your Secalot firmware to version 5 or greater.",
+  "walletNotInitialized": "Ethereum wallet on your Secalot is not initialized.",
+  "lastPinTry": "Invalid PIN-code. Be careful, after entering a wrong PIN-code three times in a row, your Secalot Ethereum wallet would be permanently wiped.",
+  "invalidPinCode": "PIN-code not verified.",
+  "invalidPinCodeLength": "Invalid PIN-code length.",
+  "timeout": "Operation timed out."
 }

--- a/src/translations/errors-secalot/ja_JP.json
+++ b/src/translations/errors-secalot/ja_JP.json
@@ -1,4 +1,10 @@
 {
   "signFailed": "Sign failed",
-  "notConnected": "Cannot read property 'requestId' of null"
+  "notConnected": "Cannot read property 'requestId' of null",
+  "updateFirmwareToV5": "Please update your Secalot firmware to version 5 or greater.",
+  "walletNotInitialized": "Ethereum wallet on your Secalot is not initialized.",
+  "lastPinTry": "Invalid PIN-code. Be careful, after entering a wrong PIN-code three times in a row, your Secalot Ethereum wallet would be permanently wiped.",
+  "invalidPinCode": "PIN-code not verified.",
+  "invalidPinCodeLength": "Invalid PIN-code length.",
+  "timeout": "Operation timed out."
 }

--- a/src/translations/errors-secalot/ko_KR.json
+++ b/src/translations/errors-secalot/ko_KR.json
@@ -1,4 +1,10 @@
 {
   "signFailed": "Sign failed",
-  "notConnected": "Cannot read property 'requestId' of null"
+  "notConnected": "Cannot read property 'requestId' of null",
+  "updateFirmwareToV5": "Please update your Secalot firmware to version 5 or greater.",
+  "walletNotInitialized": "Ethereum wallet on your Secalot is not initialized.",
+  "lastPinTry": "Invalid PIN-code. Be careful, after entering a wrong PIN-code three times in a row, your Secalot Ethereum wallet would be permanently wiped.",
+  "invalidPinCode": "PIN-code not verified.",
+  "invalidPinCodeLength": "Invalid PIN-code length.",
+  "timeout": "Operation timed out."
 }

--- a/src/translations/errors-secalot/ru_RU.json
+++ b/src/translations/errors-secalot/ru_RU.json
@@ -1,4 +1,10 @@
 {
   "signFailed": "Sign failed",
-  "notConnected": "Cannot read property 'requestId' of null"
+  "notConnected": "Cannot read property 'requestId' of null",
+  "updateFirmwareToV5": "Please update your Secalot firmware to version 5 or greater.",
+  "walletNotInitialized": "Ethereum wallet on your Secalot is not initialized.",
+  "lastPinTry": "Invalid PIN-code. Be careful, after entering a wrong PIN-code three times in a row, your Secalot Ethereum wallet would be permanently wiped.",
+  "invalidPinCode": "PIN-code not verified.",
+  "invalidPinCodeLength": "Invalid PIN-code length.",
+  "timeout": "Operation timed out."
 }

--- a/src/translations/errors-secalot/zh_CN.json
+++ b/src/translations/errors-secalot/zh_CN.json
@@ -1,4 +1,10 @@
 {
   "signFailed": "Sign failed",
-  "notConnected": "Cannot read property 'requestId' of null"
+  "notConnected": "Cannot read property 'requestId' of null",
+  "updateFirmwareToV5": "Please update your Secalot firmware to version 5 or greater.",
+  "walletNotInitialized": "Ethereum wallet on your Secalot is not initialized.",
+  "lastPinTry": "Invalid PIN-code. Be careful, after entering a wrong PIN-code three times in a row, your Secalot Ethereum wallet would be permanently wiped.",
+  "invalidPinCode": "PIN-code not verified.",
+  "invalidPinCodeLength": "Invalid PIN-code length.",
+  "timeout": "Operation timed out."
 }

--- a/src/wallets/hardware/secalot/errorHandler.js
+++ b/src/wallets/hardware/secalot/errorHandler.js
@@ -3,7 +3,16 @@ import Vue from 'vue';
 
 const ERRORS = {
   'Sign failed': 'secalotError.signFailed',
-  "Cannot read property 'requestId' of null": 'secalotError.notConnected'
+  "Cannot read property 'requestId' of null": 'secalotError.notConnected',
+  'Please update your Secalot firmware to version 4 or greater.':
+    'secalotError.updateFirmwareToV4',
+  'Ethereum wallet on your Secalot is not initialized.':
+    'secalotError.walletNotInitialized',
+  'Invalid PIN-code. Be careful, after entering a wrong PIN-code three times in a row, your Secalot Ethereum wallet would be permanently wiped.':
+    'secalotError.lastPinTry',
+  'PIN-code not verified.': 'secalotError.invalidPinCode',
+  'Invalid PIN-code length.': 'secalotError.invalidPinCodeLength',
+  'Operation timed out.': 'secalotError.timeout'
 };
 const WARNING = {};
 
@@ -11,11 +20,11 @@ export default err => {
   const errorValues = Object.keys(ERRORS);
   const warningValues = Object.keys(WARNING);
   const foundError = errorValues.find(item => {
-    return item.includes(err.message);
+    return item.includes(err.message) || item.includes(err);
   });
 
   const foundWarning = warningValues.find(item => {
-    return item.includes(err.message);
+    return item.includes(err.message) || item.includes(err);
   });
 
   if (foundError) {

--- a/src/wallets/hardware/secalot/secalotUsb.js
+++ b/src/wallets/hardware/secalot/secalotUsb.js
@@ -1,8 +1,8 @@
 'use strict';
 import u2f from 'u2f-api';
 
-const SecalotUsb = function(timeoutSeconds) {
-  this.timeoutSeconds = timeoutSeconds;
+const SecalotUsb = function() {
+  this.timeoutSeconds = 120;
 };
 
 SecalotUsb.webSafe64 = base64 =>
@@ -17,10 +17,35 @@ SecalotUsb.normal64 = base64 =>
 
 SecalotUsb.prototype.u2fCallback = function(response, callback) {
   if (typeof response['signatureData'] !== 'undefined') {
-    const data = Buffer.from(
+    let data = Buffer.from(
       SecalotUsb.normal64(response['signatureData']),
       'base64'
     );
+
+    if (data.length < 5 + 2) {
+      callback(
+        undefined,
+        'Please update your Secalot firmware to version 4 or greater.'
+      );
+      return;
+    }
+
+    if (
+      data[0] !== 0x01 ||
+      data[1] !== 0x00 ||
+      data[2] !== 0x00 ||
+      data[3] !== 0x00 ||
+      data[4] !== 0x00
+    ) {
+      callback(
+        undefined,
+        'Please update your Secalot firmware to version 4 or greater.'
+      );
+      return;
+    }
+
+    data = data.slice(5, data.length);
+
     callback(data.toString('hex'));
   } else {
     callback(undefined, response);


### PR DESCRIPTION
### Devop

- [ ] Updated CHANGELOG.md
- [ ] Add PR label

With this change, Secalot will work on all Chrome versions, old and new.
A firmware update to version 4 is required. It can be downloaded from (https://www.secalot.com/downloads/).
If Secalot runs an old firmware, it will be detected and a toast with a suggestion to update will be shown.
I've also updated some Secalot related error messages to be shown as toasts.

