### PR TITLE
feat: ✨ add recent wallets list to access page

### DIFF
--- a/src/composables/useWagmiConnect.ts
+++ b/src/composables/useWagmiConnect.ts
@@ -5,6 +5,7 @@ import WagmiWallet from '@/providers/ethereum/wagmiWallet'
 
 import { ROUTES_WALLET } from '@/router/routeNames'
 import { useWalletStore } from '@/stores/walletStore'
+import { useRecentWalletsStore } from '@/stores/recentWalletsStore'
 import { type WalletConfig } from '@/modules/access/common/walletConfigs'
 
 export const useWagmiConnect = () => {
@@ -14,6 +15,8 @@ export const useWagmiConnect = () => {
 
   const { connectors } = wagmiConfig
   const walletStore = useWalletStore()
+  const recentWalletsStore = useRecentWalletsStore()
+  const { addWallet } = recentWalletsStore
   const { setWallet } = walletStore
   const router = useRouter()
 
@@ -48,6 +51,7 @@ export const useWagmiConnect = () => {
             wagmiWalletData.value = ''
             openWalletConnectModal.value = false
             setWallet(wagWallet)
+            addWallet(wallet)
             router.push({ name: ROUTES_WALLET.DASHBOARD.NAME })
           } catch (error) {
             console.error('WalletConnect connect failed:', error)

--- a/src/i18n/locales/access_wallet/en.json
+++ b/src/i18n/locales/access_wallet/en.json
@@ -5,6 +5,7 @@
     "need_help": "Need help accessing your wallet?",
     "search_wallet": "Search for your wallet",
     "select_wallet": "Select your wallet",
+    "recent": "Recent",
     "all_wallets": {
       "title": "All Wallets",
       "description": "Ledger, private key, keystore, mobile wallets, we have it all"
@@ -40,5 +41,4 @@
     "or_copy_link": "OR copy link",
     "need_help": "How to connect your wallet"
   }
-
 }

--- a/src/modules/access/ModuleAccessKeystore.vue
+++ b/src/modules/access/ModuleAccessKeystore.vue
@@ -82,6 +82,7 @@ import { computed, reactive, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { ROUTES_WALLET } from '@/router/routeNames'
 import { useWalletStore } from '@/stores/walletStore'
+import { useRecentWalletsStore } from '@/stores/recentWalletsStore'
 import {
   unlockKeystore,
   type V3Keystore,
@@ -95,6 +96,7 @@ import AppBaseButton from '@/components/AppBaseButton.vue'
 import { type StepDescription } from '@/types/components/appStepper'
 import AppInput from '@/components/AppInput.vue'
 import { watchDebounced } from '@vueuse/core'
+import { walletConfigs } from '@/modules/access/common/walletConfigs'
 
 import AppNotRecommended from '@/components/AppNotRecommended.vue'
 
@@ -169,6 +171,8 @@ const resetKeystore = () => {
  * Keystore Password
  -------------------------*/
 const walletStore = useWalletStore()
+const recentWalletsStore = useRecentWalletsStore()
+const { addWallet } = recentWalletsStore
 const router = useRouter()
 const { setWallet } = walletStore
 
@@ -198,6 +202,7 @@ const enterPassword = async () => {
       )
       resetKeystore()
       setWallet(wallet)
+      addWallet(walletConfigs.keystore)
       isUnlockingKeystore.value = false
       router.push({ path: ROUTES_WALLET.WALLET.PATH })
     }

--- a/src/modules/access/ModuleAccessMnemonic.vue
+++ b/src/modules/access/ModuleAccessMnemonic.vue
@@ -83,6 +83,9 @@ import MnemonicToWallet from '@/providers/ethereum/mnemonicToWallet'
 import { type SelectAddress } from './types/selectAddress'
 import { useRouter } from 'vue-router'
 
+import { walletConfigs } from '@/modules/access/common/walletConfigs'
+import { useRecentWalletsStore } from '@/stores/recentWalletsStore'
+
 /**------------------------
  * Steps
  -------------------------*/
@@ -200,6 +203,8 @@ const setPage = (isNext: boolean) => {
  * Access Wallet
  ------------------------*/
 
+const recentWalletsStore = useRecentWalletsStore()
+const { addWallet } = recentWalletsStore
 const walletStore = useWalletStore()
 const router = useRouter()
 const { setWallet } = walletStore
@@ -211,6 +216,7 @@ const access = async () => {
   await wallet.value?.getWallet(selectedIndex.value).then(wallet => {
     if (wallet) {
       setWallet(wallet)
+      addWallet(walletConfigs.mnemonic)
     }
   })
 

--- a/src/modules/access/ModuleAccessPrivateKey.vue
+++ b/src/modules/access/ModuleAccessPrivateKey.vue
@@ -36,12 +36,17 @@ import { isPrivateKey } from '@/modules/access/common/helpers'
 import AppInput from '@/components/AppInput.vue'
 import AppNotRecommended from '@/components/AppNotRecommended.vue'
 import { hexToBytes } from 'viem'
+import { walletConfigs } from '@/modules/access/common/walletConfigs'
+import { useRecentWalletsStore } from '@/stores/recentWalletsStore'
 
 const privateKeyInput = ref('')
 
 const walletStore = useWalletStore()
 const router = useRouter()
 const { setWallet } = walletStore
+
+const recentWalletsStore = useRecentWalletsStore()
+const { addWallet } = recentWalletsStore
 
 const submitIsDisabled = computed<boolean>(() => {
   return privateKeyInput.value === '' || !isValidPrivateKey.value
@@ -80,6 +85,7 @@ const unlock = () => {
       '0x1',
     )
     setWallet(wallet)
+    addWallet(walletConfigs.privateKey)
     privateKeyInput.value = ''
     router.push({ path: ROUTES_WALLET.WALLET.PATH })
   } catch (error) {

--- a/src/modules/access/components/wallets_lists/BtnWallet.vue
+++ b/src/modules/access/components/wallets_lists/BtnWallet.vue
@@ -12,6 +12,9 @@
         width="68px"
         class="w-[68px] h-5"
       />
+      <h4 v-if="isRecent" class="text-s-15 font-medium leading-p-150">
+        {{ $t('access_wallet.recent') }}
+      </h4>
       <div class="flex grow item-center justify-end">
         <div v-for="(type, index) in wallet.type" :key="index">
           <img
@@ -55,6 +58,7 @@ import { onMounted, ref } from 'vue'
 
 const props = defineProps<{
   wallet: WalletConfig
+  isRecent?: boolean
 }>()
 
 const emit = defineEmits<{

--- a/src/modules/access/components/wallets_lists/BtnWallet.vue
+++ b/src/modules/access/components/wallets_lists/BtnWallet.vue
@@ -12,9 +12,12 @@
         width="68px"
         class="w-[68px] h-5"
       />
-      <h4 v-if="isRecent" class="text-s-15 font-medium leading-p-150">
+      <h5
+        v-if="isRecent"
+        class="text-s-11 font-bold pl-[5px] leading-p-100 tracking-sp-00"
+      >
         {{ $t('access_wallet.recent') }}
-      </h4>
+      </h5>
       <div class="flex grow item-center justify-end">
         <div v-for="(type, index) in wallet.type" :key="index">
           <img

--- a/src/modules/access/components/wallets_lists/WalletsListDefault.vue
+++ b/src/modules/access/components/wallets_lists/WalletsListDefault.vue
@@ -6,6 +6,15 @@
     <div
       class="grid grid-cols-2 xs:grid-cols-3 sm:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-7 gap-4 md:gap-6"
     >
+      <!-- RECENTLY USED WALLETS -->
+      <btn-wallet
+        v-for="wallet in recentWallets"
+        :key="wallet.id"
+        :wallet="wallet"
+        is-recent
+        @clickWallet="clickDefaultWallet"
+      ></btn-wallet>
+
       <btn-wallet
         v-for="wallet in defaultWallets"
         :key="wallet.id"
@@ -25,6 +34,7 @@
   </div>
 </template>
 <script setup lang="ts">
+import { storeToRefs } from 'pinia'
 import WalletConnectDialog from '../WalletConnectDialog.vue'
 import DontHaveWallet from './DontHaveWallet.vue'
 import {
@@ -33,12 +43,15 @@ import {
 } from '@/modules/access/common/walletConfigs'
 import BtnWallet from './BtnWallet.vue'
 import { useWagmiConnect } from '@/composables/useWagmiConnect'
+import { useRecentWalletsStore } from '@/stores/recentWalletsStore'
 
 const { wagmiWalletData, openWalletConnectModal, connect, clickedWallet } =
   useWagmiConnect()
 
-const keys = Object.keys(walletConfigs) as Array<keyof typeof walletConfigs>
+const recentWalletsStore = useRecentWalletsStore()
+const { recentWallets } = storeToRefs(recentWalletsStore)
 
+const keys = Object.keys(walletConfigs) as Array<keyof typeof walletConfigs>
 const defaultWallets = keys
   .filter(key => {
     return walletConfigs[key].isDefault === true

--- a/src/stores/recentWalletsStore.ts
+++ b/src/stores/recentWalletsStore.ts
@@ -1,0 +1,24 @@
+import { defineStore } from 'pinia'
+import { useLocalStorage } from '@vueuse/core'
+import type { WalletConfig } from '@/modules/access/common/walletConfigs'
+
+export const useRecentWalletsStore = defineStore('useRecentWalletsStore', () => {
+
+  const recentWallets = useLocalStorage<WalletConfig[]>('recentWallets', [], { mergeDefaults: true })
+  const addWallet = (passedWallet: WalletConfig) => {
+    const passedWalletExists = recentWallets.value.find(wallet => wallet.id === passedWallet.id) !== undefined
+    const isOfficial = passedWallet.isOfficial
+
+    if (passedWalletExists || isOfficial) {
+      return
+    }
+    if (recentWallets.value.length < 2) {
+      recentWallets.value.push(passedWallet)
+    } else {
+      recentWallets.value.splice(0, 1); // remove the first element
+      recentWallets.value.push(passedWallet)
+    }
+  }
+
+  return { addWallet, recentWallets }
+})

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -82,6 +82,7 @@ export default {
         's-28': '28px',
         's-17': '17px',
         's-15': '15px',
+        's-11': '11px',
       },
       lineHeight: {
         'p-100': '100%',
@@ -93,6 +94,7 @@ export default {
       },
       letterSpacing: {
         'sp-06': '0.6px',
+        'sp-00': '0px',
       },
       transitionProperty: {
         height: 'height',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a "Recent Wallets" section, displaying up to two recently used, non-official wallets for quick access.
  - Wallets accessed via keystore, mnemonic, private key, or wallet connect are now saved to the recent wallets list.
  - "Recent" label is now shown for recently used wallets in the wallet selection interface.

- **Localization**
  - Added English translation for the "Recent" label in the wallet access interface.

- **Style**
  - Extended Tailwind CSS with new font size and letter spacing utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->