### PR TITLE
fix: 🐛 reset pagination to page 1 when changing category or items per…

### DIFF
--- a/src/modules/crypto/ModuleExploreCrypto.vue
+++ b/src/modules/crypto/ModuleExploreCrypto.vue
@@ -558,8 +558,9 @@
           class="flex flex-col xs:flex-row items-center justify-between text-s-14 mt-4 border-t border-grey-5 pt-4 px-2"
         >
           <div
-            v-if="!isLoading && selectedCryptoFilter.value !== 'watchlist'"
+            v-if="selectedCryptoFilter.value !== 'watchlist'"
             class="text-info order-3 xs:order-1 mb-4 xs:mb-0"
+            :class="isLoading ? 'invisible' : 'visible'"
           >
             {{ getCurrentViewableItemsIndex }} of {{ totalTokenCount }} results
           </div>
@@ -575,10 +576,10 @@
               <ChevronLeftIcon class="w-4 h-4" />
             </app-btn-icon>
 
-            <div class="flex items-center gap-2">
-              <span class="text-black">{{ page }}</span>
+            <div class="flex items-center justify-center gap-2 min-w-[70px]">
+              <span class="text-black tabular-nums">{{ page }}</span>
               <span class="text-info">of</span>
-              <span class="text-info">{{ totalPages }}</span>
+              <span class="text-info tabular-nums">{{ totalPages }}</span>
             </div>
             <app-btn-icon
               :disabled="!isLoading && page >= totalPages"
@@ -1192,6 +1193,14 @@ watch(
     } else {
       debounceFetchTokens()
     }
+  },
+)
+
+// Reset page to 1 when filter or items per page changes
+watch(
+  () => [selectedCryptoFilter.value, shownItems.value],
+  () => {
+    page.value = 1
   },
 )
 

--- a/src/modules/stocks/ModuleAllStock.vue
+++ b/src/modules/stocks/ModuleAllStock.vue
@@ -448,8 +448,8 @@
           class="flex flex-col xs:flex-row items-center justify-between text-s-14 mt-4 border-t border-grey-5 pt-4 px-2"
         >
           <div
-            v-if="!isLoading"
             class="!text-s-12 xs:!text-s-14 text-info order-2 xs:order-1 mb-4 xs:mb-0"
+            :class="isLoading ? 'invisible' : 'visible'"
           >
             {{ getCurrentViewableItemsIndex }} of {{ totalTokenCount }} results
           </div>
@@ -461,10 +461,10 @@
             >
               <chevron-left-icon class="w-4 h-4" />
             </app-btn-icon>
-            <div class="flex items-center gap-2">
-              <span class="text-black">{{ page }}</span>
+            <div class="flex items-center justify-center gap-2 min-w-[70px]">
+              <span class="text-black tabular-nums">{{ page }}</span>
               <span class="text-info">of</span>
-              <span class="text-info">{{ totalPages }}</span>
+              <span class="text-info tabular-nums">{{ totalPages }}</span>
             </div>
             <app-btn-icon
               :disabled="!isLoading && page >= totalPages"
@@ -933,6 +933,14 @@ watch(
     } else {
       debounceFetchTokens()
     }
+  },
+)
+
+// Reset page to 1 when filter or items per page changes
+watch(
+  () => [selectedCryptoFilter.value, shownItems.value],
+  () => {
+    page.value = 1
   },
 )
 


### PR DESCRIPTION
### Fix

Summary
Fixes pagination bug where changing category tabs (e.g., from "All Assets" to "Commodities") or items per page would keep the previous page number instead of resetting to page 1.

Changes
- Added watcher to reset `page` to 1 when `selectedCryptoFilter` or `shownItems` changes
- Applied fix to both `/stocks` (ModuleAllStock.vue) and `/crypto` (ModuleExploreCrypto.vue) routes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pagination now resets to the first page when filters or items-per-page change, preventing stale or invalid page selections in crypto and stock views.
* **Style / UI**
  * Result counts are now hidden/shown via styling for smoother loading transitions.
  * Page indicator centered and updated to use consistent, tabular-style numerals for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->