### PR TITLE
Hide switch address if logged in via WalletConnect

### DIFF
--- a/src/layouts/InterfaceLayout/components/InterfaceAddress/InterfaceAddress.vue
+++ b/src/layouts/InterfaceLayout/components/InterfaceAddress/InterfaceAddress.vue
@@ -107,7 +107,8 @@ import {
   KEYSTORE,
   PRIV_KEY,
   MEW_CONNECT,
-  WEB3_WALLET
+  WEB3_WALLET,
+  WALLET_CONNECT
 } from '@/wallets/bip44/walletTypes';
 
 export default {
@@ -150,7 +151,8 @@ export default {
         this.account.identifier !== KEYSTORE &&
         this.account.identifier !== PRIV_KEY &&
         this.account.identifier !== MEW_CONNECT &&
-        this.account.identifier !== WEB3_WALLET
+        this.account.identifier !== WEB3_WALLET &&
+        this.account.identifier !== WALLET_CONNECT
       ) {
         this.hasMultipleAddr = true;
       } else {


### PR DESCRIPTION
Because clicking on it causes the error "Wallet type wallet_connect can't switch addresses"

### Bug

* \[ ] Updated CHANGELOG.md
* \[ ] Is this a user submitted bug?
  * \[ ] Link to issue:
* \[ ] Add PR label
* \[x] No hard-coded strings