### PR TITLE
Change EtherCore explorer address

### DIFF
--- a/src/networks/types/ERE.js
+++ b/src/networks/types/ERE.js
@@ -7,7 +7,7 @@ export default {
   name_long: 'EtherCore',
   homePage: 'https://ethercore.org',
   blockExplorerTX: 'https://explorer.ethercore.org/tx/[[txHash]]',
-  blockExplorerAddr: 'https://explorer.ethercore.org/addr/[[address]]',
+  blockExplorerAddr: 'https://explorer.ethercore.org/address/[[address]]',
   chainID: 466,
   tokens: tokens,
   contracts: contracts,


### PR DESCRIPTION
Our explorer https://explorer.ethercore.org address route has been changed.

Please have a look at https://github.com/MyEtherWallet/ethereum-lists/pull/1398 also.