### PR TITLE
bitbox01: hotfix on v5: make BitBox01 work with WebHID, drop U2F-hijack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4874,19 +4874,6 @@
             "readable-stream": "~1.0.26"
           }
         },
-        "handlebars": {
-          "version": "4.7.7",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
-          "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.5",
-            "neo-async": "^2.6.0",
-            "source-map": "^0.6.1",
-            "uglify-js": "^3.1.4",
-            "wordwrap": "^1.0.0"
-          }
-        },
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -4894,9 +4881,9 @@
           "dev": true
         },
         "marked": {
-          "version": "0.6.3",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.3.tgz",
-          "integrity": "sha512-Fqa7eq+UaxfMriqzYLayfqAE40WN03jf+zHjT18/uXNuzjq3TY0XTbrAoPeqSJrAmPz11VuUA+kBPYOhHt9oOQ==",
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.1.tgz",
+          "integrity": "sha512-+H0L3ibcWhAZE02SKMqmvYsErLo4EAVJxu5h3bHBBDvvjeWXtl92rGUSBYHL2++5Y+RSNgl8dYOAXcYe7lp1fA==",
           "dev": true
         },
         "readable-stream": {
@@ -4911,29 +4898,10 @@
             "string_decoder": "~0.10.x"
           }
         },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
         "string_decoder": {
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        },
-        "uglify-js": {
-          "version": "3.13.6",
-          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.6.tgz",
-          "integrity": "sha512-rRprLwl8RVaS+Qvx3Wh5hPfPBn9++G6xkGlUupya0s5aDmNjI7z3lnRLB3u7sN4OmbB0pWgzhM9BEJyiWAwtAA==",
-          "dev": true,
-          "optional": true
-        },
-        "wordwrap": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
           "dev": true
         }
       }
@@ -5507,9 +5475,9 @@
           },
           "dependencies": {
             "y18n": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-              "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+              "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
               "dev": true
             }
           }
@@ -8382,9 +8350,9 @@
           },
           "dependencies": {
             "acorn": {
-              "version": "6.4.2",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
-              "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
+              "version": "7.4.1",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+              "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
               "dev": true
             }
           }
@@ -11394,9 +11362,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.4.2",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
-          "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
           "dev": true
         },
         "acorn-walk": {
@@ -11445,17 +11413,6 @@
           "version": "1.0.30001133",
           "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001133.tgz",
           "integrity": "sha512-s3XAUFaC/ntDb1O3lcw9K8MPeOW7KO3z9+GzAoBxfz1B0VdacXPMKgFUtG4KIsgmnbexmi013s9miVu4h+qMHw=="
-        },
-        "chalk": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
         },
         "cliui": {
           "version": "6.0.0",
@@ -11599,16 +11556,6 @@
           "requires": {
             "merge-stream": "^2.0.0",
             "supports-color": "^7.0.0"
-          }
-        },
-        "json5": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
-          "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minimist": "^1.2.5"
           }
         },
         "jsonfile": {
@@ -11858,32 +11805,6 @@
                 "@types/json-schema": "^7.0.5",
                 "ajv": "^6.12.4",
                 "ajv-keywords": "^3.5.2"
-              }
-            }
-          }
-        },
-        "vue-loader-v16": {
-          "version": "npm:vue-loader@16.3.0",
-          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.3.0.tgz",
-          "integrity": "sha512-UDgni/tUVSdwHuQo+vuBmEgamWx88SuSlEb5fgdvHrlJSPB9qMBRF6W7bfPWSqDns425Gt1wxAUif+f+h/rWjg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "chalk": "^4.1.0",
-            "hash-sum": "^2.0.0",
-            "loader-utils": "^2.0.0"
-          },
-          "dependencies": {
-            "loader-utils": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-              "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "big.js": "^5.2.2",
-                "emojis-list": "^3.0.0",
-                "json5": "^2.1.2"
               }
             }
           }
@@ -12502,6 +12423,11 @@
         "mime-types": "~2.1.24",
         "negotiator": "0.6.2"
       }
+    },
+    "acorn": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg=="
     },
     "acorn-globals": {
       "version": "4.3.4",
@@ -15362,12 +15288,6 @@
           "requires": {
             "minimist": "^1.2.5"
           }
-        },
-        "y18n": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-          "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
-          "dev": true
         }
       }
     },
@@ -16100,9 +16020,9 @@
           },
           "dependencies": {
             "y18n": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-              "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+              "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
               "dev": true
             }
           }
@@ -17698,9 +17618,9 @@
           },
           "dependencies": {
             "y18n": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-              "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+              "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
               "dev": true
             }
           }
@@ -19203,11 +19123,6 @@
         "secp256k1": "3.7.1"
       },
       "dependencies": {
-        "acorn": {
-          "version": "6.4.2",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
-          "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ=="
-        },
         "bn.js": {
           "version": "4.12.0",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
@@ -20273,9 +20188,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.4.2",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
-          "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
           "dev": true
         }
       }
@@ -23745,6 +23660,26 @@
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
       "dev": true
     },
+    "handlebars": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.0.tgz",
+      "integrity": "sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==",
+      "dev": true,
+      "requires": {
+        "async": "^2.5.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
+      }
+    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -26213,9 +26148,9 @@
           },
           "dependencies": {
             "y18n": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-              "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+              "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
               "dev": true
             }
           }
@@ -26592,9 +26527,9 @@
           },
           "dependencies": {
             "acorn": {
-              "version": "6.4.2",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
-              "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
+              "version": "7.4.1",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+              "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
               "dev": true
             }
           }
@@ -27264,9 +27199,9 @@
           },
           "dependencies": {
             "y18n": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-              "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+              "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
               "dev": true
             }
           }
@@ -27826,9 +27761,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.4.2",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
-          "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
           "dev": true
         },
         "ajv": {
@@ -30792,9 +30727,9 @@
           },
           "dependencies": {
             "y18n": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-              "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+              "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
               "dev": true
             }
           }
@@ -34671,9 +34606,9 @@
           },
           "dependencies": {
             "y18n": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-              "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ=="
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+              "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="
             }
           }
         },
@@ -36061,9 +35996,9 @@
           },
           "dependencies": {
             "y18n": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-              "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+              "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
               "dev": true
             }
           }
@@ -39919,6 +39854,13 @@
         }
       }
     },
+    "uglify-js": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.14.0.tgz",
+      "integrity": "sha512-R/tiGB1ZXp2BC+TkRGLwj8xUZgdfT2f4UZEgX6aVjJ5uttPrr4fYmwTWDGqVnBCLbOXRMY6nr/BTbwCtVfps0g==",
+      "dev": true,
+      "optional": true
+    },
     "uid-number": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
@@ -40878,9 +40820,9 @@
           },
           "dependencies": {
             "acorn": {
-              "version": "6.4.2",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
-              "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
+              "version": "7.4.1",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+              "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
               "dev": true
             }
           }
@@ -40985,6 +40927,83 @@
           "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
           "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
           "dev": true
+        }
+      }
+    },
+    "vue-loader-v16": {
+      "version": "npm:vue-loader@16.3.3",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.3.3.tgz",
+      "integrity": "sha512-/1GzCuQ6MRORbC+leKTKoTGtpQt60bYe0gDGEextSteA2OM+v201FPha5jzmjQzVhRcwieZeUvezAtG5a/e5cw==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "hash-sum": "^2.0.0",
+        "loader-utils": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "json5": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+          "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         }
       }
     },
@@ -43583,9 +43602,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.4.2",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
-          "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
           "dev": true
         },
         "acorn-walk": {
@@ -44171,9 +44190,9 @@
           },
           "dependencies": {
             "y18n": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-              "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+              "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
               "dev": true
             }
           }
@@ -44942,6 +44961,12 @@
         "cuint": "^0.2.2"
       }
     },
+    "y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true
+    },
     "yaeti": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
@@ -45253,9 +45278,9 @@
           },
           "dependencies": {
             "y18n": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-              "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
+              "version": "4.0.3",
+              "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+              "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
               "dev": true
             }
           }

--- a/src/layouts/InterfaceLayout/InterfaceLayout-mobile.scss
+++ b/src/layouts/InterfaceLayout/InterfaceLayout-mobile.scss
@@ -13,7 +13,7 @@
   }
 
   .wrap {
-    padding-top: 0px !important;
+    padding-top: 0 !important;
     .contents {
       background-color: $light-grey-2;
       padding: 10px;

--- a/src/layouts/InterfaceLayout/InterfaceLayout-tablet.scss
+++ b/src/layouts/InterfaceLayout/InterfaceLayout-tablet.scss
@@ -13,7 +13,7 @@
   }
 
   .wrap {
-    padding-top: 0px !important;
+    padding-top: 0 !important;
     .contents {
       background-color: $light-grey-2;
       padding: 10px;

--- a/src/wallets/hardware/bitbox/digitalBitboxUsb.js
+++ b/src/wallets/hardware/bitbox/digitalBitboxUsb.js
@@ -6,76 +6,81 @@
 
 'use strict';
 
-import u2f from 'u2f-api';
-
 const DigitalBitboxUsb = function () {};
 
-// Convert from normal to web-safe, strip trailing "="s
-DigitalBitboxUsb.webSafe64 = function (base64) {
-  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-};
+let _callback = null;
+let _hidDevice = null;
+let _readBuffer = null;
+let _dataLen = null;
 
-// Convert from web-safe to normal, add trailing "="s
-DigitalBitboxUsb.normal64 = function (base64) {
-  return (
-    // eslint-disable-next-line
-    base64.replace(/\-/g, '+').replace(/_/g, '/') +
-    '=='.substring(0, (3 * base64.length) % 4)
-  );
-};
-
-DigitalBitboxUsb.prototype.u2fCallback = function (response, callback) {
-  if ('signatureData' in response) {
-    const data = new Buffer(
-      DigitalBitboxUsb.normal64(response.signatureData),
-      'base64'
-    );
-    callback(data.slice(5));
-  } else {
-    callback(undefined, response);
+async function connectWebHID() {
+  if (_hidDevice !== null) {
+    return;
   }
-};
+  const vendorID = 0x03eb;
+  const productID = 0x2402;
+  _hidDevice = (
+    await navigator.hid.requestDevice({ filters: [{ vendorID, productID }] })
+  )[0];
+  await _hidDevice.open();
+  _hidDevice.addEventListener('inputreport', event => {
+    if (!_callback) {
+      return;
+    }
+    const data = Buffer.from(event.data.buffer);
+    if (_readBuffer === null) {
+      if (data.length < 7) {
+        throw 'unexpected response';
+      }
+      _dataLen = data[5] * 256 + data[6];
+      _readBuffer = data.slice(7);
+    } else {
+      if (data.length < 5) {
+        throw 'unexpected response';
+      }
+      _readBuffer = Buffer.concat([_readBuffer, data.slice(5)]);
+    }
+    if (_readBuffer.length >= _dataLen) {
+      const x = _readBuffer.slice(0, _dataLen);
+      const cb = _callback;
+      _callback = null;
+      _readBuffer = null;
+      _dataLen = null;
+      cb(x);
+    }
+  });
+}
 
+const cid = 0xff000000;
+const cmd = 0x80 + 0x40 + 0x01;
 DigitalBitboxUsb.prototype.exchange = function (msg, callback) {
+  _callback = callback;
   msg = Buffer.from(msg, 'ascii');
-  const kh_max_len = 128 - 2; // Subtract 2 bytes for `index` and `total` header
-  // Challenge is needed for U2F but unused in the hijack procedure
-  const challenge = new Buffer(
-    'dbdbdbdbdbdbdbdbdbdbdbdbdbdbdbdbdbdbdbdbdbdbdbdbdbdbdbdbdbdbdbdb',
-    'hex'
-  );
-  const total = Math.ceil(msg.length / kh_max_len);
-  const self = this;
-  const localCallback = function (result) {
-    self.u2fCallback(result, callback);
-  };
-  for (let index = 0; index < total; index++) {
-    const kh = Buffer.concat([
-      Buffer.from([total]),
-      Buffer.from([index]),
-      msg.slice(index * kh_max_len, (index + 1) * kh_max_len)
-    ]);
-    const key = {
-      appId: location.origin,
-      challenge: DigitalBitboxUsb.webSafe64(challenge.toString('base64')),
-      version: 'U2F_V2',
-      keyHandle: DigitalBitboxUsb.webSafe64(kh.toString('base64'))
-    };
-    // Set timeout to 35 seconds for Windows 10 to wait for user confirmation
-    // Keep 3 seconds for other plaforms so that polling is fast enough
-    let timeout;
-    navigator.platform.indexOf('Win') >= 0 &&
-    (navigator.userAgent.indexOf('Windows NT 10.0') != -1 ||
-      navigator.userAgent.indexOf('Windows 10.0') != -1)
-      ? (timeout = 35)
-      : (timeout = 3);
-    u2f
-      .sign(key, timeout)
-      .then(localCallback)
-      .catch(err => {
-        callback(undefined, err);
-      });
-  }
+  connectWebHID().then(() => {
+    const kh_max_len = 64;
+    let index = 0;
+    while (msg.length > 0) {
+      const tmp = Buffer.alloc(4);
+      tmp.writeUInt32BE(cid);
+      let header = null;
+      if (index === 0) {
+        const tmp2 = Buffer.alloc(2);
+        tmp2.writeUInt16BE(msg.length & 0xffff);
+        header = Buffer.concat([tmp, Buffer.from([cmd]), tmp2]);
+      } else {
+        const seq = index - 1;
+        header = Buffer.concat([tmp, Buffer.from([seq])]);
+      }
+      const chunk = msg.slice(0, kh_max_len - header.length);
+      msg = msg.slice(kh_max_len - header.length);
+      let kh = Buffer.concat([header, chunk]);
+      if (kh.length < kh_max_len) {
+        kh = Buffer.concat([kh, Buffer.alloc(kh_max_len - kh.length, 0xee)]);
+      }
+      _hidDevice.sendReport(0, Uint8Array.from(kh));
+      index++;
+    }
+  });
 };
 
 export default DigitalBitboxUsb;


### PR DESCRIPTION
BitBox01 is currently not functional on v6.0.3 and it does not seem
trivial to make it work.

The previous version is hosted at https://v5.myetherwallet.com/, but
there, BitBox01 support also broken.

This patch is a hot-fix for the v5 deployment that makes the BitBox01
integration functional again, using WebHID (Chrome only).

This will help BitBox01 users migrate their coins to a new wallet.

