### PR TITLE
fix: format balance string in address

### DIFF
--- a/src/modules/access-wallet/software/components/AccessWalletMnemonic.vue
+++ b/src/modules/access-wallet/software/components/AccessWalletMnemonic.vue
@@ -392,7 +392,7 @@ import { checkCustomPath } from '../handlers/pathHelper';
 import AppBtnRow from '@/core/components/AppBtnRow';
 import { getEthBalance } from '@/apollo/queries/wallets/wallets.graphql';
 import { fromWei } from 'web3-utils';
-
+import { formatFloatingPointValue } from '@/core/helpers/numberFormatHelper';
 const MAX_ADDRESSES = 5;
 
 export default {
@@ -443,9 +443,10 @@ export default {
             /**
              * Sets the balance of the account of accountAddress
              */
-            this.accounts[this.onAccountIndex].balance = fromWei(
-              data.getEthBalance.balance
-            );
+            this.accounts[this.onAccountIndex].balance =
+              formatFloatingPointValue(
+                fromWei(data.getEthBalance.balance)
+              ).value;
             /**
              * Find the next index and set the address of it to accountAddress
              */


### PR DESCRIPTION
<!-- NOTE: Remove the parts that's not relevant -->

This fixes oveflow of the balance string in the access mnemonic phrase table