### PR TITLE
add ethereum classic path as presented in mew v3  [5.0.8]

### DIFF
--- a/src/wallets/bip44/ledgerPaths.js
+++ b/src/wallets/bip44/ledgerPaths.js
@@ -3,6 +3,7 @@ import {
   ledgerLiveEthereum,
   ledgerEthereumClassic,
   ledgerLiveEthereumClassic,
+  ledgerEthereumClassicVintage,
   ropsten,
   rskMainnet,
   rskTestnet
@@ -12,6 +13,7 @@ export default [
   ledgerLiveEthereum,
   ledgerEthereumClassic,
   ledgerLiveEthereumClassic,
+  ledgerEthereumClassicVintage,
   ropsten,
   rskMainnet,
   rskTestnet

--- a/src/wallets/bip44/paths.js
+++ b/src/wallets/bip44/paths.js
@@ -95,6 +95,10 @@ const ledgerEthereumClassic = {
   path: "m/44'/60'/160720'/0",
   label: 'Ethereum Classic'
 };
+const ledgerEthereumClassicVintage = {
+  path: "m/44'/60'/160720'/0'",
+  label: 'Ethereum Classic MEW Vintage'
+};
 const ledgerLiveEthereumClassic = {
   path: "m/44'/61'",
   label: 'Ethereum Classic - Ledger Live'
@@ -126,6 +130,7 @@ export {
   ledgerLiveEthereum,
   ledgerEthereumClassic,
   ledgerLiveEthereumClassic,
+  ledgerEthereumClassicVintage,
   ropsten,
   singularDTV,
   expanse,


### PR DESCRIPTION
It appears that an ETC path used in [mew vintage](https://github.com/kvhnuke/etherwallet/blob/385cf62a3aa1960f8c43e768e00b250d1e8959fb/app/scripts/controllers/decryptWalletCtrl.js#L29) is slightly different than the path used on the [current mew](https://github.com/MyEtherWallet/MyEtherWallet/blob/b7f815823813de78c98ba8c01ecf8ecd54809ca0/src/wallets/bip44/paths.js#L94).

