### PR TITLE
Fix transaction gas param before sendTransaction 

### DIFF
--- a/changelog/fix-5266.md
+++ b/changelog/fix-5266.md
@@ -1,0 +1,1 @@
+fix: fix tx gas parameter in send transaction

--- a/src/utils/web3-provider/methods/eth_sendTransaction.js
+++ b/src/utils/web3-provider/methods/eth_sendTransaction.js
@@ -50,7 +50,7 @@ export default async ({ payload, store, requestManager }, res, next) => {
     if (tx.gasLimit) {
       tx.gas = tx.gasLimit;
     }
-    tx.gas = !tx.gas ? await ethCalls.estimateGas(localTx) : tx.gas;
+    tx.gas = !tx.gas || tx.gas === '0x0' ? await ethCalls.estimateGas(localTx) : tx.gas;
     tx.gasLimit = tx.gas;
   } catch (e) {
     res(e);


### PR DESCRIPTION
### Fix

* \[X] Added entry to ./changelog
* \[ ] Is this a user submitted bug?
  * \[ ] Link to issue:
* \[ ] Add PR label

## Description:

When i try to swap RIF -> USDC and click send transaction then i am facing the error: 
```
Missing parameter, gasPrice, gas or value
```

The reason is that gas field in tx payload is coming as 0x0 instead of null and causing `estimateGas` to bypass in the following conditional clause: tx.gas = !tx.gas ? await ethCalls.estimateGas(localTx) : tx.gas;

This pull request fixes this issue by including "0x0" into the conditional clause so that the estimateGas call could trigger. 

### How to reproduce the issue


https://github.com/user-attachments/assets/f80afa01-0d19-451e-9a0a-fe019c4562d8


