### PR TITLE
feat: ✨ hide wagmi wallets when selected network is not evm

### DIFF
--- a/src/composables/useWalletList.ts
+++ b/src/composables/useWalletList.ts
@@ -1,11 +1,15 @@
+import { storeToRefs } from 'pinia';
 import { computed } from 'vue'
 import { type WalletConfig, WalletConfigType, walletConfigs, type defaultWalletId } from '@/modules/access/common/walletConfigs'
 import * as rainbowkitWallets from '@rainbow-me/rainbowkit/wallets'
 import Configs from '@/configs'
+import { useChainsStore } from '@/stores/chainsStore'
 
 export const useWalletList = () => {
   const DEFAULT_IDS = ['enkrypt', 'mew']
   const projectId = Configs.WALLET_CONNECT_PROJECT_ID
+  const chainStore = useChainsStore()
+  const { selectedChain } = storeToRefs(chainStore)
 
   /** -------------------
  * Wallets
@@ -17,6 +21,7 @@ export const useWalletList = () => {
   )
 
   const newWalletList = computed<WalletConfig[]>(() => {
+    if (selectedChain.value && selectedChain.value.type !== 'EVM') return []
     const newConArr: WalletConfig[] = []
     initializedWallets.forEach(wallet => {
       if (!DEFAULT_IDS.includes(wallet.id) && wallet.id !== 'ledger') {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Wallet options are now hidden for non-EVM chains, ensuring that only relevant wallets are displayed based on the selected chain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->