### PR TITLE
fix: 🐛 tx cancelling on send, fix disconnect bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Fix
+
+- fix metamask error on cancelling send and fix bug when disconnecting through metamask [#5337](https://github.com/MyEtherWallet/MyEtherWallet/pull/5337)
+
+
 ### v7.0.2
 
 # Feat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Feat
 
 - Swap and Trade Tokenized stock rewards [#5327](https://github.com/MyEtherWallet/MyEtherWallet/pull/5327)
+- Balance Refresh and Tx has for rewards [#5334](https://github.com/MyEtherWallet/MyEtherWallet/pull/5334)
 
 ### v7.0.1
 

--- a/src/components/core_layouts/TheHeader.vue
+++ b/src/components/core_layouts/TheHeader.vue
@@ -161,7 +161,7 @@ const { t } = useI18n()
 const store = useWalletStore()
 const chainStore = useChainsStore()
 const { isWalletConnected, wallet } = storeToRefs(store)
-const { setWallet, setWatchOnlyIfExist } = store
+const { setWallet, setWatchOnlyIfExist, disconnectWallet } = store
 const { isEvmChain, isBitcoinChain } = storeToRefs(chainStore)
 const { isMobile, isXLMinAndUp } = useAppBreakpoints()
 
@@ -255,6 +255,10 @@ watch(
         injectedInfo?.provider.on(
           'accountsChanged',
           async (accounts: unknown) => {
+            if(accounts && (accounts as string[]).length === 0) {
+              disconnectWallet()
+              return
+            }
             if (
               (accounts as string[])[0] !== (await wallet.value?.getAddress())
             ) {

--- a/src/modules/access/composables/useConnectWallet.ts
+++ b/src/modules/access/composables/useConnectWallet.ts
@@ -146,13 +146,13 @@ export const useConnectWallet = () => {
           wallet.downloadUrls?.firefox
         const link = _haslink
           ? {
-              title: 'Click here to install',
-              url: _haslink,
-            }
+            title: 'Click here to install',
+            url: _haslink,
+          }
           : {
-              title: "Don't have a wallet?",
-              url: 'https://enkrypt.com',
-            }
+            title: "Don't have a wallet?",
+            url: 'https://enkrypt.com',
+          }
         toastStore.addToastMessage({
           text: 'Web3 wallet not detected',
           textSecondary: `Please install ${wallet.name} extension to connect or select a different wallet.`,

--- a/src/modules/rewards/RewardsPortfolio.vue
+++ b/src/modules/rewards/RewardsPortfolio.vue
@@ -34,7 +34,7 @@
           Remember to earn another<br />reward tomorrow!
         </p>
         <div
-          class="mt-3 inline-flex items-center gap-1.5 bg-white/60 rounded-full px-3 py-1 w-fit -mr-5"
+          class="mt-3 inline-flex items-center gap-1.5 bg-white/60 rounded-full px-3 py-1 w-fit -mr-5 -ml-2"
         >
           <svg
             v-if="isPending"
@@ -62,6 +62,18 @@
             }}
           </span>
         </div>
+        <a
+          v-if="!isPending && todaysReward?.rewardTransactionHash"
+          :href="`https://www.ethvm.com/tx/${todaysReward.rewardTransactionHash}?t=actions`"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-s-11 text-info mt-0.5 group hover:underline"
+        >
+          See Reward Tx
+          <arrow-long-right-icon
+            class="w-4 h-4 text-info inline-block group-hover:translate-x-1 transition-transform"
+          />
+        </a>
       </div>
       <div class="hidden xs:block shrink-0">
         <img
@@ -188,6 +200,7 @@ import { useToastStore } from '@/stores/toastStore'
 import { useChainsStore } from '@/stores/chainsStore'
 import { useWalletStore } from '@/stores/walletStore'
 import { useRewardsStore } from '@/stores/rewardsStore'
+import { ArrowLongRightIcon } from '@heroicons/vue/24/solid'
 
 const walletMenuStore = useWalletMenuStore()
 const { isOpenSideMenu } = storeToRefs(walletMenuStore)

--- a/src/modules/send/components/EvmTransactionConfirmation.vue
+++ b/src/modules/send/components/EvmTransactionConfirmation.vue
@@ -433,7 +433,7 @@ const confirmTransaction = async () => {
                 ? e.toLowerCase()
                 : ''
         
-        if (msg.includes('user rejected') || msg.includes('rejected') || msg.includes('denied')) {
+        if (msg.includes('rejected') || msg.includes('denied')  || msg.includes('cancelled')) {
           toastStore.addToastMessage({
             type: ToastType.Info,
             text: 'Transaction canceled by user',

--- a/src/modules/send/components/EvmTransactionConfirmation.vue
+++ b/src/modules/send/components/EvmTransactionConfirmation.vue
@@ -432,7 +432,8 @@ const confirmTransaction = async () => {
               : typeof e === 'string'
                 ? e.toLowerCase()
                 : ''
-        if (msg.includes('user rejected')) {
+        
+        if (msg.includes('user rejected') || msg.includes('rejected') || msg.includes('denied')) {
           toastStore.addToastMessage({
             type: ToastType.Info,
             text: 'Transaction canceled by user',

--- a/src/modules/swap/components/BestOfferModal.vue
+++ b/src/modules/swap/components/BestOfferModal.vue
@@ -4,7 +4,7 @@
     class="sm:max-w-[400px] !min-h-[385px] sm:mx-auto"
   >
     <template #content>
-      <div class="flex items-center justify-center">
+      <div class="flex items-center justify-center pt-12">
         <img
           :src="bestOfferIcon"
           class="w-[175px]"

--- a/src/stores/rewardsStore.ts
+++ b/src/stores/rewardsStore.ts
@@ -6,6 +6,8 @@ import { useWalletStore } from './walletStore'
 import { useChainsStore } from './chainsStore'
 import { useToastStore } from './toastStore'
 import { analytics, RewardsEvent } from '@/analytics'
+import useBalanceHandler from '@/utils/balanceHandler'
+import type { TokenBalancesRaw } from '@/mew_api/types'
 
 type PoolStatusResponse = components['schemas']['PoolStatusResponse']
 type EligibilityResponse = components['schemas']['EligibilityResponse']
@@ -30,7 +32,8 @@ const fetchRewards = async <T>(url: string): Promise<T> => {
 
 export const useRewardsStore = defineStore('rewardsStore', () => {
   const walletStore = useWalletStore()
-  const { walletAddress } = storeToRefs(walletStore)
+  const { walletAddress, wallet } = storeToRefs(walletStore)
+  const { setTokens, setIsLoadingBalances } = walletStore
   const chainsStore = useChainsStore()
   const { isBitcoinChain } = storeToRefs(chainsStore)
   const earnedPotentialRewardAddresses = ref<string[]>([]) // to track if user has earned a potential reward in the current eligibility period. This is needed to show the "Earned Potential Reward" badge immediately after user becomes eligible, without waiting for the next eligibility fetch.
@@ -210,6 +213,9 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
         const toastStore = useToastStore()
         toastStore.toggleRewardToast(true)
         stopRewardsPoll()
+        wallet.value?.getBalance().then((balances: TokenBalancesRaw) => {
+          useBalanceHandler(balances, setTokens, setIsLoadingBalances)
+        })
       }
     }, 5000)
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved errors when cancelling a send via MetaMask and when disconnecting MetaMask.
  * Improved detection/classification of user-rejected or cancelled transactions so cancellation toasts display correctly.
  * Ensure wallet disconnects immediately when MetaMask reports no accounts.

* **Style**
  * Added extra top padding to the best-offer modal header for improved spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->