### PR TITLE
FIX/RNS DAPP: Use web3 provider to derive signer in RNS manager dapp

### DIFF
--- a/changelog/fix-4587.md
+++ b/changelog/fix-4587.md
@@ -1,0 +1,1 @@
+fix web3 provider to derive signer in rns manager dapp

--- a/src/dapps/rns-manager-dapp/TheRNSManagerLayout.vue
+++ b/src/dapps/rns-manager-dapp/TheRNSManagerLayout.vue
@@ -205,11 +205,12 @@ export default {
   },
   methods: {
     setup() {
-      const provider = new ethers.providers.Web3Provider(
+      const ethersProvider = new ethers.providers.Web3Provider(
         this.web3.currentProvider
       );
-      this.nameHandler = new RNSManager(this.instance, provider);
-      this.reverseHandler = new ReverseRegister(this.instance, provider);
+      const ethersSigner = ethersProvider.getSigner();
+      this.nameHandler = new RNSManager(ethersSigner);
+      this.reverseHandler = new ReverseRegister(ethersSigner);
     },
     async findDomain() {
       try {
@@ -285,7 +286,7 @@ export default {
         label,
         address,
         this.regSecret,
-        BigNumber(duration),
+        BigNumber.from(duration),
         this.domainPrice
       );
 

--- a/src/dapps/rns-manager-dapp/handlers/handlerRNSManager.js
+++ b/src/dapps/rns-manager-dapp/handlers/handlerRNSManager.js
@@ -1,4 +1,4 @@
-import { ethers, Wallet, BigNumber, Contract, utils, constants } from 'ethers';
+import { ethers, BigNumber, Contract, utils, constants } from 'ethers';
 import { RSKRegistrar } from './helpers/rskRegistrar';
 
 // Reverse Lookup
@@ -22,8 +22,7 @@ const fifsAddrRegistrarAddress = '0xd9c79ced86ecf49f5e4a973594634c83197c35ab';
 const rifTokenAddress = '0x2acc95758f8b5f583470ba265eb685a8f45fc9d5';
 
 export default class RNSManager {
-  constructor(wallet, provider) {
-    const signer = new Wallet(wallet.privateKey, provider);
+  constructor(signer) {
     const rskRegistrar = new RSKRegistrar(
       rskOwnerAddress,
       fifsAddrRegistrarAddress,

--- a/src/dapps/rns-manager-dapp/handlers/helpers/reverseRegistrar.js
+++ b/src/dapps/rns-manager-dapp/handlers/helpers/reverseRegistrar.js
@@ -1,4 +1,4 @@
-import { Contract, Wallet } from 'ethers';
+import { Contract } from 'ethers';
 
 const RNS_REGISTRY_ADDRESS = '0xd25c3f94a743b93ecffecbe691beea51c3c2d9d1';
 const REVERSE_REGISTER_ABI = [
@@ -7,8 +7,7 @@ const REVERSE_REGISTER_ABI = [
 ];
 
 export default class ReverseRegistrar {
-  constructor(wallet, provider) {
-    const signer = new Wallet(wallet.privateKey, provider);
+  constructor(signer) {
     const reverseRegisterContract = new Contract(
       RNS_REGISTRY_ADDRESS,
       REVERSE_REGISTER_ABI,


### PR DESCRIPTION
### Fix

* \[X] Added entry to ./changelog
* \[ ] Add PR label

### Description
This PR fixes web3 provider in rns manager dapp. Previously it deriving signer from priv key which is not available in all cases and also not a good approach. Now using web3 provider to derive signer and passing it to rns manager. 

### Testing
- Tested by connecting with metamask and sending / approving transactions
- Tested with mnemonic / seed phrase
