### PR TITLE
fix: 🐛 white screen when paste fixed

### DIFF
--- a/src/modules/swap/ModuleSwap.vue
+++ b/src/modules/swap/ModuleSwap.vue
@@ -392,7 +392,12 @@ const toLoadingState = computed(() => isLoading.value)
 const fromLoadingState = computed(() => !swapLoaded.value)
 
 const fromAmountError = computed(() => {
-  if (!fromAmount.value || fromAmount.value === '0' || fromAmount.value === '')
+  if (
+    !fromAmount.value ||
+    fromAmount.value === '0' ||
+    fromAmount.value === '' ||
+    BigNumber(fromAmount.value).isNaN()
+  )
     return t('swap.error.amount-required')
 
   if (!fromTokenSelected.value) return ''
@@ -1055,6 +1060,11 @@ watch(
         return
       }
       debounceFetchQuotes()
+    } else {
+      // Clear stale quotes when amount becomes invalid
+      providers.value = []
+      selectedQuote.value = undefined
+      toAmount.value = ''
     }
   },
 )


### PR DESCRIPTION
### Fix

Truncate fromAmount and toAmount to 4 decimal places in TradeInitiatedModal.vue to prevent text overflow. Shows full value in tooltip on hover when truncated. Follows the same pattern used in SwapOfferModal.vue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation to correctly treat non-numeric amount inputs as invalid, preventing them from proceeding.
  * Prevented stale quote information from displaying when the amount is cleared or becomes invalid; quotes and selections are cleared and the displayed converted amount resets to avoid misleading results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->