### PR TITLE
bitbox01: fix WebHID filters to restore access in Chrome 97+

### DIFF
--- a/src/wallets/hardware/bitbox/digitalBitboxUsb.js
+++ b/src/wallets/hardware/bitbox/digitalBitboxUsb.js
@@ -17,10 +17,10 @@ async function connectWebHID() {
   if (_hidDevice !== null) {
     return;
   }
-  const vendorID = 0x03eb;
-  const productID = 0x2402;
+  const vendorId = 0x03eb;
+  const productId = 0x2402;
   _hidDevice = (
-    await navigator.hid.requestDevice({ filters: [{ vendorID, productID }] })
+    await navigator.hid.requestDevice({ filters: [{ vendorId, productId }] })
   )[0];
   await _hidDevice.open();
   _hidDevice.addEventListener('inputreport', event => {


### PR DESCRIPTION
WebHID access to the BitBox01 stopped working as of Chrome version
97 due to incorrect vendor/product filter names. See also:
digitalbitbox/bitbox02-api-js#62

The same issue was fixed for the BitBox02 previously here:
https://github.com/MyEtherWallet/MyEtherWallet/issues/3618
