### PR TITLE
TomoChain supports all ETH hd paths

### DIFF
--- a/src/wallets/hardware/ledger/appPaths.js
+++ b/src/wallets/hardware/ledger/appPaths.js
@@ -148,8 +148,8 @@ const appList = [
   },
   {
     network: TOMO,
-    prefixes: ["m/44'/889'"],
-    paths: [tomoChain]
+    prefixes: ["m/44'/889'", "m/44'/60'"],
+    paths: [tomoChain, ledgerEthereum, ledgerLiveEthereum, ethereum]
   },
   {
     network: ROP,


### PR DESCRIPTION
TOMO Holders use both TomoChain Hd path and ETH hd paths