### PR TITLE
fix: 🐛 ui swap initiated pop copy hash

### DIFF
--- a/src/components/AppBtnCopy.vue
+++ b/src/components/AppBtnCopy.vue
@@ -76,7 +76,7 @@ const copyClick = async (payload: MouseEvent) => {
     await navigator.clipboard.writeText(props.copyValue)
     toastStore.addToastMessage({
       text: `${t('common.copied_to_clipboard')}`,
-      textSecondary: props.copyValue,
+      hash: props.copyValue,
     })
     emit('copy', payload)
   } catch {


### PR DESCRIPTION
### Fix

Fixed toast UI overflow when copying hashes/addresses. Changed textSecondary to hash property in AppBtnCopy.vue which applies break-all styling to properly wrap long hex strings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal data handling for copy notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->