### PR TITLE
fix config property paths in wallet worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ### Release v5.2.1
 
+### Bug
+
+- Correct wrong property path for config object in wallet.worker.js [#1604](https://github.com/MyEtherWallet/MyEtherWallet/pull/1604)
+
+### Release v5.2.1
+
 ### Feature
 
 - Ambrpay Integration[#1441](https://github.com/MyEtherWallet/MyEtherWallet/pull/1441)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### Release v5.2.1
+### Release v5.2.1-hotfix.1
 
 ### Bug
 

--- a/src/workers/wallet.worker.js
+++ b/src/workers/wallet.worker.js
@@ -39,8 +39,8 @@ const createJsonWalletFromPrivateKey = (privateKey, password) => {
   const createdWallet = {};
   const wallet = new Wallet.fromPrivateKey(Buffer.from(privateKey, 'hex'));
   createdWallet.walletJson = wallet.toV3(password, {
-    kdf: Configs.wallet.kdf,
-    n: Configs.wallet.n
+    kdf: Configs.kdf,
+    n: Configs.n
   });
   createdWallet.name = wallet.getV3Filename();
   return createdWallet;
@@ -50,8 +50,8 @@ const create = password => {
   const createdWallet = {};
   const wallet = new Wallet.generate();
   createdWallet.walletJson = wallet.toV3(password, {
-    kdf: Configs.wallet.kdf,
-    n: Configs.wallet.n
+    kdf: Configs.kdf,
+    n: Configs.n
   });
   createdWallet.name = wallet.getV3Filename();
   return createdWallet;


### PR DESCRIPTION
### Bug

- [x] Updated CHANGELOG.md
- [x] Add PR label

- correct wrong property path for config object in wallet.worker.js
