### PR TITLE
Update LRC token Information

### DIFF
--- a/src/partners/kyber/config/currenciesETH.js
+++ b/src/partners/kyber/config/currenciesETH.js
@@ -379,7 +379,7 @@ const KyberCurrenciesETH = {
   },
   LRC: {
     symbol: 'LRC',
-    name: 'LoopringCoin',
+    name: 'Loopring',
     decimals: 18,
     contractAddress: '0xbbbbca6a901c926f240b89eacb641d8aec7aeafd'
   },

--- a/src/partners/partnersConfig/EthereumTokens.js
+++ b/src/partners/partnersConfig/EthereumTokens.js
@@ -194,7 +194,7 @@ export default {
   },
   LRC: {
     symbol: 'LRC',
-    name: 'LoopringCoin',
+    name: 'Loopring',
     decimals: 18,
     contractAddress: '0xbbbbca6a901c926f240b89eacb641d8aec7aeafd'
   },


### PR DESCRIPTION
The LRC token was upgraded to a new version on May 7th, 2019. The new token's address is 0xBBbbCA6A901c926F240b89EacB641d8Aec7AEafD (lrctoken.eth). For more information please see: https://medium.com/loopring-protocol/lrc-token-upgraded-a26ee6f87b84


### Feature

- [ ] Updated CHANGELOG.md
- [x] Is this a user-submitted feature request?
- [ ] Link to issue:
- [ ] Add test cases or procedure
- [ ] Add PR label



