### PR TITLE
Feat/v7 rewards add balance refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Feat
 
 - Swap and Trade Tokenized stock rewards [#5327](https://github.com/MyEtherWallet/MyEtherWallet/pull/5327)
+- Balance Refresh and Tx has for rewards [#5334](https://github.com/MyEtherWallet/MyEtherWallet/pull/5334)
 
 ### v7.0.1
 

--- a/src/modules/rewards/RewardsPortfolio.vue
+++ b/src/modules/rewards/RewardsPortfolio.vue
@@ -34,7 +34,7 @@
           Remember to earn another<br />reward tomorrow!
         </p>
         <div
-          class="mt-3 inline-flex items-center gap-1.5 bg-white/60 rounded-full px-3 py-1 w-fit -mr-5"
+          class="mt-3 inline-flex items-center gap-1.5 bg-white/60 rounded-full px-3 py-1 w-fit -mr-5 -ml-2"
         >
           <svg
             v-if="isPending"
@@ -62,6 +62,18 @@
             }}
           </span>
         </div>
+        <a
+          v-if="!isPending && todaysReward?.rewardTransactionHash"
+          :href="`https://www.ethvm.com/tx/${todaysReward.rewardTransactionHash}?t=actions`"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-s-11 text-info mt-0.5 group hover:underline"
+        >
+          See Reward Tx
+          <arrow-long-right-icon
+            class="w-4 h-4 text-info inline-block group-hover:translate-x-1 transition-transform"
+          />
+        </a>
       </div>
       <div class="hidden xs:block shrink-0">
         <img
@@ -188,6 +200,7 @@ import { useToastStore } from '@/stores/toastStore'
 import { useChainsStore } from '@/stores/chainsStore'
 import { useWalletStore } from '@/stores/walletStore'
 import { useRewardsStore } from '@/stores/rewardsStore'
+import { ArrowLongRightIcon } from '@heroicons/vue/24/solid'
 
 const walletMenuStore = useWalletMenuStore()
 const { isOpenSideMenu } = storeToRefs(walletMenuStore)

--- a/src/stores/rewardsStore.ts
+++ b/src/stores/rewardsStore.ts
@@ -6,6 +6,8 @@ import { useWalletStore } from './walletStore'
 import { useChainsStore } from './chainsStore'
 import { useToastStore } from './toastStore'
 import { analytics, RewardsEvent } from '@/analytics'
+import useBalanceHandler from '@/utils/balanceHandler'
+import type { TokenBalancesRaw } from '@/mew_api/types'
 
 type PoolStatusResponse = components['schemas']['PoolStatusResponse']
 type EligibilityResponse = components['schemas']['EligibilityResponse']
@@ -30,7 +32,8 @@ const fetchRewards = async <T>(url: string): Promise<T> => {
 
 export const useRewardsStore = defineStore('rewardsStore', () => {
   const walletStore = useWalletStore()
-  const { walletAddress } = storeToRefs(walletStore)
+  const { walletAddress, wallet } = storeToRefs(walletStore)
+  const { setTokens, setIsLoadingBalances } = walletStore
   const chainsStore = useChainsStore()
   const { isBitcoinChain } = storeToRefs(chainsStore)
   const earnedPotentialRewardAddresses = ref<string[]>([]) // to track if user has earned a potential reward in the current eligibility period. This is needed to show the "Earned Potential Reward" badge immediately after user becomes eligible, without waiting for the next eligibility fetch.
@@ -210,6 +213,9 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
         const toastStore = useToastStore()
         toastStore.toggleRewardToast(true)
         stopRewardsPoll()
+        wallet.value?.getBalance().then((balances: TokenBalancesRaw) => {
+          useBalanceHandler(balances, setTokens, setIsLoadingBalances)
+        })
       }
     }, 5000)
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * View completed reward transactions on the Ethereum blockchain directly from the rewards portfolio (opens in a new tab).
  * Wallet balances automatically refresh when a reward completes successfully.

* **Style**
  * Adjusted reward badge layout and added a right-arrow icon with hover animation for the external transaction link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->