### PR TITLE
fix: add tooltip to show full address on address table

### DIFF
--- a/changelog/fix-4368.md
+++ b/changelog/fix-4368.md
@@ -1,0 +1,1 @@
+* add tooltip to show full address on settings address table

--- a/src/modules/settings/components/SettingsAddressTable.vue
+++ b/src/modules/settings/components/SettingsAddressTable.vue
@@ -31,7 +31,18 @@
                   width="20px"
                   :address="td.address"
                 />
-                <mew-transform-hash :hash="td.address" class="mr-2 mew-label" />
+                <mew-tooltip
+                  :text="td.address"
+                  hide-icon
+                  class="address-container"
+                >
+                  <template #contentSlot>
+                    <mew-transform-hash
+                      :hash="td.address"
+                      class="mr-2 mew-label"
+                    />
+                  </template>
+                </mew-tooltip>
                 <app-copy-btn :copy-value="td.address">
                   <v-btn x-small icon color="greenPrimary">
                     <img
@@ -210,4 +221,8 @@ export default {
 };
 </script>
 
-<style lang="scss" scoped></style>
+<style lang="scss" scoped>
+.address-container {
+  max-width: 210px;
+}
+</style>


### PR DESCRIPTION
### Fix

* \[x] Added entry to ./changelog
* \[x] Add PR label
   - add tooltip to show full address on settings address table 
![Screenshot from 2022-11-17 22-34-15](https://user-images.githubusercontent.com/9893774/202636799-b0ad2271-4f31-42f7-bda8-ab3efd0060ac.png)
