### PR TITLE
bitbox02-api 0.5.0 [v5]

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "bc-vault-js": "2.0.3",
     "bignumber.js": "9.0.0",
     "bip39": "3.0.2",
-    "bitbox02-api": "0.4.1",
+    "bitbox02-api": "0.5.0",
     "bootstrap-vue": "2.14.0",
     "codecov": "3.6.5",
     "copy-webpack-plugin": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "bignumber.js": "9.0.0",
     "bip39": "3.0.2",
     "bitbox02-api": "0.4.1",
-    "bootstrap-vue": "2.13.1",
+    "bootstrap-vue": "2.14.0",
     "codecov": "3.6.5",
     "copy-webpack-plugin": "5.1.1",
     "detectrtc": "1.4.0",


### PR DESCRIPTION
Hi

This is a bump to the newest `bitbox02-api` dep. This will ensure that a newer bitbox02 firmware is compatible with MEW.

In a separate commit, I also bumped `bootstrap-vue`, as the `npm build` forced me to.

Thanks.