### PR TITLE
feat: ✨ add price impact warning for swaps exceeding maximum threshold

### DIFF
--- a/src/modules/swap/ModuleSwap.vue
+++ b/src/modules/swap/ModuleSwap.vue
@@ -138,6 +138,15 @@
 
       <!-- Error Display -->
       <div
+        v-if="!isLoading && priceImpactTooHigh"
+        :class="blurClass"
+        class="w-full max-w-[340px] p-4 bg-error-10 border border-error rounded-12 mb-2"
+      >
+        <p class="text-error text-s-14 text-center">
+          Price impact is too high {{ priceImpact.toFixed(2) }}%
+        </p>
+      </div>
+      <div
         v-if="!isLoading && generalError"
         :class="blurClass"
         class="w-full max-w-[340px] p-4 bg-error-10 border border-error rounded-12 mb-2"
@@ -264,7 +273,7 @@ import { isSignableWallet } from '@/utils/walletUtils'
 import { captureException } from '@sentry/vue'
 
 const isDevMode = configs.IS_DEV_MODE
-
+const MAX_PRICE_IMPACT = 10
 // --- Stores ---
 const walletMenu = useWalletMenuStore()
 const { walletPanel } = storeToRefs(walletMenu)
@@ -495,6 +504,19 @@ const toAmountError = computed(() => {
   return ''
 })
 
+const priceImpact = computed(() => {
+  const fromAmt = parseFloat(fromAmount.value)
+  const toAmt = parseFloat(toAmount.value)
+  const fromPrice = fromTokenSelected.value?.price || 0
+  const toPrice = toTokenSelected.value?.price || 0
+  if (!fromAmt || !toAmt || !fromPrice || !toPrice) return 0
+  const fromValue = fromAmt * fromPrice
+  const toValue = toAmt * toPrice
+  return ((fromValue - toValue) / fromValue) * 100
+})
+
+const priceImpactTooHigh = computed(() => priceImpact.value > MAX_PRICE_IMPACT)
+
 const isSwapDisabled = computed(
   () =>
     (swapLoaded.value && !supportedNetwork.value) ||
@@ -507,7 +529,8 @@ const isSwapDisabled = computed(
     (isCrossChain.value && toAddressError.value !== '') ||
     isLoadingQuotes.value ||
     !hasChainBalance.value ||
-    isSameToken.value,
+    isSameToken.value ||
+    priceImpactTooHigh.value,
 )
 
 // --- Helper Methods ---

--- a/src/modules/trade/ModuleTrade.vue
+++ b/src/modules/trade/ModuleTrade.vue
@@ -63,6 +63,15 @@
                       v-for="pct in [25, 50, 75, 100]"
                       :key="pct"
                       class="px-[10px] py-1 text-s-11 leading-p-120 font-semibold bg-white hoverBGWhite rounded-full transition-all duration-150 shadow-button shadow-button-elevated"
+                      :disabled="
+                        pct === 100 &&
+                        fromTokenSelected?.address === MAIN_TOKEN_CONTRACT
+                      "
+                      :class="{
+                        'opacity-40 cursor-not-allowed':
+                          pct === 100 &&
+                          fromTokenSelected?.address === MAIN_TOKEN_CONTRACT,
+                      }"
                       @click="setPercentageAmount(pct)"
                     >
                       {{ pct === 100 ? 'Max' : `${pct}%` }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Price impact warning banner appears when price impact exceeds 10% and shows the computed percentage.
  * Swap/bridge actions are disabled when price impact is too high to prevent unfavorable trades.

* **UX Improvements**
  * The "Max" sell percentage button is disabled and visually dimmed when selling the main platform token; other button behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->