### PR TITLE
An exception is thrown when signing transactions with Secalot

### DIFF
--- a/src/wallets/hardware/secalot/secalotEth.js
+++ b/src/wallets/hardware/secalot/secalotEth.js
@@ -1,5 +1,5 @@
 'use strict';
-import { toBuffer } from 'ethereumjs-util';
+import { toBuffer, stripZeros, rlp } from 'ethereumjs-util';
 
 const SecalotEth = function(comm, pinCode) {
   this.comm = comm;
@@ -151,12 +151,15 @@ SecalotEth.prototype.signTransaction = function(path, eTx, callback) {
     }
   };
 
-  const savedRaw = eTx.raw.slice();
-  eTx.v = chainID;
-  eTx.r = 0;
-  eTx.s = 0;
-  const dataToHash = eTx.serialize();
-  eTx.raw = savedRaw;
+  const items = eTx.raw
+    .slice(0, 6)
+    .concat([
+      toBuffer(chainID),
+      stripZeros(toBuffer(0)),
+      stripZeros(toBuffer(0))
+    ]);
+
+  const dataToHash = rlp.encode(items);
 
   rawData = Buffer.from(dataToHash, 'hex');
 


### PR DESCRIPTION
With MEW v5.0.14, ethereumjs-tx was updated from version 1.3.7 to version 2.0.0. With this update, an exception is unconditionally thrown in SecalotEth.prototype.signTransaction when raw data that is to be signed by the hardware device is constructed. SecalotEth.js, line 155, eTx.v = chainID;. Ethereumjs-tx 2.0.0 introduced a check that when a new "v" is assigned to a transaction, it should be compatible with EIP155 (v=chainID*2 + 35 or + 36). Here raw data to be signed was constructed (v=checkID, s=0, r=0), so this check was failing.

This pull request fixes the issue.

### Bug

- [ ] Updated CHANGELOG.md
- [ ] Is this a user submitted bug?
  - [ ] Link to issue:
- [ ] Add PR label
