### PR TITLE
feat: ✨ display ticker tags on stock news articles

### DIFF
--- a/src/modules/stocks/ModuleNews.vue
+++ b/src/modules/stocks/ModuleNews.vue
@@ -41,13 +41,22 @@
             <p class="text-s-14 line-clamp-2">
               {{ article.title }}
             </p>
-            <p class="text-s-11 text-info">
-              {{
-                article.timestamp
-                  ? new Date(article.timestamp).toLocaleDateString()
-                  : ''
-              }}
-            </p>
+            <div class="flex items-center gap-2 flex-wrap">
+              <p class="text-s-11 text-info">
+                {{
+                  article.timestamp
+                    ? new Date(article.timestamp).toLocaleDateString()
+                    : ''
+                }}
+              </p>
+              <span
+v-for="ticker in article.tickers || []"
+                :key="ticker"
+                class="text-s-9 font-semibold tracking-sp-06 uppercase text-info bg-mewBg px-2 py-[1px] rounded"
+              >
+                {{ ticker }}
+              </span>
+            </div>
           </div>
         </a>
       </div>


### PR DESCRIPTION
### Fix

Desription

Adds ticker tags to the Stock News section so users can quickly see which tokens/stocks each article is related to.

Changes

Renders the `tickers` array (already provided by the backend in `recentNews`) as small tag chips next to the article date in `ModuleNews.vue`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * News articles now display ticker badges inline with the article timestamp so associated stock symbols are visible at a glance.
  * Ticker badges wrap responsively to keep metadata readable on narrow screens.
  * Badges only appear when tickers are present, avoiding clutter for articles without associated symbols.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->