### PR TITLE
chore: update @trezor/connect-web to version 9.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@sentry/vue": "7.109.0",
     "@shapeshiftoss/hdwallet-core": "1.54.1",
     "@shapeshiftoss/hdwallet-keepkey-webusb": "1.54.1",
-    "@trezor/connect-web": "9.4.0",
+    "@trezor/connect-web": "9.5.0",
     "@unstoppabledomains/resolution": "9.0.0",
     "@walletconnect/ethereum-provider": "2.16.2",
     "@walletconnect/modal": "2.6.2",


### PR DESCRIPTION
Hello from Trezor,

We noticed that you are using an older version of the @trezor/connect-web library, which we are planning to deprecate in the upcoming months.

This PR updates it to the latest version to ensure continued compatibility.