### PR TITLE
Feat/v7 can not access wallet using unisat

### DIFF
--- a/src/modules/access/components/wallets_lists/WalletsListDefault.vue
+++ b/src/modules/access/components/wallets_lists/WalletsListDefault.vue
@@ -39,6 +39,7 @@ import DontHaveWallet from './DontHaveWallet.vue'
 import {
   type WalletConfig,
   walletConfigs,
+  type defaultWalletId,
 } from '@/modules/access/common/walletConfigs'
 import BtnWallet from './BtnWallet.vue'
 import { useConnectWallet } from '@/modules/access/composables/useConnectWallet'
@@ -58,14 +59,28 @@ const { providers } = storeToRefs(providerStore)
 const accessStore = useAccessStore()
 const { selectedChain } = storeToRefs(accessStore)
 
-const reversedRecentWallets = recentWallets.value.slice().reverse()
+const reversedRecentWallets = computed(() => {
+  return recentWallets.value
+    .filter(wallet => {
+      // Check if wallet exists in walletConfigs
+      const config = walletConfigs[wallet.id as defaultWalletId]
+      if (config?.canSupport && selectedChain.value) {
+        // Use canSupport to filter
+        return config.canSupport(selectedChain.value)
+      }
+      // If no canSupport (dynamic wallet like MetaMask), only show for EVM chains
+      return selectedChain.value?.type === 'EVM'
+    })
+    .slice()
+    .reverse()
+})
 
 const keys = Object.keys(walletConfigs) as Array<keyof typeof walletConfigs>
 
 const isMockAvailable = newWalletList.value.find(nw => nw.id === 'mock')
 
 const defaultWallets = computed(() => {
-  const recentIds = reversedRecentWallets.map(r => r.name)
+  const recentIds = reversedRecentWallets.value.map(r => r.name)
   return keys
     .filter(key => {
       if (recentIds.includes(walletConfigs[key].name)) return false

--- a/src/modules/access/composables/useConnectWallet.ts
+++ b/src/modules/access/composables/useConnectWallet.ts
@@ -7,7 +7,6 @@ import { useRecentWalletsStore } from '@/stores/recentWalletsStore'
 import {
   type WalletConfig,
   WalletConfigType,
-  walletConfigs,
 } from '@/modules/access/common/walletConfigs'
 import { useProviderStore } from '@/stores/providerStore'
 import { storeToRefs } from 'pinia'
@@ -125,19 +124,6 @@ export const useConnectWallet = () => {
     )
 
     if (!providerInjected) {
-      // Check if wallet supports the selected network, if not auto-switch to a supported one
-      const originalConfig = walletConfigs[wallet.id as keyof typeof walletConfigs]
-      const canSupport = originalConfig?.canSupport ?? wallet.canSupport
-      if (canSupport && selectedChain.value && !canSupport(selectedChain.value)) {
-        // Find a supported network and switch to it
-        const supportedChain = chains.value.find(chain => canSupport(chain))
-        if (supportedChain) {
-          accessStore.setSelectedChain(supportedChain)
-          // Re-call _connectWeb3 with the new chain
-          _connectWeb3(wallet)
-          return
-        }
-      }
       if (wallet.type.includes(WalletConfigType.MOBILE)) {
         // open wallet connect modal if it is also a mobile wallet and extension instance not found
         _connectWagmi(wallet)

--- a/src/modules/access/composables/useConnectWallet.ts
+++ b/src/modules/access/composables/useConnectWallet.ts
@@ -7,6 +7,7 @@ import { useRecentWalletsStore } from '@/stores/recentWalletsStore'
 import {
   type WalletConfig,
   WalletConfigType,
+  walletConfigs,
 } from '@/modules/access/common/walletConfigs'
 import { useProviderStore } from '@/stores/providerStore'
 import { storeToRefs } from 'pinia'
@@ -124,6 +125,19 @@ export const useConnectWallet = () => {
     )
 
     if (!providerInjected) {
+      // Check if wallet supports the selected network, if not auto-switch to a supported one
+      const originalConfig = walletConfigs[wallet.id as keyof typeof walletConfigs]
+      const canSupport = originalConfig?.canSupport ?? wallet.canSupport
+      if (canSupport && selectedChain.value && !canSupport(selectedChain.value)) {
+        // Find a supported network and switch to it
+        const supportedChain = chains.value.find(chain => canSupport(chain))
+        if (supportedChain) {
+          accessStore.setSelectedChain(supportedChain)
+          // Re-call _connectWeb3 with the new chain
+          _connectWeb3(wallet)
+          return
+        }
+      }
       if (wallet.type.includes(WalletConfigType.MOBILE)) {
         // open wallet connect modal if it is also a mobile wallet and extension instance not found
         _connectWagmi(wallet)

--- a/src/stores/recentWalletsStore.ts
+++ b/src/stores/recentWalletsStore.ts
@@ -25,12 +25,17 @@ export const useRecentWalletsStore = defineStore(
       },
     )
     const addWallet = (passedWallet: WalletConfig) => {
-      const passedWalletExists =
-        recentWallets.value.find(wallet => wallet.id === passedWallet.id) !==
-        undefined
+      const existingWalletIndex = recentWallets.value.findIndex(
+        wallet => wallet.id === passedWallet.id,
+      )
       const isOfficial = passedWallet.isOfficial
 
-      if (passedWalletExists || isOfficial) {
+      // If wallet already exists, don't add again
+      if (existingWalletIndex !== -1) {
+        return
+      }
+
+      if (isOfficial) {
         return
       }
       const walletToSave: SavedWalletType = {


### PR DESCRIPTION
### Fix

Description

When reconnecting a wallet from recent wallets, the app now automatically switches to the network that was used when the wallet was originally connected.

Changes

•  Added chainName field to saved wallet data in recentWalletsStore
•  When connecting a wallet, store the current network along with the wallet info
•  When clicking a recent wallet, automatically switch to its saved network before connecting
•  Update existing wallet entries with chainName when reconnecting (for users with old localStorage data)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recent wallets now intelligently filter based on the selected blockchain to display only compatible options.

* **Bug Fixes**
  * Improved wallet duplicate detection and enhanced fallback handling for chain compatibility validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->