### PR TITLE
FIX checksum error when you input a `Rootstock` checksummed address on send screen

### DIFF
--- a/changelog/fix-4993.md
+++ b/changelog/fix-4993.md
@@ -1,0 +1,1 @@
+fix rootstock checksum error

--- a/src/modules/address-book/ModuleAddressBook.vue
+++ b/src/modules/address-book/ModuleAddressBook.vue
@@ -44,6 +44,7 @@ import WAValidator from 'multicoin-address-validator';
 import { isAddress, toChecksumAddress } from '@/core/helpers/addressUtils';
 import Resolver from '@/modules/name-resolver/index';
 import { ERROR, Toast } from '../toast/handler/handlerToast';
+import { ROOTSTOCK } from '@/utils/networks/types';
 
 const USER_INPUT_TYPES = {
   typed: 'TYPED',
@@ -334,8 +335,13 @@ export default {
     resolveAddress: throttle(async function () {
       if (this.nameResolver) {
         try {
+          // Ethers.js rejects Rootstock checksummed address so use lowercase address.
+          const inputAddress =
+            this.network.type.chainID === ROOTSTOCK.chainID
+              ? this.inputAddr.toLowerCase()
+              : this.inputAddr;
           const reverseName = await this.nameResolver.resolveAddress(
-            this.inputAddr
+            inputAddress
           );
           // if (reverseName && !reverseName.name) {
           //   try {


### PR DESCRIPTION
### Fix

* \[X] Added entry to ./changelog
* \[ ] Is this a user submitted bug?
  * \[ ] Link to issue:
* \[ ] Add PR label

### Description

This pr fixes `Error bad address checksum` thrown by ethers.js dependency used by ens.js dependency. Actually ethers.js rejects rootstock checksummed addresses so address needs to be lowercased before passing this function. 

### How to reproduce
- Select Rootstock network
- On send screen put a Rootstock checksummed address 

https://github.com/user-attachments/assets/13923f20-d92a-4120-a658-e5da4770e9c0


### Snapshot

<img width="1505" alt="Screenshot 2024-08-28 at 3 03 44 PM" src="https://github.com/user-attachments/assets/831d5ef3-942f-4cf7-a7fd-f9317701b60d">
