### PR TITLE
bitbox-windows: fix u2f timeout for windows users

### DIFF
--- a/src/wallets/hardware/bitbox/digitalBitboxEth.js
+++ b/src/wallets/hardware/bitbox/digitalBitboxEth.js
@@ -12,7 +12,9 @@
 
 import * as Crypto from 'crypto';
 import * as HDKey from 'hdkey';
-const BitBoxSupportedMajorVersion = 7;
+import * as semver from 'semver';
+
+const BitBoxSupportedVersion = '7.0.1';
 const hijackState = {
   // Order must match that in the firmware code
   responseReady: 0,
@@ -166,16 +168,11 @@ class DigitalBitboxEth {
             callback(undefined, 'errorUpgradeFirmware');
             return;
           }
-          const match = /^v(\d+)\.\d+\.\d+/.exec(response.device.version);
-          if (match === null || match.length != 2) {
-            throw 'unexpected reply';
-          }
-          const majorVersion = parseInt(match[1]);
-          if (majorVersion < BitBoxSupportedMajorVersion) {
+          if (semver.lt(response.device.version, BitBoxSupportedVersion)) {
             callback(undefined, 'errorUpgradeFirmware');
             return;
           }
-          if (majorVersion > BitBoxSupportedMajorVersion) {
+          if (semver.gt(response.device.version, BitBoxSupportedVersion)) {
             callback(undefined, 'errorUnsupportedFirmware');
             return;
           }

--- a/src/wallets/hardware/bitbox/digitalBitboxUsb.js
+++ b/src/wallets/hardware/bitbox/digitalBitboxUsb.js
@@ -64,8 +64,16 @@ DigitalBitboxUsb.prototype.exchange = function(msg, callback) {
       version: 'U2F_V2',
       keyHandle: DigitalBitboxUsb.webSafe64(kh.toString('base64'))
     };
+    // Set timeout to 35 seconds for Windows 10 to wait for user confirmation
+    // Keep 3 seconds for other plaforms so that polling is fast enough
+    let timeout;
+    navigator.platform.indexOf('Win') >= 0 &&
+    (navigator.userAgent.indexOf('Windows NT 10.0') != -1 ||
+      navigator.userAgent.indexOf('Windows 10.0') != -1)
+      ? (timeout = 35)
+      : (timeout = 3);
     u2f
-      .sign(key, 3) // 3-second timeout so that polling is fast enough
+      .sign(key, timeout)
       .then(localCallback)
       .catch(err => {
         callback(undefined, err);


### PR DESCRIPTION
Increases timeout to 35 seconds for Windows users instead of polling
every 3 seconds since Windows 10 1903+ waits for user confirmation

### Bug
- Fixes U2F hijack issue for new Windows 10 update 1903 by waiting 35 seconds (to accommodate 30 second firmware timeout) instead of polling every 3 seconds. Windows < 10, MacOS and Linux are not affected, this is a Windows 10 only fix. 
- Windows 10 users pre-1903 update may have to wait up to 25 seconds if they do not sign a transaction within 3 seconds. 
- Fix tested on newest Chrome on Windows 10 1903, Windows 10 1803, Ubuntu 18.04 and MacOS

@SteveMieskoski 
- There is an associated firmware patch release v7.0.1 here: https://github.com/digitalbitbox/mcu/releases/tag/v7.0.1 that can be loaded via the `load_firmware.py` script for testing
- **The firmware will be released to users tomorrow, Sep 17th for updating via the BitBox App**
- The applied fix can be tested on our instance of MEW at: https://digitalbitbox.com/mew/

