### PR TITLE
Fix missing guard

### DIFF
--- a/src/builds/mewcx/cxHelpers/cxWeb3.js
+++ b/src/builds/mewcx/cxHelpers/cxWeb3.js
@@ -7,7 +7,7 @@ if (
   (window.hasOwnProperty('ethereum') && window.ethereum)
 ) {
   if (
-    (window.web3 && window.web3.currentProvider.isMew) ||
+    (window.web3 && window.web3.currentProvider && window.web3.currentProvider.isMew) ||
     (window.ethereum && window.ethereum.isMew)
   ) {
     window.dispatchEvent(event);


### PR DESCRIPTION
Hi, I'm not an user of your extension, but one of the users of my webapp, monitored by Sentry, had your Chrome Extension throwing an error, which, because you miss one small guard, has been catched by my Error watching process (I'm not really sure if it's a good thing that the code running in a Chrome Extension, throwing an error, will be catch by the visited website code, but I think it's more something to address to the Google Chrome team).

Anyway, while reading the report from Sentry then your code to see what it was, I saw that the error is a simple guard missing... so, as I'm a nice guy, I make you a fast PR to fix that.

Have a nice week-end!
