### PR TITLE
Enhance Secalot’s firmware version detection

### DIFF
--- a/src/wallets/hardware/secalot/secalotEth.js
+++ b/src/wallets/hardware/secalot/secalotEth.js
@@ -70,6 +70,14 @@ SecalotEth.prototype.getAddress = function(path, callback) {
     }
   };
 
+  buffer = Buffer.alloc(4);
+  buffer[0] = 0x80;
+  buffer[1] = 0xc4;
+  buffer[2] = 0x00;
+  buffer[3] = 0x00;
+
+  apdus.push(buffer.toString('hex'));
+
   if (typeof this.pinCode !== 'undefined') {
     const pin = Buffer.from(this.pinCode, 'utf8');
     buffer = Buffer.alloc(5 + pin.length);


### PR DESCRIPTION
### Bug

- [ ] Updated CHANGELOG.md
- [ ] Is this a user submitted bug?
  - [ ] Link to issue:
- [ ] Add PR label

In the pull request from yesterday, a check for Secalot's firmware version was added. If the version is less than 4, a pin code check is still performed and then an error message to update to version 4 or later is displayed. With that, if a user enters a wrong pin into the form and presses "Unlock wallet" repeatedly, the wallet will be wiped because of the wrong pin, but the user would not know about that, as the error messages say "incorrect version".
This commit fixes this. 
