### PR TITLE
fix: remove empty token icon slot from ens reverse lookup dropdown se…

### DIFF
--- a/changelog/fix-4126.md
+++ b/changelog/fix-4126.md
@@ -1,0 +1,1 @@
+* remove empty token icon slot from ens reverse lookup dropdown selector

--- a/src/dapps/ens-manager-dapp/components/reverse/EnsReverseLookup.vue
+++ b/src/dapps/ens-manager-dapp/components/reverse/EnsReverseLookup.vue
@@ -24,6 +24,8 @@
           :value="selectedDomain"
           filter-placeholder="Search for Domain"
           :items="domainListItems"
+          normal-dropdown
+          no-capitalize
           @input="setDomain"
         >
         </mew-select>


### PR DESCRIPTION
### Fix

* \[x] Added entry to ./changelog
* \[x] Add PR label
   - remove empty token icon slot from ens reverse lookup dropdown selector
![Screenshot from 2022-08-22 10-56-37](https://user-images.githubusercontent.com/9893774/185987564-d7f4275d-3100-4db0-96e2-a2ae42a9b187.png)
