### PR TITLE
fix: 🐛 white screen when paste fixed

### DIFF
--- a/src/modules/swap/ModuleSwap.vue
+++ b/src/modules/swap/ModuleSwap.vue
@@ -392,7 +392,12 @@ const toLoadingState = computed(() => isLoading.value)
 const fromLoadingState = computed(() => !swapLoaded.value)
 
 const fromAmountError = computed(() => {
-  if (!fromAmount.value || fromAmount.value === '0' || fromAmount.value === '')
+  if (
+    !fromAmount.value ||
+    fromAmount.value === '0' ||
+    fromAmount.value === '' ||
+    BigNumber(fromAmount.value).isNaN()
+  )
     return t('swap.error.amount-required')
 
   if (!fromTokenSelected.value) return ''
@@ -1055,6 +1060,11 @@ watch(
         return
       }
       debounceFetchQuotes()
+    } else {
+      // Clear stale quotes when amount becomes invalid
+      providers.value = []
+      selectedQuote.value = undefined
+      toAmount.value = '0'
     }
   },
 )


### PR DESCRIPTION
### Fix

Added BigNumber(fromAmount.value).isNaN() check in fromAmountError computed to prevent white screen crash when pasting or typing invalid values (like . or random strings) in the Swap amount input. Also clears stale quotes when the amount becomes invalid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved swap input validation to properly reject non-numeric values
  * Enhanced quote caching to clear outdated quotes when input becomes invalid, ensuring more accurate swap operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->