### PR TITLE
Feat/v7 trade buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@commitlint/config-conventional": "^20.3.1",
     "@enkryptcom/hw-wallets": "^0.0.16",
     "@enkryptcom/name-resolution": "^0.0.8",
-    "@enkryptcom/swap": "^0.0.9",
+    "@enkryptcom/swap": "^0.0.15",
     "@enkryptcom/types": "^0.0.5",
     "@ethereumjs/common": "^4.4.0",
     "@ethereumjs/tx": "^5.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^0.0.8
         version: 0.0.8(@siddomains/sid-contracts@0.1.31(@nomiclabs/hardhat-web3@2.1.0(hardhat@2.26.3(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.10))(web3@1.10.4(bufferutil@4.1.0)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(ethers@5.8.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(hardhat@2.26.3(bufferutil@4.1.0)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))(typescript@5.9.3)(utf-8-validate@5.0.10))(utf-8-validate@5.0.10)(web3-core-helpers@1.10.4)(web3-core-promievent@1.10.4)(web3-eth-abi@4.4.1(typescript@5.9.3)(zod@3.25.76))(web3-utils@4.3.3))(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@enkryptcom/swap':
-        specifier: ^0.0.9
-        version: 0.0.9(@polkadot/util@14.0.1)(assert@2.1.0)(axios@1.13.3(debug@4.4.1))(bufferutil@4.1.0)(debug@4.4.1)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
+        specifier: ^0.0.15
+        version: 0.0.15(@polkadot/util@14.0.1)(assert@2.1.0)(axios@1.13.3(debug@4.4.1))(bufferutil@4.1.0)(debug@4.4.1)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@enkryptcom/types':
         specifier: ^0.0.5
         version: 0.0.5
@@ -1672,8 +1672,8 @@ packages:
     resolution: {integrity: sha512-pWzSxfmcgqdZQWyfWdowQ2MS9YFNOgW5EVpnAQjGYyKZIjvBLMil1h54n1v67n5qXPA5qr8IjEauffLaUlhkrw==}
     engines: {node: '>=14.15.0'}
 
-  '@enkryptcom/swap@0.0.9':
-    resolution: {integrity: sha512-cOH8DrNdpwhbfUMpcZ5sDn9xbV3nfi7EvjYbnV1GeB4t290tIbQUIpp9ajPZL37oZJ9jogcw7HQucUxJjiyroA==}
+  '@enkryptcom/swap@0.0.15':
+    resolution: {integrity: sha512-hElmyk5ww3n2pWoKo5J+skTkSadJWdDvTP7nHH+G/sMjFGpOe0PNRdEWnOBEAnuYDEH8g+1ZuKUZGmjfm0Sn9w==}
     engines: {node: '>=14.15.0'}
 
   '@enkryptcom/types@0.0.4':
@@ -12841,11 +12841,11 @@ packages:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
 
-  rango-sdk-basic@0.1.72:
-    resolution: {integrity: sha512-J9kevhC6vB6Wr0+EPuQdEHMr4NkaCsrJDhoXlwh0bEkAbDI4pl71meXepm5jjlrK5TTVtcpW3mKeQ6fDWlFFMQ==}
+  rango-sdk-basic@0.1.73:
+    resolution: {integrity: sha512-YMYuPWgrdvnjjXT1ODI1HfVxuPvlQSrgAMkmrsQCOqcZdgIcifJcr4fGCBsIObotARw0quwUmBJWLlE3QOgAIQ==}
 
-  rango-types@0.1.93:
-    resolution: {integrity: sha512-Sek7l5T7QWUMidSSaeSpPid3bK+ii93Vl1QDw4GSYRzoR1mc1EoqLI62OZw1whlogVKF5BtoUsoZ2k8SxWbT1g==}
+  rango-types@0.1.94:
+    resolution: {integrity: sha512-ljeB0XMO7HNPbS+ugPcgyEGWXE9qhUXMBWd8wqK0xg3sk9ofcEv56ggGe7u6wQG5f46EL1IunN9axlrrYORqIA==}
 
   raw-body@2.4.0:
     resolution: {integrity: sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==}
@@ -18245,7 +18245,7 @@ snapshots:
       - encoding
       - utf-8-validate
 
-  '@enkryptcom/swap@0.0.9(@polkadot/util@14.0.1)(assert@2.1.0)(axios@1.13.3(debug@4.4.1))(bufferutil@4.1.0)(debug@4.4.1)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+  '@enkryptcom/swap@0.0.15(@polkadot/util@14.0.1)(assert@2.1.0)(axios@1.13.3(debug@4.4.1))(bufferutil@4.1.0)(debug@4.4.1)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@1inch/fusion-sdk': 2.4.6(assert@2.1.0)(axios@1.13.3(debug@4.4.1))(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@1inch/limit-order-sdk': 5.2.3(assert@2.1.0)(axios@1.13.3(debug@4.4.1))(bufferutil@4.1.0)(utf-8-validate@5.0.10)
@@ -18258,7 +18258,7 @@ snapshots:
       isomorphic-ws: 5.0.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       json-rpc-2.0: 1.7.1
       lodash: 4.17.23
-      rango-sdk-basic: 0.1.72(debug@4.4.1)
+      rango-sdk-basic: 0.1.73(debug@4.4.1)
       reconnecting-websocket: 4.4.0
       uuid: 13.0.0
       web3-eth: 1.10.4
@@ -22438,7 +22438,7 @@ snapshots:
   '@polkadot/keyring@12.6.2(@polkadot/util-crypto@12.6.2(@polkadot/util@12.6.2))(@polkadot/util@12.6.2)':
     dependencies:
       '@polkadot/util': 12.6.2
-      '@polkadot/util-crypto': 12.6.2(@polkadot/util@12.6.2)
+      '@polkadot/util-crypto': 12.6.2(@polkadot/util@14.0.1)
       tslib: 2.8.1
 
   '@polkadot/keyring@14.0.1(@polkadot/util-crypto@14.0.1(@polkadot/util@14.0.1))(@polkadot/util@14.0.1)':
@@ -22564,7 +22564,7 @@ snapshots:
       '@polkadot/types-codec': 11.2.1
       '@polkadot/types-create': 11.2.1
       '@polkadot/util': 12.6.2
-      '@polkadot/util-crypto': 12.6.2(@polkadot/util@12.6.2)
+      '@polkadot/util-crypto': 12.6.2(@polkadot/util@14.0.1)
       rxjs: 7.8.2
       tslib: 2.8.1
 
@@ -34848,15 +34848,15 @@ snapshots:
 
   range-parser@1.2.1: {}
 
-  rango-sdk-basic@0.1.72(debug@4.4.1):
+  rango-sdk-basic@0.1.73(debug@4.4.1):
     dependencies:
       axios: 1.13.3(debug@4.4.1)
-      rango-types: 0.1.93
+      rango-types: 0.1.94
       uuid-random: 1.3.2
     transitivePeerDependencies:
       - debug
 
-  rango-types@0.1.93: {}
+  rango-types@0.1.94: {}
 
   raw-body@2.4.0:
     dependencies:

--- a/src/App.vue
+++ b/src/App.vue
@@ -32,6 +32,7 @@ import { useTimeoutFn } from '@vueuse/core'
 import { usePurchaseStore } from '@/stores/purchaseStore'
 import useBalanceHandler from './utils/balanceHandler'
 import { useStocksStore } from '@/stores/stocksStore'
+import { useSwap } from '@/composables/useSwap'
 
 const dialogStore = useDialogStore()
 const { isAreaHidden } = storeToRefs(dialogStore)
@@ -47,6 +48,7 @@ const store = useWalletStore()
 const { wallet, walletAddress, isWalletConnected, hasMissingBalances } =
   storeToRefs(store)
 const chainStore = useChainsStore()
+const { initSwapper } = useSwap()
 const { selectedChain } = storeToRefs(chainStore)
 const { setTokens, setIsLoadingBalances } = store
 const isLoadingComplete = ref(false)
@@ -151,5 +153,6 @@ onMounted(() => {
     const provider = customEvent.detail
     addProvider(provider)
   })
+  initSwapper()
 })
 </script>

--- a/src/components/AppSelect.vue
+++ b/src/components/AppSelect.vue
@@ -27,7 +27,7 @@
         role="listbox"
         aria-label="Select an option"
         v-show="openSelect"
-        class="absolute top-full focus:outline-none z-[100] pt-2"
+        class="absolute top-full focus:outline-none z-[500] pt-2"
         :class="position"
       >
         <div

--- a/src/composables/useSwap.ts
+++ b/src/composables/useSwap.ts
@@ -72,7 +72,7 @@ export const useSwap = (): {
   const globalStore = useGlobalStore()
   const walletStore = useWalletStore()
   const swapInstance: Ref<Swapper | null> = ref(null)
-  const { selectedChain, allChains } = storeToRefs(chainsStore)
+  const { selectedChain, allChains, swapChains } = storeToRefs(chainsStore)
   const { selectedNetwork } = storeToRefs(globalStore)
   const { tokens, balanceWei, isWalletConnected } = storeToRefs(walletStore)
   const supportedNetwork = ref<boolean>(true)
@@ -161,7 +161,7 @@ export const useSwap = (): {
           if (chain) return chain
         })
         .filter((chain): chain is Chain => chain !== undefined)
-
+      swapChains.value = toChains.value
       const allFromTokensWithBalance = allFromTokens.all.map(token => {
         let tokenBalance = '0'
         let tokenPrice = token.price

--- a/src/composables/useSwap.ts
+++ b/src/composables/useSwap.ts
@@ -72,7 +72,7 @@ export const useSwap = (): {
   const globalStore = useGlobalStore()
   const walletStore = useWalletStore()
   const swapInstance: Ref<Swapper | null> = ref(null)
-  const { selectedChain, chains } = storeToRefs(chainsStore)
+  const { selectedChain, allChains } = storeToRefs(chainsStore)
   const { selectedNetwork } = storeToRefs(globalStore)
   const { tokens, balanceWei, isWalletConnected } = storeToRefs(walletStore)
   const supportedNetwork = ref<boolean>(true)
@@ -157,7 +157,7 @@ export const useSwap = (): {
       toChains.value = toTokensNetworks
         .map(networkName => {
           const chainName = enumToChain[networkName as SupportedNetworkName]
-          const chain = chains.value.find(chain => chain.name === chainName)
+          const chain = allChains.value.find(chain => chain.name === chainName)
           if (chain) return chain
         })
         .filter((chain): chain is Chain => chain !== undefined)

--- a/src/i18n/locales/swap/en.json
+++ b/src/i18n/locales/swap/en.json
@@ -40,6 +40,7 @@
       "minimum-received": "Minimum received",
       "offer-includes": "Offer includes {feePercent}% fee",
       "proceed": "Proceed With Swap",
+      "proceed-bridge": "Proceed With Bridge",
       "decline": "Decline Swap",
       "unknown-provider": "Unknown provider",
       "offers": "Offer | {count} other offers",

--- a/src/modules/crypto/ModuleExploreCrypto.vue
+++ b/src/modules/crypto/ModuleExploreCrypto.vue
@@ -458,8 +458,9 @@
                               </li>
                               <li
                                 v-else-if="
-                                  token.chains.length > 0 ||
-                                  getTokenIsCurrentNative(token)
+                                  currentChainhasSwapSupport &&
+                                  (token.chains.length > 0 ||
+                                    getTokenIsCurrentNative(token))
                                 "
                                 @click.stop="[toggleMenu, swapBtn(token, true)]"
                                 class="p-2 flex items-center hoverBGWhite rounded-12"
@@ -490,8 +491,9 @@
                     </app-base-button>
                     <app-base-button
                       v-else-if="
-                        token.chains.length > 0 ||
-                        getTokenIsCurrentNative(token)
+                        currentChainhasSwapSupport &&
+                        (token.chains.length > 0 ||
+                          getTokenIsCurrentNative(token))
                       "
                       size="small"
                       @click="swapBtn(token)"
@@ -689,8 +691,11 @@ const tableContainer = ref<HTMLElement | null>(null)
 
 const toastStore = useToastStore()
 const chainsStore = useChainsStore()
-const { isLoaded: isLoadedChains, selectedChain: selectedChainStore } =
-  storeToRefs(chainsStore)
+const {
+  isLoaded: isLoadedChains,
+  selectedChain: selectedChainStore,
+  currentChainhasSwapSupport,
+} = storeToRefs(chainsStore)
 const searchInput = ref('')
 const activeSort = ref({ label: '', value: '' })
 const selectedChainFilter = ref<Chain | null>(null)
@@ -775,10 +780,14 @@ const getIsBridgeable = (token: DisplayToken): boolean => {
   const isAvailableOnCurrentChain = token.chains.some(
     c => c.chainName === currentChainName,
   )
+  // Check if any native chain has swap support
+  const hasSwapSupportChain = token.nativeChains.some(c =>
+    chainsStore.chainHasSwapSupport(c.chainName),
+  )
   if (isNativeToken && isNativeToCurrentChain) {
     return false
   }
-  return isNativeToken && !isAvailableOnCurrentChain
+  return isNativeToken && !isAvailableOnCurrentChain && hasSwapSupportChain
 }
 const buyBtn = () => {
   window.open(
@@ -793,9 +802,14 @@ const bridgeBtn = (token: DisplayToken, isMobile = false) => {
       ? selectedChainFilter.value
       : selectedChainStore.value
   ) as Chain
-  const tokenOnChain =
-    token.nativeChains.find(c => c.chainName === selectedChain?.name) ||
-    token.nativeChains[0]
+  // Find the first native chain with swap support
+  const tokenOnChain = token.nativeChains.find(c =>
+    chainsStore.chainHasSwapSupport(c.chainName),
+  )
+
+  if (!tokenOnChain) {
+    return
+  }
 
   const targetToChain =
     chainsStore.allChains.find(c => c.name === tokenOnChain.chainName) ||

--- a/src/modules/crypto/ModuleExploreCrypto.vue
+++ b/src/modules/crypto/ModuleExploreCrypto.vue
@@ -798,7 +798,7 @@ const bridgeBtn = (token: DisplayToken, isMobile = false) => {
     token.nativeChains[0]
 
   const targetToChain =
-    chainsStore.chains.find(c => c.name === tokenOnChain.chainName) ||
+    chainsStore.allChains.find(c => c.name === tokenOnChain.chainName) ||
     selectedChain
   storeSwapValues({
     fromToken: {} as NewTokenInfo,

--- a/src/modules/crypto/ModuleExploreCrypto.vue
+++ b/src/modules/crypto/ModuleExploreCrypto.vue
@@ -411,6 +411,13 @@
                             }}</span>
                           </button>
                           <hr
+                            v-if="
+                              isBuyable(token.coinId) ||
+                              token.ondo !== null ||
+                              getIsBridgeable(token) ||
+                              token.chains.length > 0 ||
+                              getTokenIsCurrentNative(token)
+                            "
                             class="h-px bg-grey-outline border-0 w-full my-2 xs:hidden"
                           />
 
@@ -423,20 +430,44 @@
                               <icon-buy class="text-primary w-4 h-4 mr-2" />
                               <p>Buy</p>
                             </li>
-                            <li
-                              @click.stop="[toggleMenu, swapBtn(token, true)]"
-                              class="p-2 flex items-center hoverBGWhite rounded-12"
-                            >
-                              <icon-swap class="text-primary w-4 h-4 mr-2" />
-                              <p>Swap</p>
-                            </li>
-                            <li
-                              @click.stop="[toggleMenu, bridgeBtn(token, true)]"
-                              class="p-2 flex items-center hoverBGWhite rounded-12"
-                            >
-                              <icon-bridge class="text-primary w-4 h-4 mr-2" />
-                              <p>Bridge</p>
-                            </li>
+                            <template v-if="token.ondo !== null">
+                              <li
+                                @click.stop="[
+                                  tradeBtn(token, true),
+                                  toggleMenu(),
+                                ]"
+                                class="p-2 flex items-center hoverBGWhite rounded-12"
+                              >
+                                <icon-trade class="text-primary w-4 h-4 mr-2" />
+                                <p>Trade</p>
+                              </li>
+                            </template>
+                            <template v-else>
+                              <li
+                                v-if="getIsBridgeable(token)"
+                                @click.stop="[
+                                  toggleMenu,
+                                  bridgeBtn(token, true),
+                                ]"
+                                class="p-2 flex items-center hoverBGWhite rounded-12"
+                              >
+                                <icon-bridge
+                                  class="text-primary w-4 h-4 mr-2"
+                                />
+                                <p>Bridge</p>
+                              </li>
+                              <li
+                                v-else-if="
+                                  token.chains.length > 0 ||
+                                  getTokenIsCurrentNative(token)
+                                "
+                                @click.stop="[toggleMenu, swapBtn(token, true)]"
+                                class="p-2 flex items-center hoverBGWhite rounded-12"
+                              >
+                                <icon-swap class="text-primary w-4 h-4 mr-2" />
+                                <p>Swap</p>
+                              </li>
+                            </template>
                           </ul>
                         </div>
                       </template>
@@ -444,11 +475,30 @@
                   </div>
                   <div class="hidden lg:flex flex-row gap-2 justify-end">
                     <app-base-button
+                      v-if="token.ondo !== null"
+                      size="small"
+                      @click="tradeBtn(token)"
+                      class="min-w-[60px]"
+                      >Trade
+                    </app-base-button>
+                    <app-base-button
+                      v-else-if="getIsBridgeable(token)"
+                      size="small"
+                      @click="bridgeBtn(token)"
+                      class="min-w-[60px]"
+                      >Bridge
+                    </app-base-button>
+                    <app-base-button
+                      v-else-if="
+                        token.chains.length > 0 ||
+                        getTokenIsCurrentNative(token)
+                      "
                       size="small"
                       @click="swapBtn(token)"
                       class="min-w-[60px]"
                       >Swap
                     </app-base-button>
+
                     <app-base-button
                       v-if="isBuyable(token.coinId)"
                       size="small"
@@ -580,6 +630,7 @@ import AppTooltip from '@/components/AppTooltip.vue'
 import IconBuy from '@/assets/icons/core_menu/icon-buy.vue'
 import IconSwap from '@/assets/icons/core_menu/icon-swap.vue'
 import IconBridge from '@/assets/icons/core_menu/icon-bridge.vue'
+import IconTrade from '@/assets/icons/core_menu/icon-trade.vue'
 import {
   StarIcon as StarSolidIcon,
   ChevronDownIcon,
@@ -624,7 +675,7 @@ import { useInputStore } from '@/stores/inputStore'
 import { getAPIPath } from '@/utils/constructAPIPath'
 
 const walletMenu = useWalletMenuStore()
-const { setWalletPanel } = walletMenu
+const { setWalletPanel, setSelectedTradeTokenSymbol } = walletMenu
 const { isOpenSideMenu } = storeToRefs(walletMenu)
 
 const purchaseStore = usePurchaseStore()
@@ -699,6 +750,28 @@ const nextPage = () => {
   tableContainer.value?.scrollTo(0, 0)
 }
 
+/** -------------------------------
+ * Buy/Trade/Swap/Bridge Button Actions
+-------------------------------*/
+
+const getTokenIsCurrentNative = (token: DisplayToken): boolean => {
+  if (!selectedChainStore.value) {
+    return false
+  }
+  const currentChainName = selectedChainStore.value.name
+  return token.nativeChains.some(c => c.chainName === currentChainName)
+}
+const getIsBridgeable = (token: DisplayToken): boolean => {
+  if (!selectedChainStore.value) {
+    return false
+  }
+  const isNativeToken = token.nativeChains.length > 0
+  const currentChainName = selectedChainStore.value.name
+  const hasCurrentChainAsNative = token.nativeChains.some(
+    c => c.chainName === currentChainName,
+  )
+  return isNativeToken && !hasCurrentChainAsNative
+}
 const buyBtn = () => {
   window.open(
     'https://ccswap.myetherwallet.com/',
@@ -721,7 +794,6 @@ const swapBtn = (token: DisplayToken, isMobile = false) => {
       ? selectedChainFilter.value
       : selectedChainStore.value
   ) as Chain
-
   const tokenOnChain =
     token.chains.find(c => c.chainName === selectedChain?.name) ||
     token.chains[0]
@@ -742,6 +814,17 @@ const swapBtn = (token: DisplayToken, isMobile = false) => {
     toChain: targetToChain as Chain,
   })
   setWalletPanel('swap')
+  if (!isOpenSideMenu.value) {
+    walletMenu.setIsOpenSideMenu(true)
+  }
+  if (!isMobile) {
+    goToTokenPage(token)
+  }
+}
+
+const tradeBtn = (token: DisplayToken, isMobile = false) => {
+  setSelectedTradeTokenSymbol(token.symbol)
+  setWalletPanel('trade')
   if (!isOpenSideMenu.value) {
     walletMenu.setIsOpenSideMenu(true)
   }

--- a/src/modules/crypto/ModuleExploreCrypto.vue
+++ b/src/modules/crypto/ModuleExploreCrypto.vue
@@ -478,14 +478,14 @@
                       v-if="token.ondo !== null"
                       size="small"
                       @click="tradeBtn(token)"
-                      class="min-w-[60px]"
+                      class="min-w-[64px]"
                       >Trade
                     </app-base-button>
                     <app-base-button
                       v-else-if="getIsBridgeable(token)"
                       size="small"
                       @click="bridgeBtn(token)"
-                      class="min-w-[60px]"
+                      class="min-w-[64px]"
                       >Bridge
                     </app-base-button>
                     <app-base-button
@@ -495,7 +495,7 @@
                       "
                       size="small"
                       @click="swapBtn(token)"
-                      class="min-w-[60px]"
+                      class="min-w-[64px]"
                       >Swap
                     </app-base-button>
 
@@ -663,6 +663,8 @@ import { useWatchlistStore } from '@/stores/watchlistTableStore'
 import { useFetchWatchlist } from '@/composables/useFetchWatchlist'
 import { type AppSelectOption } from '@/types/components/appSelect'
 import { useWalletMenuStore } from '@/stores/walletMenuStore'
+import { MAIN_TOKEN_CONTRACT } from '@/stores/walletStore'
+
 import { ALL_CHAINS } from '@/components/select_chain/helpers'
 import { useRouter } from 'vue-router'
 import {
@@ -767,10 +769,16 @@ const getIsBridgeable = (token: DisplayToken): boolean => {
   }
   const isNativeToken = token.nativeChains.length > 0
   const currentChainName = selectedChainStore.value.name
-  const hasCurrentChainAsNative = token.nativeChains.some(
+  const isNativeToCurrentChain = token.nativeChains.some(
     c => c.chainName === currentChainName,
   )
-  return isNativeToken && !hasCurrentChainAsNative
+  const isAvailableOnCurrentChain = token.chains.some(
+    c => c.chainName === currentChainName,
+  )
+  if (isNativeToken && isNativeToCurrentChain) {
+    return false
+  }
+  return isNativeToken && !isAvailableOnCurrentChain
 }
 const buyBtn = () => {
   window.open(
@@ -780,6 +788,29 @@ const buyBtn = () => {
   )
 }
 const bridgeBtn = (token: DisplayToken, isMobile = false) => {
+  const selectedChain = (
+    selectedChainFilter.value && selectedChainFilter.value.name !== 'all'
+      ? selectedChainFilter.value
+      : selectedChainStore.value
+  ) as Chain
+  const tokenOnChain =
+    token.nativeChains.find(c => c.chainName === selectedChain?.name) ||
+    token.nativeChains[0]
+
+  const targetToChain =
+    chainsStore.chains.find(c => c.name === tokenOnChain.chainName) ||
+    selectedChain
+  storeSwapValues({
+    fromToken: {} as NewTokenInfo,
+    toToken: {
+      address: MAIN_TOKEN_CONTRACT,
+      symbol: token.symbol,
+      decimals: tokenOnChain?.decimals || 18,
+      name: token.name,
+    } as NewTokenInfo,
+    fromAmount: '',
+    toChain: targetToChain as Chain,
+  })
   setWalletPanel('bridge')
   if (!isOpenSideMenu.value) {
     walletMenu.setIsOpenSideMenu(true)
@@ -794,9 +825,15 @@ const swapBtn = (token: DisplayToken, isMobile = false) => {
       ? selectedChainFilter.value
       : selectedChainStore.value
   ) as Chain
+  const _chains = getTokenIsCurrentNative(token)
+    ? token.nativeChains
+    : token.chains
+  const _address = getTokenIsCurrentNative(token)
+    ? MAIN_TOKEN_CONTRACT
+    : token.chains.find(c => c.chainName === selectedChain?.name)?.address || ''
+
   const tokenOnChain =
-    token.chains.find(c => c.chainName === selectedChain?.name) ||
-    token.chains[0]
+    _chains.find(c => c.chainName === selectedChain?.name) || _chains[0]
 
   const targetToChain =
     chainsStore.chains.find(c => c.name === tokenOnChain.chainName) ||
@@ -805,7 +842,7 @@ const swapBtn = (token: DisplayToken, isMobile = false) => {
   storeSwapValues({
     fromToken: {} as NewTokenInfo,
     toToken: {
-      address: tokenOnChain?.address || '',
+      address: _address,
       symbol: token.symbol,
       decimals: tokenOnChain?.decimals || 18,
       name: token.name,

--- a/src/modules/crypto/ModuleTokenInfo.vue
+++ b/src/modules/crypto/ModuleTokenInfo.vue
@@ -201,17 +201,22 @@ const setSwapWalletStore = () => {
   const currentChainToken = fetchedTokenData.value.supportedChains.find(
     chain => chain.chainName === selectedChain.value?.name,
   )
+  const currentBalance = fetchedTokenData.value.chainBalances?.find(
+    chain => chain.chainName === selectedChain.value?.name,
+  )
   if (
     currentChainToken &&
     currentChainToken.contract &&
-    isInSwapPackage(currentChainToken.chainName)
+    isInSwapPackage(currentChainToken.chainName) &&
+    currentBalance &&
+    currentBalance.result.ok
   ) {
     storeSwapValues({
       fromToken: {} as NewTokenInfo,
       toToken: {
         address: currentChainToken.contract,
         symbol: fetchedTokenData.value.symbol,
-        decimals: 18,
+        decimals: currentBalance.result.value.decimals || 18,
         name: fetchedTokenData.value.name,
       } as NewTokenInfo,
       fromAmount: '',
@@ -237,9 +242,11 @@ const setBridgeValues = (
   const targetToChain = _chain
     ? _chain
     : fetchedTokenData.value.supportedChains.find(
-        chain => chain.chainName !== selectedChain.value?.name,
+        chain =>
+          chain.chainName !== selectedChain.value?.name &&
+          isInSwapPackage(chain.chainName),
       )
-  if (targetToChain && isInSwapPackage(targetToChain.chainName)) {
+  if (targetToChain) {
     const chainInstore = chainsStore.allChains.find(
       c => c.name === targetToChain.chainName,
     )
@@ -247,12 +254,18 @@ const setBridgeValues = (
       return
     }
     const _contract = targetToChain?.contract || MAIN_TOKEN_CONTRACT
+    const chainBalance = fetchedTokenData.value.chainBalances?.find(
+      chain => chain.chainName === targetToChain.chainName,
+    )
+    if (!chainBalance || !chainBalance.result.ok) {
+      return
+    }
     bridgeValues.value = {
       fromToken: {} as NewTokenInfo,
       toToken: {
         address: _contract,
         symbol: fetchedTokenData.value.symbol,
-        decimals: 18,
+        decimals: chainBalance.result.value.decimals || 18,
         name: fetchedTokenData.value.name,
       } as NewTokenInfo,
       fromAmount: '',

--- a/src/modules/crypto/ModuleTokenInfo.vue
+++ b/src/modules/crypto/ModuleTokenInfo.vue
@@ -118,6 +118,8 @@
         :token-symbol="tokenData?.symbol"
         :supported-chains="tokenData?.supportedChains"
         :current-price="tokenData?.currentPrice?.toString() || undefined"
+        :is-stock-view="false"
+        @bridge-to-chain="setBridgeWalletStore"
       />
     </div>
     <!-- Market Data -->
@@ -130,6 +132,8 @@
       :token-symbol="tokenData?.symbol || undefined"
       :supported-chains="tokenData?.supportedChains"
       :token-id="tokenData?.coinId"
+      :is-stock-view="false"
+      @bridge-to-chain="setBridgeWalletStore"
     />
   </div>
 </template>
@@ -145,7 +149,7 @@ import {
   ArrowTrendingDownIcon,
   ArrowTrendingUpIcon,
 } from '@heroicons/vue/24/outline'
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { formatFiatValue } from '@/utils/numberFormatHelper'
 import { useChainsStore } from '@/stores/chainsStore'
 import { storeToRefs } from 'pinia'
@@ -159,9 +163,11 @@ import { useTokenInfoStore } from '@/stores/tokenInfoStore'
 import type { DisplayToken } from '../portfolio/components/balances/TableTokenBalance.vue'
 import { useInputStore } from '@/stores/inputStore'
 import { useWatchlistStore } from '@/stores/watchlistTableStore'
-import type { Chain } from '@/mew_api/types'
+import type { Chain, TokenSupportedChain } from '@/mew_api/types'
 import type { NewTokenInfo } from '@/composables/useSwap'
 import { useRecentlyViewedTokensStore } from '@/stores/recentlyViewedTokensStore'
+import { MAIN_TOKEN_CONTRACT } from '@/stores/walletStore'
+
 const props = defineProps({
   tokenId: {
     type: String,
@@ -176,13 +182,102 @@ const recentlyViewedTokensStore = useRecentlyViewedTokensStore()
  * Wallet Menu Buttons
  --------------------*/
 const walletMenu = useWalletMenuStore()
-const { isOpenSideMenu } = storeToRefs(walletMenu)
+const { isOpenSideMenu, walletPanel } = storeToRefs(walletMenu)
 
 /** --------------------
  * Input Store
  --------------------*/
 const inputStore = useInputStore()
 const { storeSwapValues } = inputStore
+
+const isInSwapPackage = (chainName: string): boolean => {
+  return chainsStore.chainHasSwapSupport(chainName)
+}
+
+const setSwapWalletStore = () => {
+  if (fetchedTokenData.value === null || tokenData.value === null) {
+    return
+  }
+  const currentChainToken = fetchedTokenData.value.supportedChains.find(
+    chain => chain.chainName === selectedChain.value?.name,
+  )
+  if (
+    currentChainToken &&
+    currentChainToken.contract &&
+    isInSwapPackage(currentChainToken.chainName)
+  ) {
+    storeSwapValues({
+      fromToken: {} as NewTokenInfo,
+      toToken: {
+        address: currentChainToken.contract,
+        symbol: fetchedTokenData.value.symbol,
+        decimals: 18,
+        name: fetchedTokenData.value.name,
+      } as NewTokenInfo,
+      fromAmount: '',
+      toChain: selectedChain.value as Chain,
+    })
+  }
+}
+
+interface BridgeValues {
+  fromToken: NewTokenInfo
+  toToken: NewTokenInfo
+  fromAmount: string
+  toChain: Chain
+}
+const bridgeValues = ref<BridgeValues | undefined>(undefined)
+
+const setBridgeValues = (
+  _chain: TokenSupportedChain | undefined = undefined,
+) => {
+  if (fetchedTokenData.value === null || tokenData.value === null) {
+    return
+  }
+  const targetToChain = _chain
+    ? _chain
+    : fetchedTokenData.value.supportedChains.find(
+        chain => chain.chainName !== selectedChain.value?.name,
+      )
+  if (targetToChain && isInSwapPackage(targetToChain.chainName)) {
+    const chainInstore = chainsStore.allChains.find(
+      c => c.name === targetToChain.chainName,
+    )
+    if (!chainInstore) {
+      return
+    }
+    const _contract = targetToChain?.contract || MAIN_TOKEN_CONTRACT
+    bridgeValues.value = {
+      fromToken: {} as NewTokenInfo,
+      toToken: {
+        address: _contract,
+        symbol: fetchedTokenData.value.symbol,
+        decimals: 18,
+        name: fetchedTokenData.value.name,
+      } as NewTokenInfo,
+      fromAmount: '',
+      toChain: chainInstore,
+    }
+  }
+}
+
+const setBridgeWalletStore = (
+  _chain: TokenSupportedChain | undefined = undefined,
+) => {
+  setBridgeValues(_chain)
+  if (bridgeValues.value) {
+    storeSwapValues(bridgeValues.value)
+  }
+  walletMenu.setWalletPanel('bridge')
+}
+
+watch(walletPanel, () => {
+  if (walletPanel.value === 'swap') {
+    setSwapWalletStore()
+  } else if (walletPanel.value === 'bridge') {
+    setBridgeWalletStore()
+  }
+})
 
 /** --------------------
  * Fetch Data
@@ -231,19 +326,10 @@ onFetchResponse(() => {
     isStock: false,
   })
   if (currentChainToken) {
-    storeSwapValues({
-      fromToken: {} as NewTokenInfo,
-      toToken: {
-        address: currentChainToken.contract,
-        symbol: fetchedTokenData.value.symbol,
-        decimals: 18,
-        name: fetchedTokenData.value.name,
-      } as NewTokenInfo,
-      fromAmount: '',
-      toChain: selectedChain.value as Chain,
-    })
+    setSwapWalletStore()
     walletMenu.setWalletPanel('swap')
   } else {
+    setBridgeWalletStore(currentChainToken)
     walletMenu.setWalletPanel('bridge')
   }
   tokenLocalStore.value = fetchedTokenData.value

--- a/src/modules/crypto/components/token_info/TokenInfoBalance.vue
+++ b/src/modules/crypto/components/token_info/TokenInfoBalance.vue
@@ -118,7 +118,12 @@
               <p class="text-info text-s-14 font-medium">${{ i.fiatValue }}</p>
             </div>
           </div>
-          <app-base-button size="small" class="shrink-0 hidden sm:block">
+          <app-base-button
+            v-if="!isStockView && canBridge(i)"
+            size="small"
+            class="shrink-0 hidden sm:block"
+            @click="bridgeBtn(i)"
+          >
             Bridge
           </app-base-button>
         </div>
@@ -180,6 +185,11 @@ const props = defineProps({
     type: String,
     required: false,
   },
+  isStockView: {
+    type: Boolean,
+    required: false,
+    default: false,
+  },
 })
 
 /** --------------------
@@ -193,6 +203,10 @@ const { selectedChain } = storeToRefs(chainsStore)
 
 const walletMenu = useWalletMenuStore()
 const { isOpenSideMenu } = storeToRefs(walletMenu)
+
+const canBridge = (chain: TokenSupportedChain): boolean => {
+  return chainsStore.chainHasSwapSupport(chain.chainName)
+}
 
 /** --------------------
  * Balances
@@ -299,5 +313,12 @@ const getFormattedFiatValueForChain = (balance: string) => {
 }
 const getChainIcon = (chainName: string): string | undefined => {
   return chainsStore.getChainIcon(chainName)
+}
+
+const emit = defineEmits<{
+  bridgeToChain: [chain: TokenSupportedChain]
+}>()
+const bridgeBtn = (chain: TokenSupportedChain) => {
+  emit('bridgeToChain', chain)
 }
 </script>

--- a/src/modules/crypto/components/token_info/TokenInfoSupportedChains.vue
+++ b/src/modules/crypto/components/token_info/TokenInfoSupportedChains.vue
@@ -71,6 +71,14 @@
               current chain
             </span>
           </div>
+          <app-base-button
+            v-else-if="!isStockView && canBridge(i)"
+            size="small"
+            class="shrink-0 hidden sm:block mx-auto"
+            @click="bridgeBtn(i)"
+          >
+            Bridge
+          </app-base-button>
         </div>
       </div>
     </div>
@@ -79,6 +87,7 @@
 
 <script setup lang="ts">
 import AppBtnCopy from '@/components/AppBtnCopy.vue'
+import AppBaseButton from '@/components/AppBaseButton.vue'
 import { type PropType } from 'vue'
 import { useChainsStore } from '@/stores/chainsStore'
 import { storeToRefs } from 'pinia'
@@ -86,6 +95,7 @@ import AppTokenLogo from '@/components/AppTokenLogo.vue'
 import { truncateAddress } from '@/utils/filters'
 import { type TokenSupportedChain } from '@/mew_api/types'
 import { useWalletMenuStore } from '@/stores/walletMenuStore'
+
 const walletMenu = useWalletMenuStore()
 const { isOpenSideMenu } = storeToRefs(walletMenu)
 
@@ -105,8 +115,25 @@ defineProps({
   tokenIconUrl: {
     type: String,
   },
+  isStockView: {
+    type: Boolean,
+    required: false,
+    default: true,
+  },
 })
 
 const chainsStore = useChainsStore()
 const { selectedChain } = storeToRefs(chainsStore)
+
+const emit = defineEmits<{
+  bridgeToChain: [chain: TokenSupportedChain]
+}>()
+
+const bridgeBtn = (chain: TokenSupportedChain) => {
+  emit('bridgeToChain', chain)
+}
+
+const canBridge = (chain: TokenSupportedChain): boolean => {
+  return chainsStore.chainHasSwapSupport(chain.chainName)
+}
 </script>

--- a/src/modules/crypto/components/token_info/TokenInfoSupportedChains.vue
+++ b/src/modules/crypto/components/token_info/TokenInfoSupportedChains.vue
@@ -10,7 +10,7 @@
         <div
           v-for="i in supportedChains"
           :key="i.chainName"
-          class="flex items-center justify-start py-3 -ml-1 pl-1 gap-5"
+          class="flex items-center justify-start py-3 -ml-1 pl-1 gap-5 max-w-[360px]"
         >
           <div class="flex items-center">
             <div class="relative mr-4 shrink-0">
@@ -74,7 +74,7 @@
           <app-base-button
             v-else-if="!isStockView && canBridge(i)"
             size="small"
-            class="shrink-0 hidden sm:block mx-auto"
+            class="shrink-0 hidden sm:block ml-auto"
             @click="bridgeBtn(i)"
           >
             Bridge

--- a/src/modules/portfolio/components/balances/TableTokenBalance.vue
+++ b/src/modules/portfolio/components/balances/TableTokenBalance.vue
@@ -377,20 +377,31 @@
                           <icon-buy class="text-primary w-4 h-4 mr-2" />
                           <p>Buy</p>
                         </li>
-                        <li
-                          @click.stop="[swapBtn(token, true), toggleMenu()]"
-                          class="p-2 flex items-center hoverBGWhite rounded-12"
-                        >
-                          <icon-swap class="text-primary w-4 h-4 mr-2" />
-                          <p>Swap</p>
-                        </li>
-                        <li
-                          @click.stop="[bridgeBtn(token, true), toggleMenu()]"
-                          class="p-2 flex items-center hoverBGWhite rounded-12"
-                        >
-                          <icon-bridge class="text-primary w-4 h-4 mr-2" />
-                          <p>Bridge</p>
-                        </li>
+                        <template v-if="token.ondo !== undefined">
+                          <li
+                            @click.stop="[tradeBtn(token, true), toggleMenu()]"
+                            class="p-2 flex items-center hoverBGWhite rounded-12"
+                          >
+                            <icon-trade class="text-primary w-4 h-4 mr-2" />
+                            <p>Trade</p>
+                          </li>
+                        </template>
+                        <template v-else>
+                          <li
+                            @click.stop="[swapBtn(token, true), toggleMenu()]"
+                            class="p-2 flex items-center hoverBGWhite rounded-12"
+                          >
+                            <icon-swap class="text-primary w-4 h-4 mr-2" />
+                            <p>Swap</p>
+                          </li>
+                          <li
+                            @click.stop="[bridgeBtn(token, true), toggleMenu()]"
+                            class="p-2 flex items-center hoverBGWhite rounded-12"
+                          >
+                            <icon-bridge class="text-primary w-4 h-4 mr-2" />
+                            <p>Bridge</p>
+                          </li>
+                        </template>
                       </ul>
                       <ul v-else>
                         <li
@@ -423,6 +434,14 @@
                 class="hidden lg:flex flex-row gap-2 justify-end"
               >
                 <app-base-button
+                  v-if="token.ondo !== undefined"
+                  size="small"
+                  @click="tradeBtn(token)"
+                  class="min-w-[60px]"
+                  >Trade
+                </app-base-button>
+                <app-base-button
+                  v-else
                   size="small"
                   @click="swapBtn(token)"
                   class="min-w-[60px]"
@@ -586,6 +605,7 @@ import {
 import IconBuy from '@/assets/icons/core_menu/icon-buy.vue'
 import IconSwap from '@/assets/icons/core_menu/icon-swap.vue'
 import IconBridge from '@/assets/icons/core_menu/icon-bridge.vue'
+import IconTrade from '@/assets/icons/core_menu/icon-trade.vue'
 import { StarIcon as StarOutlineIcon } from '@heroicons/vue/24/outline'
 
 // Composables & Utils
@@ -658,7 +678,7 @@ const purchaseStore = usePurchaseStore()
 const { isBuyable } = purchaseStore
 
 const { selectedChain } = storeToRefs(chainStore)
-const { setWalletPanel } = walletMenu
+const { setWalletPanel, setSelectedTradeTokenSymbol } = walletMenu
 const { isOpenSideMenu } = storeToRefs(walletMenu)
 const {
   isWalletConnected,
@@ -1045,6 +1065,13 @@ const swapBtn = (token: DisplayToken, isMobile = false) => {
 
 const bridgeBtn = (token: DisplayToken, isMobile = false) => {
   setWalletPanel('bridge')
+  if (!isOpenSideMenu.value) walletMenu.setIsOpenSideMenu(true)
+  if (!isMobile) goToTokenPage(token)
+}
+
+const tradeBtn = (token: DisplayToken, isMobile = false) => {
+  setSelectedTradeTokenSymbol(token.symbol)
+  setWalletPanel('trade')
   if (!isOpenSideMenu.value) walletMenu.setIsOpenSideMenu(true)
   if (!isMobile) goToTokenPage(token)
 }

--- a/src/modules/portfolio/components/balances/TableTokenBalance.vue
+++ b/src/modules/portfolio/components/balances/TableTokenBalance.vue
@@ -365,6 +365,12 @@
                         }}</span>
                       </button>
                       <hr
+                        v-if="
+                          props.view === 'custom' ||
+                          isBuyable(token.coinId) ||
+                          token.ondo !== undefined ||
+                          currentChainhasSwapSupport
+                        "
                         class="h-px bg-grey-outline border-0 w-full my-2 xs:hidden"
                       />
 
@@ -386,20 +392,13 @@
                             <p>Trade</p>
                           </li>
                         </template>
-                        <template v-else>
+                        <template v-else-if="currentChainhasSwapSupport">
                           <li
                             @click.stop="[swapBtn(token, true), toggleMenu()]"
                             class="p-2 flex items-center hoverBGWhite rounded-12"
                           >
                             <icon-swap class="text-primary w-4 h-4 mr-2" />
                             <p>Swap</p>
-                          </li>
-                          <li
-                            @click.stop="[bridgeBtn(token, true), toggleMenu()]"
-                            class="p-2 flex items-center hoverBGWhite rounded-12"
-                          >
-                            <icon-bridge class="text-primary w-4 h-4 mr-2" />
-                            <p>Bridge</p>
                           </li>
                         </template>
                       </ul>
@@ -441,7 +440,7 @@
                   >Trade
                 </app-base-button>
                 <app-base-button
-                  v-else
+                  v-else-if="currentChainhasSwapSupport"
                   size="small"
                   @click="swapBtn(token)"
                   class="min-w-[60px]"
@@ -604,7 +603,6 @@ import {
 } from '@heroicons/vue/24/solid'
 import IconBuy from '@/assets/icons/core_menu/icon-buy.vue'
 import IconSwap from '@/assets/icons/core_menu/icon-swap.vue'
-import IconBridge from '@/assets/icons/core_menu/icon-bridge.vue'
 import IconTrade from '@/assets/icons/core_menu/icon-trade.vue'
 import { StarIcon as StarOutlineIcon } from '@heroicons/vue/24/outline'
 
@@ -677,7 +675,7 @@ const tokenInfoStore = useTokenInfoStore()
 const purchaseStore = usePurchaseStore()
 const { isBuyable } = purchaseStore
 
-const { selectedChain } = storeToRefs(chainStore)
+const { selectedChain, currentChainhasSwapSupport } = storeToRefs(chainStore)
 const { setWalletPanel, setSelectedTradeTokenSymbol } = walletMenu
 const { isOpenSideMenu } = storeToRefs(walletMenu)
 const {
@@ -1059,12 +1057,6 @@ const customTokenAction = (action: 'delete' | 'edit', token: TokenBalance) => {
 
 const swapBtn = (token: DisplayToken, isMobile = false) => {
   setWalletPanel('swap')
-  if (!isOpenSideMenu.value) walletMenu.setIsOpenSideMenu(true)
-  if (!isMobile) goToTokenPage(token)
-}
-
-const bridgeBtn = (token: DisplayToken, isMobile = false) => {
-  setWalletPanel('bridge')
   if (!isOpenSideMenu.value) walletMenu.setIsOpenSideMenu(true)
   if (!isMobile) goToTokenPage(token)
 }

--- a/src/modules/stocks/ModuleAllStock.vue
+++ b/src/modules/stocks/ModuleAllStock.vue
@@ -383,18 +383,11 @@
 
                           <ul>
                             <li
-                              @click.stop="[toggleMenu, swapBtn(token, true)]"
+                              @click.stop="[toggleMenu, tradeBtn(token, true)]"
                               class="p-2 flex items-center hoverBGWhite rounded-12"
                             >
-                              <icon-swap class="text-primary w-4 h-4 mr-2" />
-                              <p>Swap</p>
-                            </li>
-                            <li
-                              @click.stop="[toggleMenu, bridgeBtn(token, true)]"
-                              class="p-2 flex items-center hoverBGWhite rounded-12"
-                            >
-                              <icon-bridge class="text-primary w-4 h-4 mr-2" />
-                              <p>Bridge</p>
+                              <icon-trade class="text-primary w-4 h-4 mr-2" />
+                              <p>Trade</p>
                             </li>
                           </ul>
                         </div>
@@ -404,8 +397,8 @@
                   <div
                     class="hidden lg:flex flex-row gap-1 justify-end flex-wrap"
                   >
-                    <app-base-button size="small" @click="swapBtn(token)"
-                      >Swap
+                    <app-base-button size="small" @click="tradeBtn(token)"
+                      >Trade
                     </app-base-button>
                   </div>
                 </td>
@@ -520,8 +513,7 @@ import AppBtnGroup from '@/components/AppBtnGroup.vue'
 import AppTokenLogo from '@/components/AppTokenLogo.vue'
 import AppTokenSymbol from '@/components/AppTokenSymbol.vue'
 import AppPopUpMenu from '@/components/AppPopUpMenu.vue'
-import IconSwap from '@/assets/icons/core_menu/icon-swap.vue'
-import IconBridge from '@/assets/icons/core_menu/icon-bridge.vue'
+import IconTrade from '@/assets/icons/core_menu/icon-trade.vue'
 import {
   StarIcon as StarSolidIcon,
   ChevronDownIcon,
@@ -562,7 +554,7 @@ import { useRouter } from 'vue-router'
 import { STOCK_INFO_ROUTE_NAMES } from '@/router/routeNames'
 
 const walletMenu = useWalletMenuStore()
-const { setWalletPanel } = walletMenu
+const { setWalletPanel, setSelectedTradeTokenSymbol } = walletMenu
 const { isOpenSideMenu } = storeToRefs(walletMenu)
 
 const tableContainer = ref<HTMLElement | null>(null)
@@ -636,17 +628,9 @@ const nextPage = () => {
   tableContainer.value?.scrollTo(0, 0)
 }
 
-const bridgeBtn = (token: DisplayToken, isMobile = false) => {
-  setWalletPanel('bridge')
-  if (!isOpenSideMenu.value) {
-    walletMenu.setIsOpenSideMenu(true)
-  }
-  if (!isMobile) {
-    goToTokenPage(token)
-  }
-}
-const swapBtn = (token: DisplayToken, isMobile = false) => {
-  setWalletPanel('swap')
+const tradeBtn = (token: DisplayToken, isMobile = false) => {
+  setSelectedTradeTokenSymbol(token.symbol)
+  setWalletPanel('trade')
   if (!isOpenSideMenu.value) {
     walletMenu.setIsOpenSideMenu(true)
   }

--- a/src/modules/stocks/ModuleAllStock.vue
+++ b/src/modules/stocks/ModuleAllStock.vue
@@ -383,7 +383,10 @@
 
                           <ul>
                             <li
-                              @click.stop="[toggleMenu, tradeBtn(token, true)]"
+                              @click.stop="[
+                                toggleMenu(),
+                                tradeBtn(token, true),
+                              ]"
                               class="p-2 flex items-center hoverBGWhite rounded-12"
                             >
                               <icon-trade class="text-primary w-4 h-4 mr-2" />

--- a/src/modules/swap/ModuleSwap.vue
+++ b/src/modules/swap/ModuleSwap.vue
@@ -141,7 +141,7 @@
         :disabled="isSwapDisabled"
         @click="swapButton"
       >
-        {{ t('common.swap') }}</app-base-button
+        {{ isSwapView ? 'Swap' : 'Bridge' }}</app-base-button
       >
       <div :class="['mx-auto w-full max-w-[340px]', blurClass]" v-else>
         <app-base-button class="w-full" @click="connectWalletForSwap">

--- a/src/modules/swap/ModuleSwap.vue
+++ b/src/modules/swap/ModuleSwap.vue
@@ -484,7 +484,7 @@ const validateToAddress = async () => {
     return
   }
   const valid = await toTokenSelected.value?.networkInfo.isAddress(
-    userToAddress.value.toLowerCase(),
+    userToAddress.value,
   )
   toAddressError.value = valid ? '' : 'invalid address'
 }

--- a/src/modules/swap/ModuleSwap.vue
+++ b/src/modules/swap/ModuleSwap.vue
@@ -417,6 +417,10 @@ const fromAmountError = computed(() => {
 })
 
 const toAmountError = computed(() => {
+  // In bridge mode, if toAddress is missing, don't show "no quotes" — the address input handles it
+  if (isCrossChain.value && !toAddress.value) {
+    return ''
+  }
   if (
     !isLoading.value &&
     providers.value.length === 0 &&
@@ -480,7 +484,7 @@ const clearValues = () => {
 
 const validateToAddress = async () => {
   if (!userToAddress.value) {
-    toAddressError.value = 'address is required'
+    toAddressError.value = 'Recipient address is required for bridging'
     return
   }
   const valid = await toTokenSelected.value?.networkInfo.isAddress(
@@ -944,7 +948,11 @@ watch(
       !BigNumber(fromAmount.value).isZero() &&
       toTokenSelected.value
     ) {
-      if (isCrossChain.value && !toAddress.value) return
+      if (isCrossChain.value && !toAddress.value) {
+        // Highlight the missing address instead of silently returning
+        toAddressError.value = 'Recipient address is required for bridging'
+        return
+      }
       debounceFetchQuotes()
     }
   },

--- a/src/modules/swap/ModuleSwap.vue
+++ b/src/modules/swap/ModuleSwap.vue
@@ -63,7 +63,10 @@
               :can-store="false"
               :passed-chains="toChains"
               :preselected-chain="selectedToChain"
-              :class="{ hidden: isSwapView }"
+              :class="{
+                hidden:
+                  isSwapView && selectedChain?.name === selectedToChain?.name,
+              }"
               @update:selected-chain="setToChain"
             />
             <app-swap-enter-amount

--- a/src/modules/swap/components/SwapInitiatedModal.vue
+++ b/src/modules/swap/components/SwapInitiatedModal.vue
@@ -18,7 +18,7 @@
               />
               <a
                 v-if="isBridge && toChain?.blockExplorerAddr"
-                :href="`${toChain.blockExplorerAddr}${props.toAddress}`"
+                :href="addressExplorerUrl"
                 target="_blank"
                 rel="noopener noreferrer"
                 class="hover:underline cursor-pointer font-mono text-black text-s-13 lg:text-s-16 pr-1"
@@ -414,6 +414,13 @@ const blockExplorerUrl = computed(() => {
   )
 })
 
+const addressExplorerUrl = computed(() => {
+  return (
+    props.toChain?.blockExplorerAddr.replace('[[address]]', props.toAddress) ||
+    ''
+  )
+})
+
 const isBridge = computed(() => {
   const fromChainId = props.fromChain?.chainID
   const toChainId = props.toChain?.chainID
@@ -454,8 +461,8 @@ watch(
 
       if (fromChain && toChain) {
         const createdAt = Math.floor(Date.now() / 1000)
-        const hashLink = `${fromChain.blockExplorerTX.replace('[[txHash]]', props.txHash)}`
-        const addressLink = `${toChain.blockExplorerAddr.replace('[[address]]', props.toAddress)}`
+        const hashLink = blockExplorerUrl.value
+        const addressLink = addressExplorerUrl.value
         const shared: NotificationBaseSwapBridge = {
           status: 'sent',
           hash: props.txHash,

--- a/src/modules/swap/components/SwapInitiatedModal.vue
+++ b/src/modules/swap/components/SwapInitiatedModal.vue
@@ -7,34 +7,36 @@
     <template #content>
       <div class="px-4 lg:px-6 pb-8 pt-2">
         <div class="flex flex-col items-center text-center">
-          <p class="text-s-13 lg:text-s-16 text-info px-4 leading-p-160">
+          <div class="text-s-13 lg:text-s-16 text-info px-4 leading-p-160">
             {{ completedNote }}
-            <app-blockie
-              v-if="isBridge"
-              :address="props.toAddress"
-              :size="5"
-              class="inline-block mx-2 align-middle"
-            />
-            <a
-              v-if="isBridge && toChain?.blockExplorerAddr"
-              :href="`${toChain.blockExplorerAddr}${props.toAddress}`"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="hover:underline cursor-pointer font-mono text-black text-s-14 pr-1"
-            >
-              {{ truncateHash(props.toAddress) }}
-              <arrow-up-right-icon
-                class="w-3 h-3 inline-block align-middle text-black"
-            /></a>
+            <div class="inline-flex align-middle">
+              <app-blockie
+                v-if="isBridge"
+                :address="props.toAddress"
+                :size="5"
+                class="inline-block mx-2 align-middle"
+              />
+              <a
+                v-if="isBridge && toChain?.blockExplorerAddr"
+                :href="`${toChain.blockExplorerAddr}${props.toAddress}`"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="hover:underline cursor-pointer font-mono text-black text-s-13 lg:text-s-16 pr-1"
+              >
+                {{ truncateHash(props.toAddress) }}
+                <arrow-up-right-icon
+                  class="w-3 h-3 inline-block align-middle text-black"
+              /></a>
+            </div>
             <span
               v-if="isBridge && !toChain?.blockExplorerAddr"
-              class="font-mono text-s-14"
+              class="font-mono text-s-13 lg:text-s-16"
             >
               {{ truncateHash(props.toAddress) }}
             </span>
 
             on {{ toTokenChain }}
-          </p>
+          </div>
 
           <div class="flex flex-col gap-0 w-full mt-4 lg:mt-8">
             <!-- Progress -->

--- a/src/modules/swap/components/SwapOfferModal.vue
+++ b/src/modules/swap/components/SwapOfferModal.vue
@@ -1,7 +1,7 @@
 <template>
   <app-dialog
     v-model:is-open="model"
-    title="Swap"
+    :title="title"
     class="lg:min-h-[614px] xs:min-w-[450px]"
   >
     <template #content>
@@ -264,7 +264,7 @@
           :is-loading="loadingModel"
           :disabled="!!gasFeeError"
         >
-          {{ t('swap.swap-offer.proceed') }}
+          {{ btnText }}
         </app-base-button>
         <app-btn-text
           class="mx-auto w-full mt-2 text-error"
@@ -389,6 +389,21 @@ const getProviderDisplayName = (name: string) => {
       return t('swap.swap-offer.unknown-provider')
   }
 }
+
+const isBridge = computed(() => {
+  if (!props.fromChain || !props.toChain) return false
+  return props.fromChain.name !== props.toChain.name
+})
+
+const title = computed(() => {
+  return isBridge.value ? 'Bridge' : 'Swap'
+})
+
+const btnText = computed(() => {
+  return isBridge.value
+    ? t('swap.swap-offer.proceed-bridge')
+    : t('swap.swap-offer.proceed')
+})
 
 const setItem = (item: ProviderQuoteResponse, close: () => void) => {
   selectedQuote.value = item

--- a/src/stores/chainsStore.ts
+++ b/src/stores/chainsStore.ts
@@ -7,6 +7,7 @@ export const useChainsStore = defineStore('chainsStore', () => {
   const globalStore = useGlobalStore()
   const { selectedNetwork } = storeToRefs(globalStore)
   const chains = ref<Chain[]>([])
+  const allChains = ref<Chain[]>([])
   const isLoaded = ref(false)
 
   const selectedChain = computed<Chain | undefined>(() => {
@@ -17,6 +18,7 @@ export const useChainsStore = defineStore('chainsStore', () => {
 
   const setChainData = (_chains: Chain[]) => {
     chains.value = _chains.filter(chain => chain.type !== 'SOLANA')
+    allChains.value = _chains
     if (_chains.length > 0) {
       isLoaded.value = true
     }
@@ -40,6 +42,7 @@ export const useChainsStore = defineStore('chainsStore', () => {
 
   return {
     chains,
+    allChains,
     isLoaded,
     setChainData,
     getChainIcon,

--- a/src/stores/chainsStore.ts
+++ b/src/stores/chainsStore.ts
@@ -8,6 +8,7 @@ export const useChainsStore = defineStore('chainsStore', () => {
   const { selectedNetwork } = storeToRefs(globalStore)
   const chains = ref<Chain[]>([])
   const allChains = ref<Chain[]>([])
+  const swapChains = ref<Chain[]>([])
   const isLoaded = ref(false)
 
   const selectedChain = computed<Chain | undefined>(() => {
@@ -40,9 +41,20 @@ export const useChainsStore = defineStore('chainsStore', () => {
     return selectedChain.value?.type === 'SOLANA'
   })
 
+  const chainHasSwapSupport = (chainName: string): boolean => {
+    return swapChains.value.some(chain => chain.name === chainName)
+  }
+  const currentChainhasSwapSupport = computed(() => {
+    if (!selectedChain.value) return false
+    return swapChains.value.some(
+      chain => chain.name === selectedChain.value?.name,
+    )
+  })
+
   return {
     chains,
     allChains,
+    swapChains,
     isLoaded,
     setChainData,
     getChainIcon,
@@ -50,5 +62,7 @@ export const useChainsStore = defineStore('chainsStore', () => {
     isBitcoinChain,
     isEvmChain,
     isSolChain,
+    chainHasSwapSupport,
+    currentChainhasSwapSupport,
   }
 })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Trade action for Ondo-marked tokens, plus a Bridge option where supported; actions appear in menus and header buttons.

* **Improvements**
  * Action buttons now pick Trade, Bridge, or Swap based on token and chain context; Trade pre-fills the trade panel and opens wallet side panel.
  * Swap UI shows "Swap" or "Bridge" dynamically; swapper initialization added for faster availability.
  * Bridge option added to token balance and supported-chains views; localization added for bridge CTA.

* **Dependencies**
  * Updated @enkryptcom/swap to ^0.0.15.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->