### PR TITLE
fix: 🐛 return to checksum address value

### DIFF
--- a/changelog/fix-4541.md
+++ b/changelog/fix-4541.md
@@ -1,0 +1,1 @@
+fix to checksum return value

--- a/src/core/helpers/addressUtils.js
+++ b/src/core/helpers/addressUtils.js
@@ -33,7 +33,7 @@ const toChecksumAddress = address => {
   const chainId = store.getters['global/network'].type.chainID;
   // Use EIP-1191 Address Checksum if its Rootstock network
   if (chainId === ROOTSTOCK.chainID) {
-    toChecksumAddr(address, chainId);
+    return toChecksumAddr(address, chainId);
   }
 
   return web3.utils.toChecksumAddress(address);


### PR DESCRIPTION
### Fix

* \[X] Added entry to ./changelog
* \[ ] Add PR label

### Description
The `return` statement is missing on `toChecksumAdd` call due to which address resolution is not working. Just fixed this bug by adding `return`. 

Very small pull request. Need to merge @gamalielhere 