### PR TITLE
fix: 🐛 incorrect link trading changed

### DIFF
--- a/src/modules/trade/providers/ondoHelpers.ts
+++ b/src/modules/trade/providers/ondoHelpers.ts
@@ -4,7 +4,7 @@ import { getAPIPath } from '@/utils/constructAPIPath'
 import { throttle } from 'underscore'
 
 const TRADING_RESTRICTED_HELP_URL =
-  'https://help.myetherwallet.com/en/articles/12897302-geographic-restrictions-for-mew'
+  'https://help.myetherwallet.com/en/articles/13641432-restrictions-on-tokenized-stock-trading-in-mew'
 
 const _getMarketStatus = (): Promise<GetWebSwapOndoMarketStatusResponse> => {
   return fetch(getAPIPath(`/v1/web/swap/ondo/status/market`)).then(


### PR DESCRIPTION
### Fix

Updated the "Learn more" link in the trading restrictions banner to point to the correct help article.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated help resource URL for trading restrictions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->