### PR TITLE
fix: 🐛 wallet connect proposal expired

### DIFF
--- a/src/modules/access/composables/useConnectWallet.ts
+++ b/src/modules/access/composables/useConnectWallet.ts
@@ -245,7 +245,7 @@ export const useConnectWallet = () => {
       selectedChain.value?.chainID || '1',
       wagmiConfig,
     )
-    wagWallet
+    return wagWallet
       .connect()
       .then(res => {
         if (res) {
@@ -270,6 +270,13 @@ export const useConnectWallet = () => {
           err.message.toLowerCase().includes('user rejected')
         ) {
           error = t('common.error.user_canceled_request')
+          _type = ToastType.Info
+        }
+        if (
+          err.message &&
+          err.message.toLowerCase().includes('proposal expired')
+        ) {
+          error = 'Connection timed out. Please try again.'
           _type = ToastType.Info
         }
         toastStore.addToastMessage({


### PR DESCRIPTION
### Fix

Bug Fixes

•  Fixed "Proposal expired" error being reported to Sentry when WalletConnect QR code times out.
•  Added user-friendly timeout message: "Connection timed out. Please try again."
•  Fixed unhandled promise rejection in WalletConnect connection flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced wallet connection error handling to provide clearer user feedback when connection proposals expire, displaying "Connection timed out. Please try again." instead of generic error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->