### PR TITLE
feat: v7 amplitude init

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
+    "@amplitude/analytics-browser": "^2.11.9",
     "@myetherwallet/vue-common-components": "^1.2.8",
     "@tanstack/vue-query": "^5.59.16",
     "@vueuse/core": "^11.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@amplitude/analytics-browser':
+        specifier: ^2.11.9
+        version: 2.11.9
       '@myetherwallet/vue-common-components':
         specifier: ^1.2.8
         version: 1.2.8(vue@3.5.12(typescript@5.5.4))
@@ -123,6 +126,33 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@amplitude/analytics-browser@2.11.9':
+    resolution: {integrity: sha512-FHejpsW3OypNKaIBvMwLm74UUSBcR+VwrBsj7V2VlPDNRdeaFi21kJgVYUW5AcjxTsadMzBQGBb4BarZ4k2+9Q==}
+
+  '@amplitude/analytics-client-common@2.3.5':
+    resolution: {integrity: sha512-BCP+jorfLMAKK/g87fAk4IPP/NzQLMCep+Qe23tqOCWguwTEINYnyzD/GmhaIKXSM2o9pmMLlHbhkA1vXUtF8g==}
+
+  '@amplitude/analytics-connector@1.6.1':
+    resolution: {integrity: sha512-QAGeOfBQc3tamwcECu6YqAPD4mFI1TLBoWi+n0iViYWUZma2FeDLPMihwIquxI8CVvqpn4gswFZsIPRit3q9tQ==}
+
+  '@amplitude/analytics-core@2.5.4':
+    resolution: {integrity: sha512-J5ZF8hQmxmxM+7bu25a2TfTnk/LQ/oH5FYdg79f1lJ85Aa6oUlCDxgvXwy1RVpwaFjWlZQgV4XVaAUrxtSPRFw==}
+
+  '@amplitude/analytics-remote-config@0.4.1':
+    resolution: {integrity: sha512-BYl6kQ9qjztrCACsugpxO+foLaQIC0aSEzoXEAb/gwOzInmqkyyI+Ub+aWTBih4xgB/lhWlOcidWHAmNiTJTNw==}
+
+  '@amplitude/analytics-types@2.8.4':
+    resolution: {integrity: sha512-jQ8WY1aPbpBshl0L/0YEeQn/wZlBr8Jlqc20qf8nbuDuimFy8RqAkE+BVaMI86FCkr3AJ7PjMXkGwCSbUx88CA==}
+
+  '@amplitude/experiment-core@0.10.0':
+    resolution: {integrity: sha512-FBfM6a4aHp+7OYLYiHO3kni3vCThInT6o4ucuNIB+EIvQ141gQDSjMPOET3ik82fMuJPQITex9sdpZ6cO30ALw==}
+
+  '@amplitude/plugin-autocapture-browser@1.0.3':
+    resolution: {integrity: sha512-XUQWUAw9VqtJPlmOyWjnhsEspyVakd9LuSjVNtLjhwlWv+f/yZM1AAQVUdq/Os1+b5OptSgJQ2pPfRJJHZDXTw==}
+
+  '@amplitude/plugin-page-view-tracking-browser@2.3.5':
+    resolution: {integrity: sha512-qcV4DLxRAZRriYBNvjc2PGW1EDad6PSsIXmxVs6j8i9fxY2SfdvsFd/Qd23CHj1e6Dt5QpAVJZpUMCEdqqDZbA==}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -4168,6 +4198,9 @@ packages:
     resolution: {integrity: sha512-EX4oNDwcXSivPrw2qKH2LB5PoFxEvgtv2JgwW0bU858HoLQ+kutSvjLMUqBd0PeJYEinLWhoI9Ol0eYMqj/wNQ==}
     hasBin: true
 
+  js-base64@3.7.7:
+    resolution: {integrity: sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==}
+
   js-beautify@1.15.1:
     resolution: {integrity: sha512-ESjNzSlt/sWE8sciZH8kBF8BPlwXPwhR6pWKAw8bw4Bwj+iZcnKW6ONWUutJ7eObuBZQpiIb8S7OYspWrKt7rA==}
     engines: {node: '>=14'}
@@ -5310,6 +5343,9 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  rxjs@7.8.1:
+    resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
+
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
@@ -6374,6 +6410,58 @@ snapshots:
   '@adraffy/ens-normalize@1.11.0': {}
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@amplitude/analytics-browser@2.11.9':
+    dependencies:
+      '@amplitude/analytics-client-common': 2.3.5
+      '@amplitude/analytics-core': 2.5.4
+      '@amplitude/analytics-remote-config': 0.4.1
+      '@amplitude/analytics-types': 2.8.4
+      '@amplitude/plugin-autocapture-browser': 1.0.3
+      '@amplitude/plugin-page-view-tracking-browser': 2.3.5
+      tslib: 2.8.0
+
+  '@amplitude/analytics-client-common@2.3.5':
+    dependencies:
+      '@amplitude/analytics-connector': 1.6.1
+      '@amplitude/analytics-core': 2.5.4
+      '@amplitude/analytics-types': 2.8.4
+      tslib: 2.8.0
+
+  '@amplitude/analytics-connector@1.6.1':
+    dependencies:
+      '@amplitude/experiment-core': 0.10.0
+
+  '@amplitude/analytics-core@2.5.4':
+    dependencies:
+      '@amplitude/analytics-types': 2.8.4
+      tslib: 2.8.0
+
+  '@amplitude/analytics-remote-config@0.4.1':
+    dependencies:
+      '@amplitude/analytics-client-common': 2.3.5
+      '@amplitude/analytics-core': 2.5.4
+      '@amplitude/analytics-types': 2.8.4
+      tslib: 2.8.0
+
+  '@amplitude/analytics-types@2.8.4': {}
+
+  '@amplitude/experiment-core@0.10.0':
+    dependencies:
+      js-base64: 3.7.7
+
+  '@amplitude/plugin-autocapture-browser@1.0.3':
+    dependencies:
+      '@amplitude/analytics-client-common': 2.3.5
+      '@amplitude/analytics-types': 2.8.4
+      rxjs: 7.8.1
+      tslib: 2.8.0
+
+  '@amplitude/plugin-page-view-tracking-browser@2.3.5':
+    dependencies:
+      '@amplitude/analytics-client-common': 2.3.5
+      '@amplitude/analytics-types': 2.8.4
+      tslib: 2.8.0
 
   '@ampproject/remapping@2.3.0':
     dependencies:
@@ -11187,6 +11275,8 @@ snapshots:
 
   jiti@2.3.3: {}
 
+  js-base64@3.7.7: {}
+
   js-beautify@1.15.1:
     dependencies:
       config-chain: 1.1.13
@@ -12553,6 +12643,10 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rxjs@7.8.1:
+    dependencies:
+      tslib: 2.8.0
 
   safe-buffer@5.1.2: {}
 

--- a/src/analytics/amplitude.ts
+++ b/src/analytics/amplitude.ts
@@ -1,0 +1,150 @@
+import type {
+  AccessWalletEvent,
+  BuySellEvent,
+  ConsentEvent,
+  ContractEvent,
+  CreateWalletEvent,
+  DashboardEvent,
+  EthVMEvent,
+  HeaderEvent,
+  LandingPageEvent,
+  StakingEvent,
+  SwapEvent,
+  WalletDirectLinkAccessEvent,
+} from './events'
+import { type createInstance } from '@amplitude/analytics-browser'
+
+type AmplitudeAnalyticsOptions = {
+  amplitude: ReturnType<typeof createInstance>
+}
+
+export class Analytics {
+  amplitude: ReturnType<typeof createInstance>
+
+  constructor(opts: AmplitudeAnalyticsOptions) {
+    const { amplitude } = opts
+    this.amplitude = amplitude
+  }
+
+  setConsentToTrack(value: boolean): void {
+    this.amplitude.setOptOut(value)
+  }
+
+  private async _track(
+    name: string,
+    payload: Record<PropertyKey, unknown>,
+  ): Promise<void> {
+    const ret = this.amplitude.track(name, payload)
+    const { promise } = ret
+    await promise
+  }
+
+  trackEthVMEvent = (
+    event: EthVMEvent,
+    payload: {
+      path: string
+      network: string
+    },
+  ): Promise<void> => {
+    return this._track('ethvm', { event, ...payload })
+  }
+
+  trackWalletDirectLinkAccessEvent = (
+    event: WalletDirectLinkAccessEvent,
+    payload: {
+      to: string
+    },
+  ): Promise<void> => {
+    return this._track('???wallet_direct_link_access???', { event, ...payload })
+  }
+
+  trackConsentEvent = (
+    event: ConsentEvent,
+    payload: {
+      network: string
+    },
+  ): Promise<void> => {
+    return this._track('consent', { event, ...payload })
+  }
+
+  trackLandingPageEvent = (
+    event: LandingPageEvent,
+    payload: {
+      network: string
+    },
+  ): Promise<void> => {
+    return this._track('landing_page', { event, ...payload })
+  }
+
+  trackHeaderEvent = (
+    event: HeaderEvent,
+    payload: {
+      network: string
+    },
+  ): Promise<void> => {
+    return this._track('header', { event, ...payload })
+  }
+
+  trackDashboardEvent = (
+    event: DashboardEvent,
+    payload: {
+      network: string
+    },
+  ): Promise<void> => {
+    return this._track('dashboard', { event, ...payload })
+  }
+
+  trackCreateWalletEvent = (
+    event: CreateWalletEvent,
+    payload: {
+      network: string
+    },
+  ): Promise<void> => {
+    return this._track('create_wallet', { event, ...payload })
+  }
+
+  trackAccessWalletEvent = (
+    event: AccessWalletEvent,
+    payload: {
+      network: string
+    },
+  ): Promise<void> => {
+    return this._track('access_wallet', { event, ...payload })
+  }
+
+  trackBuySellEvent = (
+    event: BuySellEvent,
+    payload: {
+      network: string
+    },
+  ): Promise<void> => {
+    return this._track('buy_sell', { event, ...payload })
+  }
+
+  trackContractEvent = (
+    event: ContractEvent,
+    payload: {
+      network: string
+    },
+  ): Promise<void> => {
+    return this._track('contract', { event, ...payload })
+  }
+
+  trackStakingEvent = (
+    event: StakingEvent,
+    payload: {
+      network: string
+    },
+  ): Promise<void> => {
+    return this._track('staking', { event, ...payload })
+  }
+
+  trackSwapEvent = (
+    event: SwapEvent,
+    payload: {
+      network: string
+    },
+  ): Promise<void> => {
+    return this._track('swap', { event, ...payload })
+  }
+}

--- a/src/analytics/amplitude.ts
+++ b/src/analytics/amplitude.ts
@@ -79,8 +79,9 @@ export class Analytics {
       const ret = this.amplitude.track(name, payload)
       const { promise } = ret
       await promise
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
     } catch (err) {
-      console.error(`Error tracking event: ${name}`, err)
+      // TODO: Send error to Sentry after we've added Sentry
     }
   }
 

--- a/src/analytics/events.ts
+++ b/src/analytics/events.ts
@@ -1,0 +1,196 @@
+
+export const EthVMEvent = {
+  ETHVM_LINK_CLICKED: 'EthVMLinkClicked',
+} as const
+export type EthVMEvent = typeof EthVMEvent[keyof typeof EthVMEvent]
+
+export const WalletDirectLinkAccessEvent = {
+  WALLET_DIRECT_LINK_ACCESS: 'WalletDirectLinkAccess'
+} as const
+export type WalletDirectLinkAccessEvent = typeof WalletDirectLinkAccessEvent[keyof typeof WalletDirectLinkAccessEvent]
+
+export const ConsentEvent = {
+  USER_OPT_OUT_TRACKING: 'UserOptOutTracking',
+  USER_OPT_IN_TRACKING: 'UserOptInTracking',
+} as const
+export type ConsentEvent = typeof ConsentEvent[keyof typeof ConsentEvent]
+
+export const LandingPageEvent = {
+  APPLE_STORE: 'AppleStore',
+  CREATE_WALLET: 'CreateWallet',
+  ACCESS_WALLET: 'AccessWallet',
+  GOOGLE_STORE_2: 'GoogleStore2',
+  APPLE_STORE_2: 'AppleStore2',
+  GOOGLE_STORE_3: 'GoogleStore3',
+  CREATE_WALLET_2: 'CreateWallet2',
+  ACCESS_WALLET_2: 'AccessWallet2',
+  MEWTOPIA: 'MewTopia',
+  PARTNERS: 'Partners',
+  ENKRYPT_LEARN_MORE: 'EnkryptLearnMore',
+  ACCESS_WALLET_MINT: 'AccessWalletMint',
+  SWAP_CLICKED: 'SwapClicked',
+  GET_TOKENS_CLICKED: 'GetTokensClicked',
+  MEW_COMMUNITY: 'MEWCommunity',
+  ACCESS_WALLET_MOBILE: 'AccessWalletMobile',
+  CREATE_WALLET_MOBILE: 'CreateWalletMobile'
+} as const
+export type LandingPageEvent = typeof LandingPageEvent[keyof typeof LandingPageEvent]
+
+export const HeaderEvent = {
+  MEW_PRODUCTS: 'MEWProducts',
+  LOGO: 'Logo',
+  WHAT_IS_MEW: 'WhatIsMEW',
+  WALLET_ACTIONS: 'WalletActions',
+  BUY_ETH: 'BuyETH',
+  BUY_ETH_MOBILE: 'BuyETHMobile'
+} as const
+export type HeaderEvent = typeof HeaderEvent[keyof typeof HeaderEvent]
+
+export const DashboardEvent = {
+  SWAP_BALANCE: 'SwapBalance',
+  SWAP_MY_TOKENS_VALUE: 'SwapMyTokensValue',
+  SWAP_PAIRS: 'SwapPairs',
+  SWAP_LEFT_NAVIGATION: 'SwapLeftNavigation',
+  SHOW_RECEIVE_ADDRESS: 'ShowReceiveAddress'
+} as const
+export type DashboardEvent = typeof DashboardEvent[keyof typeof DashboardEvent]
+
+export const CreateWalletEvent = {
+  KEYSTORE_FILE_CLICKED: 'KeystoreFileClicked',
+  MNEMONIC_PHRASE_CLICKED: 'MnemonicPhraseClicked',
+  KEYSTORE_VERIFICATION: 'KeystoreVerification',
+  KEYSTORE_DOWNLOAD: 'KeystoreDownload',
+  KEYSTORE_SUCCESS_ACCESS: 'KeystoreSuccessAccessWallet',
+  KEYSTORE_BACK: 'KeystoreDownloadBackClicked',
+  KEYSTORE_SUCCESS_CREATE: 'KeystoreSuccessCreateWallet',
+  MNEMONIC_SUCCESS: 'MnemonicSuccess',
+  MNEMONIC_SUCCESS_ACCESS: 'MnemonicSuccessAccessWallet',
+  MNEMONIC_WROTE_DOWN: 'WroteDownClicked',
+  MNEMONIC_BACK: 'MnemonicBackToStepOne',
+  MNEMONIC_SUCCESS_CREATE: 'MnemonicSuccessCreateWallet',
+  NAVIGATE_TO_ACCESS: 'NavigateToAccess',
+  BUY_HARDWARE: 'BuyHardware',
+  SOFTWARE_METHOD: 'SoftwareMethod',
+  CLOSE_SOFTWARE: 'CloseSoftware'
+} as const
+export type CreateWalletEvent = typeof CreateWalletEvent[keyof typeof CreateWalletEvent]
+
+export const AccessWalletEvent = {
+  ENKRYPT: 'Enkrypt',
+  BROWSER_EXTENSION: 'BrowserExtension',
+  MOBILE_APPS: 'MobileApps',
+  HARWARE_WALLETS: 'HardwareWallets',
+  SOFTWARE: 'Software',
+  CLOSE_SOFTWARE_ACCESS: 'CloseSoftwareAccess',
+  CLOSE_HARDWARE_ACCESS: 'CloseHardwareAccess',
+  CLOSE_MOBILE_ACCESS: 'CloseMobileAccess',
+  WEB3_ACCESS_SUCCESS: 'Web3AccessSuccess',
+  SOFTWARE_BACK: 'SoftwareBack',
+  KEYSTORE_SHOWN: 'KeystoreShown',
+  MNEMONIC_SHOWN: 'MnemonicShown',
+  PRIVATE_KEY_SHOWN: 'PrivateKeyShown',
+  KEYSTORE_CONNECTED: 'KeystoreConnected',
+  MNEMONIC_CONNECTED: 'MnemonicConnected',
+  PRIVATE_KEY_CONNECTED: 'PrivateKeyConnected',
+  WALLET_CONNECT_QR_SHOWN: 'MobileAppsWalletConnectQRShown',
+  WALLET_CONNECT_QR_SUCCESSFUL: 'MobileAppsWalletConnectQRShownSuccessful',
+  WALLET_CONNECT_QR_FAILED: 'MobileAppsWalletConnectQRShownFailed',
+  WALLET_LINK_QR_SHOWN: 'MobileAppsWalletLinkQRShown',
+  WALLET_LINK_QR_SUCCESSFUL: 'MobileAppsWalletLinkQRSuccessful',
+  WALLET_LINK_QR_FAILED: 'MobileAppsWalletLinkQRFailed',
+  MEW_WALLET_QR_SHOWN: 'MobileAppsMEWWalletQRShown',
+  MEW_WALLET_QR_SUCCESSFUL: 'MobileAppsMEWWalletQRSuccess',
+  MEW_WALLET_QR_FAILED: 'MobileAppsMEWWalletQRFailed',
+  HW_LEDGER_CLICKED: 'HWLedgerClicked',
+  HW_TREZOR_CLICKED: 'HWTrezorClicked',
+  HW_KEEPKEY_CLICKED: 'HWKeepKeyClicked',
+  HW_BITBOX02_CLICKED: 'HWBitBox02Clicked',
+  HW_COOL_WALLET_CLICKED: 'HWCoolWalletClicked',
+  HW_BITBOX02_SHOWN: 'HWBitBox02Shown',
+  HW_LEDGER_SHOWN: 'HWLedgerShown',
+  HW_COOL_WALLET_SHOWN: 'HWCoolWalletShown',
+  HW_TREZOR_SHOWN: 'HWTrezorShown',
+  HW_KEEPKEY_SHOWN: 'HWKeepKeyShown',
+  HW_LEDGER_CONNECTED: 'HWLedgerConnected',
+  HW_TREZOR_CONNECTED: 'HWTrezorConnected',
+  HW_COOL_WALLET_CONNECTED: 'HWCoolWalletConnected',
+  HW_BITBOX02_CONNECTED: 'HWBitBox02Connected',
+  HW_KEEPKEY_CONNECTED: 'HWKeepKeyConnected',
+  ACCESS_FAILED: 'Failed',
+  PRIV_KEY_TERMS: 'PrivateKeyTermsAccepted',
+  PRIV_INVISIBLE_BOX: 'PrivateKeyInvisibleBox',
+  SOFTWARE_FAILED: 'SoftwareFailed',
+  HW_FAILED: 'HWFailed'
+} as const
+export type AccessWalletEvent = typeof AccessWalletEvent[keyof typeof AccessWalletEvent]
+
+export const BuySellEvent = {
+  OPEN_BUY_SELL_MODAL: 'OpenBuySellModal',
+  BUY_NOW_BUTTON: 'BuyNow',
+  BUY_TAB: 'BuyTab',
+  SELL_TAB: 'SellTab',
+  BUY_SELL_CLOSED: 'CloseModal',
+  BUY_INPUT: 'BuyInput',
+  SELL_INPUT: 'SellInput',
+  BUY_W_SIMPLEX: 'BuyWithSimplex',
+  BUY_W_SIMPLEX_SUCCESS: 'BuyWithSimplexSuccess',
+  BUY_W_SIMPLEX_FAILED: 'BuyWithSimplexFailed',
+  BUY_W_MOONPAY: 'BuyWithMoonpay',
+  BUY_W_MOONPAY_SUCCESS: 'BuyWithMoonpaySuccess',
+  BUY_W_MOONPAY_FAILED: 'BuyWithMoonpayFailed',
+  SELL_WITH_MOONPAY: 'SellWithMoonpay',
+  SELL_WITH_MOONPAY_SUCCESS: 'SellWithMoonpaySuccess',
+  SELL_WITH_MOONPAY_FAILED: 'SellWithMoonpayFailed',
+  BUY_W_TOPPER: 'BuyWithTopper',
+  BUY_W_TOPPER_SUCCESS: 'BuyWithTopperSuccess',
+  BUY_W_TOPPER_FAILED: 'BuyWithTopperFailed',
+  BUY_PROVIDER_SELECTED: 'BuyWithProviderSelected'
+} as const
+export type BuySellEvent = typeof BuySellEvent[keyof typeof BuySellEvent]
+
+export const ContractEvent = {
+  INTERACT_W_CONTRACT_WRITE: 'InteractWithContractWriteButtonClicked',
+  INTERACT_W_CONTRACT_WRITE_SUCCESS: 'InteractWithContractWriteSuccess',
+  INTERACT_W_CONTRACT_WRITE_FAIL: 'InteractWithContractWriteFail',
+  INTERACT_W_CONTRACT_READ: 'InteractWithContractReadButtonClicked',
+  INTERACT_W_CONTRACT_READ_SUCCESS: 'InteractWithContractReadSuccess',
+  INTERACT_W_CONTRACT_READ_FAIL: 'InteractWithContractReadFail',
+  DEPLOY_CONTRACT: 'DeployContractButtonClicked',
+  DEPLOY_CONTRACT_SUCCESS: 'DeployContractSuccess',
+  DEPLOY_CONTRACT_FAIL: 'DeployContractFail',
+  NAVIGATE_TO_INTERACT: 'NavigateToInteract',
+  NAVIGATE_TO_DEPLOY: 'NavigateToDeploy'
+} as const
+export type ContractEvent = typeof ContractEvent[keyof typeof ContractEvent]
+
+export const StakingEvent = {
+  SIDE_MENU: 'SideMenu',
+  DASHBOARD: 'Dashboard',
+  DASHBOARD_CLOSED: 'DashboardClosed',
+  STAKE_CENTER_STAKED: 'PageStaked',
+  STAKE_CENTER_COINBASE: 'PageCoinbase',
+  STAKE_CENTER_MORE_ABOUT: 'PageMoreAboutStaking',
+  HEADER_NOW: 'HeaderNow'
+} as const
+export type StakingEvent = typeof StakingEvent[keyof typeof StakingEvent]
+
+export const SwapEvent = {
+  BROADCASTED: 'Broadcasted',
+  RECEIPT: 'Receipt',
+  FAILED: 'Failed',
+  NOT_BROADCASTED: 'NotBroadcasted',
+  VERIFY_PAGE_SHOWN: 'VerifyPageShown',
+  CANCELLED: 'Cancelled',
+  SUCCESS: 'Success',
+  CONFIRM_CLICKED: 'ConfirmClicked',
+  FIELD_INPUTS: 'FieldInputs',
+  NEXT_CLICKED: 'NextClicked',
+  INITIAL_MODAL_CLOSED: 'InitiatedModalClosed',
+  SWAP_INITIATED: 'SwapInitiated',
+  TRANSACTION_INITIATIED: 'TransactionInitiated',
+  X_OUT: 'XOut',
+  CLICK_OUTSIDE: 'ClickOutside',
+  BUTTON_CANCEL: 'ButtonCancel'
+} as const
+export type SwapEvent = typeof SwapEvent[keyof typeof SwapEvent]
+

--- a/src/analytics/events.ts
+++ b/src/analytics/events.ts
@@ -1,59 +1,29 @@
-
 export const EthVMEvent = {
   ETHVM_LINK_CLICKED: 'EthVMLinkClicked',
 } as const
-export type EthVMEvent = typeof EthVMEvent[keyof typeof EthVMEvent]
+export type EthVMEvent = (typeof EthVMEvent)[keyof typeof EthVMEvent]
 
 export const WalletDirectLinkAccessEvent = {
-  WALLET_DIRECT_LINK_ACCESS: 'WalletDirectLinkAccess'
+  WALLET_DIRECT_LINK_ACCESS: 'WalletDirectLinkAccess',
 } as const
-export type WalletDirectLinkAccessEvent = typeof WalletDirectLinkAccessEvent[keyof typeof WalletDirectLinkAccessEvent]
+export type WalletDirectLinkAccessEvent =
+  (typeof WalletDirectLinkAccessEvent)[keyof typeof WalletDirectLinkAccessEvent]
 
 export const ConsentEvent = {
   USER_OPT_OUT_TRACKING: 'UserOptOutTracking',
   USER_OPT_IN_TRACKING: 'UserOptInTracking',
 } as const
-export type ConsentEvent = typeof ConsentEvent[keyof typeof ConsentEvent]
-
-export const LandingPageEvent = {
-  APPLE_STORE: 'AppleStore',
-  CREATE_WALLET: 'CreateWallet',
-  ACCESS_WALLET: 'AccessWallet',
-  GOOGLE_STORE_2: 'GoogleStore2',
-  APPLE_STORE_2: 'AppleStore2',
-  GOOGLE_STORE_3: 'GoogleStore3',
-  CREATE_WALLET_2: 'CreateWallet2',
-  ACCESS_WALLET_2: 'AccessWallet2',
-  MEWTOPIA: 'MewTopia',
-  PARTNERS: 'Partners',
-  ENKRYPT_LEARN_MORE: 'EnkryptLearnMore',
-  ACCESS_WALLET_MINT: 'AccessWalletMint',
-  SWAP_CLICKED: 'SwapClicked',
-  GET_TOKENS_CLICKED: 'GetTokensClicked',
-  MEW_COMMUNITY: 'MEWCommunity',
-  ACCESS_WALLET_MOBILE: 'AccessWalletMobile',
-  CREATE_WALLET_MOBILE: 'CreateWalletMobile'
-} as const
-export type LandingPageEvent = typeof LandingPageEvent[keyof typeof LandingPageEvent]
-
-export const HeaderEvent = {
-  MEW_PRODUCTS: 'MEWProducts',
-  LOGO: 'Logo',
-  WHAT_IS_MEW: 'WhatIsMEW',
-  WALLET_ACTIONS: 'WalletActions',
-  BUY_ETH: 'BuyETH',
-  BUY_ETH_MOBILE: 'BuyETHMobile'
-} as const
-export type HeaderEvent = typeof HeaderEvent[keyof typeof HeaderEvent]
+export type ConsentEvent = (typeof ConsentEvent)[keyof typeof ConsentEvent]
 
 export const DashboardEvent = {
   SWAP_BALANCE: 'SwapBalance',
   SWAP_MY_TOKENS_VALUE: 'SwapMyTokensValue',
   SWAP_PAIRS: 'SwapPairs',
   SWAP_LEFT_NAVIGATION: 'SwapLeftNavigation',
-  SHOW_RECEIVE_ADDRESS: 'ShowReceiveAddress'
+  SHOW_RECEIVE_ADDRESS: 'ShowReceiveAddress',
 } as const
-export type DashboardEvent = typeof DashboardEvent[keyof typeof DashboardEvent]
+export type DashboardEvent =
+  (typeof DashboardEvent)[keyof typeof DashboardEvent]
 
 export const CreateWalletEvent = {
   KEYSTORE_FILE_CLICKED: 'KeystoreFileClicked',
@@ -71,9 +41,10 @@ export const CreateWalletEvent = {
   NAVIGATE_TO_ACCESS: 'NavigateToAccess',
   BUY_HARDWARE: 'BuyHardware',
   SOFTWARE_METHOD: 'SoftwareMethod',
-  CLOSE_SOFTWARE: 'CloseSoftware'
+  CLOSE_SOFTWARE: 'CloseSoftware',
 } as const
-export type CreateWalletEvent = typeof CreateWalletEvent[keyof typeof CreateWalletEvent]
+export type CreateWalletEvent =
+  (typeof CreateWalletEvent)[keyof typeof CreateWalletEvent]
 
 export const AccessWalletEvent = {
   ENKRYPT: 'Enkrypt',
@@ -120,9 +91,10 @@ export const AccessWalletEvent = {
   PRIV_KEY_TERMS: 'PrivateKeyTermsAccepted',
   PRIV_INVISIBLE_BOX: 'PrivateKeyInvisibleBox',
   SOFTWARE_FAILED: 'SoftwareFailed',
-  HW_FAILED: 'HWFailed'
+  HW_FAILED: 'HWFailed',
 } as const
-export type AccessWalletEvent = typeof AccessWalletEvent[keyof typeof AccessWalletEvent]
+export type AccessWalletEvent =
+  (typeof AccessWalletEvent)[keyof typeof AccessWalletEvent]
 
 export const BuySellEvent = {
   OPEN_BUY_SELL_MODAL: 'OpenBuySellModal',
@@ -144,9 +116,9 @@ export const BuySellEvent = {
   BUY_W_TOPPER: 'BuyWithTopper',
   BUY_W_TOPPER_SUCCESS: 'BuyWithTopperSuccess',
   BUY_W_TOPPER_FAILED: 'BuyWithTopperFailed',
-  BUY_PROVIDER_SELECTED: 'BuyWithProviderSelected'
+  BUY_PROVIDER_SELECTED: 'BuyWithProviderSelected',
 } as const
-export type BuySellEvent = typeof BuySellEvent[keyof typeof BuySellEvent]
+export type BuySellEvent = (typeof BuySellEvent)[keyof typeof BuySellEvent]
 
 export const ContractEvent = {
   INTERACT_W_CONTRACT_WRITE: 'InteractWithContractWriteButtonClicked',
@@ -159,9 +131,9 @@ export const ContractEvent = {
   DEPLOY_CONTRACT_SUCCESS: 'DeployContractSuccess',
   DEPLOY_CONTRACT_FAIL: 'DeployContractFail',
   NAVIGATE_TO_INTERACT: 'NavigateToInteract',
-  NAVIGATE_TO_DEPLOY: 'NavigateToDeploy'
+  NAVIGATE_TO_DEPLOY: 'NavigateToDeploy',
 } as const
-export type ContractEvent = typeof ContractEvent[keyof typeof ContractEvent]
+export type ContractEvent = (typeof ContractEvent)[keyof typeof ContractEvent]
 
 export const StakingEvent = {
   SIDE_MENU: 'SideMenu',
@@ -170,9 +142,9 @@ export const StakingEvent = {
   STAKE_CENTER_STAKED: 'PageStaked',
   STAKE_CENTER_COINBASE: 'PageCoinbase',
   STAKE_CENTER_MORE_ABOUT: 'PageMoreAboutStaking',
-  HEADER_NOW: 'HeaderNow'
+  HEADER_NOW: 'HeaderNow',
 } as const
-export type StakingEvent = typeof StakingEvent[keyof typeof StakingEvent]
+export type StakingEvent = (typeof StakingEvent)[keyof typeof StakingEvent]
 
 export const SwapEvent = {
   BROADCASTED: 'Broadcasted',
@@ -190,7 +162,6 @@ export const SwapEvent = {
   TRANSACTION_INITIATIED: 'TransactionInitiated',
   X_OUT: 'XOut',
   CLICK_OUTSIDE: 'ClickOutside',
-  BUTTON_CANCEL: 'ButtonCancel'
+  BUTTON_CANCEL: 'ButtonCancel',
 } as const
-export type SwapEvent = typeof SwapEvent[keyof typeof SwapEvent]
-
+export type SwapEvent = (typeof SwapEvent)[keyof typeof SwapEvent]

--- a/src/components/core_layouts/LayoutDefault.vue
+++ b/src/components/core_layouts/LayoutDefault.vue
@@ -1,39 +1,24 @@
 <template>
   <div ref="appBodyRef" :class="[coreBackground]">
-    <MewHeader
-      :use-i18n="useI18n"
-      bg-visible
-      :amplitude="{ track }"
-      :link-component="RouterLink"
-      :user-consent="userConsent"
-      :curr-project="CURR_PROJECT"
-      @update:consent="val => (userConsent = val)"
-    >
+    <MewHeader :use-i18n="useI18n" bg-visible :amplitude="analytics.amplitude" :link-component="RouterLink"
+      :user-consent="popupStore.consent" :curr-project="CURR_PROJECT" @update:consent="handleSetConsent">
       <!-- <template #lang-switch-mobile>
         <AppChangeLocale />
       </template> -->
     </MewHeader>
-    <div
-      :class="[
-        'absolute top-0 inset-x-0 flex justify-center overflow-hidden',
-        background,
-      ]"
-    ></div>
+    <div :class="[
+      'absolute top-0 inset-x-0 flex justify-center overflow-hidden',
+      background,
+    ]"></div>
     <!-- <main> -->
     <main :class="['max-w-[1392px] px-5 md-header:px-10 mx-auto']">
       <div>
         <slot />
       </div>
     </main>
-    <MewFooter
-      :use-i18n="useI18n"
-      :amplitude="{ track }"
-      :link-component="RouterLink"
-      :package-version="packageVersion"
-      :user-consent="userConsent"
-      :curr-project="CURR_PROJECT"
-      @update:consent="val => (userConsent = val)"
-    >
+    <MewFooter :use-i18n="useI18n" :amplitude="analytics.amplitude" :link-component="RouterLink"
+      :package-version="packageVersion" :user-consent="popupStore.consent" :curr-project="CURR_PROJECT"
+      @update:consent="handleSetConsent">
       <!-- <template #lang-switch-footer>
         <AppChangeLocale class="mt-5" />
       </template> -->
@@ -45,7 +30,13 @@
 import { MewHeader, MewFooter } from '@myetherwallet/vue-common-components'
 import { RouterLink } from 'vue-router'
 import { useI18n } from 'vue-i18n'
-import { ref, computed } from 'vue'
+import { computed, inject } from 'vue'
+import type { Analytics } from '@/analytics/amplitude'
+import { Provider } from '@/providers'
+import { usePopupStore } from '@/stores/popup'
+
+const popupStore = usePopupStore()
+const analytics = inject<Analytics>(Provider.ANALYTICS)!
 
 const CURR_PROJECT = 'MEW_PORTFOLIO'
 /**
@@ -73,6 +64,7 @@ const background = computed<string>(() => {
   // }
   return ''
 })
+
 const coreBackground = computed<string>(() => {
   // switch (routePath.value) {
   //   case '/':
@@ -85,18 +77,9 @@ const coreBackground = computed<string>(() => {
   return ''
 })
 
-/**
- * Fake Amplitude
- * Tracking event
- */
-const track = () => {
-  console.log('Tracking')
+function handleSetConsent(consent: boolean) {
+  popupStore.setTrackingConsent(consent)
 }
-
-/**
- * Fake User Consent
- */
-const userConsent = ref(false)
 </script>
 
 <style scoped></style>

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,10 +26,20 @@ const initialPopupStateJson = localStorage.getItem(
 if (initialPopupStateJson) {
   try {
     const initialPopupState = JSON.parse(initialPopupStateJson) as PopupState
-    if (typeof initialPopupState?.consentToTrack === 'boolean') {
-      consentToTrack = initialPopupState?.consentToTrack
-    } else {
-      console.error('Invalid consentToTrack value in popups store')
+    switch (typeof initialPopupState?.consentToTrack) {
+      case 'boolean':
+        // Returning user
+        consentToTrack = initialPopupState?.consentToTrack
+        break
+      case 'undefined':
+        // New user (or local storage wiped)
+        break
+      default:
+        // Invalid / unexpected value
+        console.error(
+          `Invalid consentToTrack value in popups store: ${String(initialPopupState?.consentToTrack)}`,
+        )
+        break
     }
   } catch (err) {
     console.error('Error parsing popups store from localStorage', err)

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,10 +5,81 @@ import { createPinia } from 'pinia'
 
 import App from './App.vue'
 import router from './router'
+import { Types, createInstance } from '@amplitude/analytics-browser'
+import { StoreConfigs } from './stores/configs'
+import { Provider } from './providers'
+import type { PopupState } from './stores/popup'
+import { Analytics } from './analytics/amplitude'
 
 const app = createApp(App)
 
+// In v6 this is ens_namehash(version)
+// TODO: figure out an appropriate value for it, ens namehash package
+// would need to be added for the previous version
+const __TMP_VERSION__ = 'v7'
+const __TMP_HASHED_VERSION__ = `tmp_local_mew_web_${__TMP_VERSION__}`
+
+let consentToTrack: boolean = false
+const initialPopupStateJson = localStorage.getItem(
+  StoreConfigs.LOCAL_STORAGE_KEYS.popups,
+)
+if (initialPopupStateJson) {
+  try {
+    const initialPopupState = JSON.parse(initialPopupStateJson) as PopupState
+    if (typeof initialPopupState?.consentToTrack === 'boolean') {
+      consentToTrack = initialPopupState?.consentToTrack
+    } else {
+      console.error('Invalid consentToTrack value in popups store')
+    }
+  } catch (err) {
+    console.error('Error parsing popups store from localStorage', err)
+  }
+}
+
+const amplitude = createInstance()
+
+// Initialise Amplitude
+amplitude.init(__TMP_HASHED_VERSION__, {
+  instanceName:
+    process.env.NODE_ENV === 'production' ? 'mew-web-prod' : 'mew-web-dev',
+  optOut: consentToTrack,
+  serverUrl:
+    process.env.NODE_ENV === 'production'
+      ? 'https://analytics-web.mewwallet.dev/record'
+      : 'https://analytics-web-development.mewwallet.dev/record',
+  appVersion: __TMP_VERSION__,
+  trackingOptions: {
+    ipAddress: false,
+  },
+  identityStorage: 'none',
+  logLevel: Types.LogLevel.None,
+  defaultTracking: {
+    formInteractions: false,
+    pageViews: false,
+  },
+})
+
 app.use(createPinia())
 app.use(router).use(i18n)
+
+/**
+ * Usage:
+ *
+ * ```ts
+ * import { inject } from 'vue'
+ * import { Provider } from '../providers'
+ * import type { Analytics } from '../analytics/amplitude'
+ * import { SomeEventType } from '../analytics/events'
+ * const analytics = inject<Analytics>(Provider.ANALYTICS)
+ *
+ * // Event handler function, fired when some event occurs
+ * function onSomethingHappened() {
+ *   analytics.trackSomeEvent(SomeEventType.Something, { payload: 'stuff' })
+ * }
+ *
+ * // ...
+ * ```
+ */
+app.provide(Provider.ANALYTICS, new Analytics({ amplitude }))
 
 app.mount('#app')

--- a/src/providers.ts
+++ b/src/providers.ts
@@ -1,0 +1,4 @@
+export const Provider = {
+  ANALYTICS: 'ANALYTICS'
+} as const
+export type Provider = typeof Provider[keyof typeof Provider]

--- a/src/stores/popup.ts
+++ b/src/stores/popup.ts
@@ -67,7 +67,7 @@ export const usePopupStore = defineStore('popups', (): PopupStore => {
   watch(
     () => storage.value.consentToTrack,
     value => {
-      analytics.setConsentToTrack(value)
+      analytics.setTrackingConsent(value)
     },
   )
 
@@ -79,13 +79,9 @@ export const usePopupStore = defineStore('popups', (): PopupStore => {
     setTrackingConsent: (consent: boolean) => {
       storage.value.consentToTrack = consent
       if (consent) {
-        analytics.trackConsentEvent(ConsentEvent.USER_OPT_IN_TRACKING, {
-          network: 'TODO: network',
-        })
+        analytics.trackConsentEvent(ConsentEvent.USER_OPT_IN_TRACKING)
       } else {
-        analytics.trackConsentEvent(ConsentEvent.USER_OPT_OUT_TRACKING, {
-          network: 'TODO: network',
-        })
+        analytics.trackConsentEvent(ConsentEvent.USER_OPT_OUT_TRACKING)
       }
     },
 


### PR DESCRIPTION
Implement Amplitude similar to Enkrypt

Tried to include all events from v6 but some might be missing. We can also remove events that are not needed any more. Also missing some things like the app name that we give to Amplitude, application version and the context to the consent tracking events since I'm not sure where we'll get that from yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Integrated Amplitude analytics for enhanced event tracking throughout the application.
  - Added user consent management for tracking, allowing users to opt-out of analytics.

- **Improvements**
  - Streamlined consent handling with centralized state management.
  - Enhanced event tracking capabilities with a variety of specific event types.
  - Introduced a new `Analytics` class for modular event tracking.
  - Added a method for updating the global analytics context.

- **Bug Fixes**
  - Improved error handling for consent retrieval from local storage.

- **Documentation**
  - Updated documentation for injecting and using the analytics instance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->