### PR TITLE
fix: 🐛 error access using unisat wallet

### DIFF
--- a/src/modules/access/composables/useConnectWallet.ts
+++ b/src/modules/access/composables/useConnectWallet.ts
@@ -7,6 +7,7 @@ import { useRecentWalletsStore } from '@/stores/recentWalletsStore'
 import {
   type WalletConfig,
   WalletConfigType,
+  walletConfigs,
 } from '@/modules/access/common/walletConfigs'
 import { useProviderStore } from '@/stores/providerStore'
 import { storeToRefs } from 'pinia'
@@ -124,6 +125,19 @@ export const useConnectWallet = () => {
     )
 
     if (!providerInjected) {
+      // Check if wallet supports the selected network, if not auto-switch to a supported one
+      const originalConfig = walletConfigs[wallet.id as keyof typeof walletConfigs]
+      const canSupport = originalConfig?.canSupport ?? wallet.canSupport
+      if (canSupport && selectedChain.value && !canSupport(selectedChain.value)) {
+        // Find a supported network and switch to it
+        const supportedChain = chains.value.find(chain => canSupport(chain))
+        if (supportedChain) {
+          accessStore.setSelectedChain(supportedChain)
+          // Re-call _connectWeb3 with the new chain
+          _connectWeb3(wallet)
+          return
+        }
+      }
       if (wallet.type.includes(WalletConfigType.MOBILE)) {
         // open wallet connect modal if it is also a mobile wallet and extension instance not found
         _connectWagmi(wallet)


### PR DESCRIPTION
### Fix

Description

When connecting a wallet that doesn't support the currently selected network (e.g., UniSat with Ethereum selected), the app now automatically switches to a compatible network (Bitcoin) instead of showing an error.

Changes

•  Auto-detect when wallet doesn't support selected network
•  Automatically switch to a supported network and proceed with connection


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet-connection validation: if a wallet doesn't support the currently selected network, the app will automatically switch to a supported network and retry connecting, and will prevent connections to unsupported networks earlier in the flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->