### PR TITLE
fix success modal not linking to unlock wallet page [5.0.8]

### DIFF
--- a/src/containers/ConfirmationContainer/components/SuccessModal/SuccessModal.vue
+++ b/src/containers/ConfirmationContainer/components/SuccessModal/SuccessModal.vue
@@ -81,6 +81,9 @@ export default {
   },
   methods: {
     hideModal() {
+      if (this.linkTo !== '/') {
+        this.$router.push({ path: this.linkTo });
+      }
       this.$refs.success.hide();
     },
     getService(parsableUrl) {


### PR DESCRIPTION
### Bug

- [ ] Updated CHANGELOG.md

-fixes user not getting redirected to access-wallet page after creating a json file or mnemonic phrase wallet.