### PR TITLE
chore: v7 vite only build index.html

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,11 @@ import vueDevTools from 'vite-plugin-vue-devtools'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [vue(), nightwatchPlugin(), vueDevTools()],
+  build: {
+    rollupOptions: {
+      input: './index.html',
+    },
+  },
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),


### PR DESCRIPTION
Nightwatch seems to generate some HTML that Vite was trying to build and complaining about missing dependencies with it. This change instructs vite to only build the app's index.html file.

Previously this would happen

```sh
$ vite dev
VITE v5.4.10  ready in 560 ms

  ➜  Local:   http://localhost:5173/
  ➜  Network: use --host to expose
  ➜  Vue DevTools: Open http://localhost:5173/__devtools__/ as a separate window
  ➜  Vue DevTools: Press Alt(⌥)+Shift(⇧)+D in App to toggle the Vue DevTools

  ➜  press h + enter to show help
Error: The following dependencies are imported but could not be resolved:

  @emotion/is-prop-valid (imported by /<cwd>/v6/tests_output/nightwatch-html-report/index.html?id=0)

Are they installed?
    at file:///<cwd>/node_modules/.pnpm/vite@5.4.10_@types+node@20.17.0_terser@5.36.0/node_modules/vite/dist/node/chunks/dep-BWSbWtLw.js:50666:15
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async file:////<cwd>/node_modules/.pnpm/vite@5.4.10_@types+node@20.17.0_terser@5.36.0/node_modules/vite/dist/node/chunks/dep-BWSbWtLw.js:50171:26
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the build configuration to specify `index.html` as the entry point for the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->