### PR TITLE
fix: 🐛 truncate amounts to 4 decimals with tooltip in TradeInitiatedM…

### DIFF
--- a/src/modules/trade/components/TradeInitiatedModal.vue
+++ b/src/modules/trade/components/TradeInitiatedModal.vue
@@ -88,9 +88,9 @@
                 </div>
                 <div class="flex flex-col text-left">
                   <p
-                    class="text-s-16 lg:text-s-20 font-bold leading-tight flex items-center gap-1"
+                    class="text-s-16 lg:text-s-20 font-bold leading-tight flex items-center gap-1 flex-wrap"
                   >
-                    {{ fromAmount }}
+                    {{ fromAmountFormatted.value }}
                     <app-token-symbol
                       :symbol="fromToken?.symbol || 'UNKNOWN'"
                       :address="
@@ -103,6 +103,11 @@
                       "
                       class="!text-s-16 lg:!text-s-20 !font-bold"
                     />
+                    <app-tooltip
+                      v-if="fromAmountFormatted.tooltipText"
+                      :text="fromAmountFormatted.tooltipText"
+                    >
+                    </app-tooltip>
                   </p>
                   <p class="text-info text-s-14">${{ fromAmountFiat }}</p>
                 </div>
@@ -130,9 +135,9 @@
                 </div>
                 <div class="flex flex-col text-left">
                   <p
-                    class="text-s-16 lg:text-s-20 font-bold leading-tight flex items-center gap-1"
+                    class="text-s-16 lg:text-s-20 font-bold leading-tight flex items-center gap-1 flex-wrap"
                   >
-                    {{ toAmount }}
+                    {{ toAmountFormatted.value }}
                     <app-token-symbol
                       :symbol="toToken?.symbol || 'UNKNOWN'"
                       :address="
@@ -145,6 +150,11 @@
                       "
                       class="!text-s-16 lg:!text-s-20 !font-bold"
                     />
+                    <app-tooltip
+                      v-if="toAmountFormatted.tooltipText"
+                      :text="toAmountFormatted.tooltipText"
+                    >
+                    </app-tooltip>
                   </p>
                   <p class="text-info text-s-14">${{ toAmountFiat }}</p>
                 </div>
@@ -213,6 +223,7 @@ import AppBaseButton from '@/components/AppBaseButton.vue'
 import AppBtnCopy from '@/components/AppBtnCopy.vue'
 import AppTokenLogo from '@/components/AppTokenLogo.vue'
 import AppTokenSymbol from '@/components/AppTokenSymbol.vue'
+import AppTooltip from '@/components/AppTooltip.vue'
 import {
   CheckCircleIcon,
   XCircleIcon,
@@ -224,7 +235,10 @@ import { useWalletStore } from '@/stores/walletStore'
 import { useAppLayoutStore } from '@/stores/appLayoutStore'
 import { useTradeOrdersStore } from '@/stores/tradeOrdersStore'
 import BigNumber from 'bignumber.js'
-import { formatFiatValue } from '@/utils/numberFormatHelper'
+import {
+  formatFiatValue,
+  formatFloatingPointValue,
+} from '@/utils/numberFormatHelper'
 
 const model = defineModel<boolean>('isOpen', { default: false })
 
@@ -253,6 +267,15 @@ const truncatedHash = computed(() => {
   if (!props.orderHash) return ''
   if (props.orderHash.length <= 16) return props.orderHash
   return `${props.orderHash.slice(0, 8)}...${props.orderHash.slice(-8)}`
+})
+
+// Formatted amounts using formatFloatingPointValue helper
+const fromAmountFormatted = computed(() => {
+  return formatFloatingPointValue(props.fromAmount ?? '0')
+})
+
+const toAmountFormatted = computed(() => {
+  return formatFloatingPointValue(props.toAmount ?? '0')
 })
 
 // Fiat values


### PR DESCRIPTION
### Fix

description

Truncate fromAmount and toAmount to 4 decimal places in TradeInitiatedModal.vue to prevent text overflow. Shows full value in tooltip on hover when truncated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added intelligent amount formatting with hoverable tooltips showing full-precision values when displayed amounts are truncated.
  * Improved layout and wrapping for numeric content in amount display sections to prevent overflow and maintain readability.
  * Enhanced presentation for both source and destination amounts, preserving fiat display while providing full-value access via tooltips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->