### PR TITLE
fix: 🐛 only allow numbers on gas price input

### DIFF
--- a/changelog/fix-3436.md
+++ b/changelog/fix-3436.md
@@ -1,0 +1,1 @@
+only allow numbers in gas price input

--- a/package-lock.json
+++ b/package-lock.json
@@ -24344,6 +24344,24 @@
           "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
           "optional": true
         },
+        "encoding": {
+          "version": "0.1.13",
+          "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+          "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+          "requires": {
+            "iconv-lite": "^0.6.2"
+          },
+          "dependencies": {
+            "iconv-lite": {
+              "version": "0.6.2",
+              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+              "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+              "requires": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+              }
+            }
+          }
+        },
         "encoding-down": {
           "version": "5.0.4",
           "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-5.0.4.tgz",
@@ -26125,13 +26143,10 @@
             "node-fetch": "~1.7.1"
           },
           "dependencies": {
-            "iconv-lite": {
-              "version": "0.6.3",
-              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-              "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-              "requires": {
-                "safer-buffer": ">= 2.1.2 < 3.0.0"
-              }
+            "is-stream": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+              "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
             },
             "node-fetch": {
               "version": "1.7.3",
@@ -26140,16 +26155,6 @@
               "requires": {
                 "encoding": "^0.1.11",
                 "is-stream": "^1.0.1"
-              },
-              "dependencies": {
-                "encoding": {
-                  "version": "0.1.13",
-                  "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-                  "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-                  "requires": {
-                    "iconv-lite": "^0.6.2"
-                  }
-                }
               }
             }
           }

--- a/src/modules/settings/components/SettingsGasPrice.vue
+++ b/src/modules/settings/components/SettingsGasPrice.vue
@@ -53,6 +53,7 @@
           placeholder=" "
           right-label="Gwei"
           class="mr-0 mr-sm-3"
+          type="number"
         />
         <mew-button
           :title="customBtn.text"


### PR DESCRIPTION
### Bug

* \[x] Added entry to ./changelog
* \[x] Add PR label
