### PR TITLE
Update Rootstock testnet RPC url

### DIFF
--- a/changelog/fix-5152.md
+++ b/changelog/fix-5152.md
@@ -1,0 +1,1 @@
+fix: update rootstock testnet rpc url

--- a/src/utils/networks/nodes/rootstock-testnet-ws.js
+++ b/src/utils/networks/nodes/rootstock-testnet-ws.js
@@ -2,7 +2,7 @@ import { ROOTSTOCKTESTNET } from '../types';
 export default {
   type: ROOTSTOCKTESTNET,
   service: 'RSK Public Testnet Websocket',
-  url: 'wss://public-node.testnet.rsk.co/websocket',
+  url: 'wss://nodes.mewapi.io/ws/rsktest',
   auth: null,
   username: '',
   password: ''


### PR DESCRIPTION
### Devop

This PR updates RPC url for Rootstock testnet.

* \[X] Added entry to ./changelog
* \[ ] Add PR label


### Fix

* \[X] Added entry to ./changelog
* \[ ] Is this a user submitted bug?
  * \[ ] Link to issue:
* \[ ] Add PR label


## Summary by CodeRabbit

- **Chores**
  - Updated the WebSocket URL for the RSK Public Testnet service to improve connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->