### PR TITLE
feat: ✨ store chosen network on bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - Add blinking info for approval on ledger or trezor [#5331](https://github.com/MyEtherWallet/MyEtherWallet/pull/5331)
 - store selected pair in swap and trade, and set it once user navigates back [#5335](https://github.com/MyEtherWallet/MyEtherWallet/pull/5335)
+- store chosen network on bridge [#5343](https://github.com/MyEtherWallet/MyEtherWallet/pull/5343)
 - fix error when watchlist tokens are cleared [#5336](https://github.com/MyEtherWallet/MyEtherWallet/pull/5336)
 
 ### v7.0.2

--- a/src/modules/swap/ModuleSwap.vue
+++ b/src/modules/swap/ModuleSwap.vue
@@ -306,8 +306,20 @@ const toastStore = useToastStore()
 const accessStore = useAccessStore()
 const rewardsStore = useRewardsStore()
 const pairStore = usePairStore()
-const { swapFromToken, swapToToken, swapToChain } = storeToRefs(pairStore)
-const { setSwapFromToken, setSwapToToken, setSwapToChain } = pairStore
+const {
+  swapFromToken,
+  swapToToken,
+  bridgeFromToken,
+  bridgeToToken,
+  bridgeToChain,
+} = storeToRefs(pairStore)
+const {
+  setSwapFromToken,
+  setSwapToToken,
+  setBridgeFromToken,
+  setBridgeToToken,
+  setBridgeToChain,
+} = pairStore
 const { t } = useI18n()
 
 // --- Refs from Stores ---
@@ -1190,20 +1202,26 @@ const connectWalletForSwap = () => {
 
 // --- Watchers ---
 
-// Sync swap pair to pairStore
+// Sync swap/bridge pair to pairStore
 watch(fromTokenSelected, token => {
-  setSwapFromToken(token ?? null)
+  if (isSwapView.value) {
+    setSwapFromToken(token ?? null)
+  } else {
+    setBridgeFromToken(token ?? null)
+  }
 })
 
 watch(toTokenSelected, token => {
-  setSwapToToken(token ?? null)
+  if (isSwapView.value) {
+    setSwapToToken(token ?? null)
+  } else {
+    setBridgeToToken(token ?? null)
+  }
 })
 
 watch(selectedToChain, chain => {
-  if (chain && chain.name !== selectedChain.value?.name) {
-    setSwapToChain(chain)
-  } else {
-    setSwapToChain(null)
+  if (!isSwapView.value) {
+    setBridgeToChain(chain && chain.name !== selectedChain.value?.name ? chain : null)
   }
 })
 
@@ -1430,11 +1448,16 @@ onBeforeMount(async () => {
 
   // Pre-populate from pairStore so setFromToken/setToToken keep the selection if found in list
   if (!hasSwapValues.value) {
-    if (swapToChain.value && swapToChain.value.name !== selectedChain.value?.name) {
-      selectedToChain.value = swapToChain.value
+    if (isSwapView.value) {
+      if (swapFromToken.value) fromTokenSelected.value = swapFromToken.value
+      if (swapToToken.value) toTokenSelected.value = swapToToken.value
+    } else {
+      if (bridgeToChain.value && bridgeToChain.value.name !== selectedChain.value?.name) {
+        selectedToChain.value = bridgeToChain.value
+      }
+      if (bridgeFromToken.value) fromTokenSelected.value = bridgeFromToken.value
+      if (bridgeToToken.value) toTokenSelected.value = bridgeToToken.value
     }
-    if (swapFromToken.value) fromTokenSelected.value = swapFromToken.value
-    if (swapToToken.value) toTokenSelected.value = swapToToken.value
   }
 
   await nextTick()

--- a/src/modules/swap/ModuleSwap.vue
+++ b/src/modules/swap/ModuleSwap.vue
@@ -306,8 +306,8 @@ const toastStore = useToastStore()
 const accessStore = useAccessStore()
 const rewardsStore = useRewardsStore()
 const pairStore = usePairStore()
-const { swapFromToken, swapToToken } = storeToRefs(pairStore)
-const { setSwapFromToken, setSwapToToken } = pairStore
+const { swapFromToken, swapToToken, swapToChain } = storeToRefs(pairStore)
+const { setSwapFromToken, setSwapToToken, setSwapToChain } = pairStore
 const { t } = useI18n()
 
 // --- Refs from Stores ---
@@ -1199,6 +1199,14 @@ watch(toTokenSelected, token => {
   setSwapToToken(token ?? null)
 })
 
+watch(selectedToChain, chain => {
+  if (chain && chain.name !== selectedChain.value?.name) {
+    setSwapToChain(chain)
+  } else {
+    setSwapToChain(null)
+  }
+})
+
 // Deep Link / Swap Values Watcher
 watch(
   () => swapValues.value,
@@ -1422,6 +1430,9 @@ onBeforeMount(async () => {
 
   // Pre-populate from pairStore so setFromToken/setToToken keep the selection if found in list
   if (!hasSwapValues.value) {
+    if (swapToChain.value && swapToChain.value.name !== selectedChain.value?.name) {
+      selectedToChain.value = swapToChain.value
+    }
     if (swapFromToken.value) fromTokenSelected.value = swapFromToken.value
     if (swapToToken.value) toTokenSelected.value = swapToToken.value
   }

--- a/src/stores/pairStore.ts
+++ b/src/stores/pairStore.ts
@@ -1,11 +1,13 @@
 import { ref } from 'vue'
 import { defineStore } from 'pinia'
 import type { NewTokenInfo } from '@/composables/useSwap'
+import type { Chain } from '@/mew_api/types'
 
 export const usePairStore = defineStore('pairStore', () => {
   // Swap pairs
   const swapFromToken = ref<NewTokenInfo | null>(null)
   const swapToToken = ref<NewTokenInfo | null>(null)
+  const swapToChain = ref<Chain | null>(null)
 
   const setSwapFromToken = (token: NewTokenInfo | null) => {
     swapFromToken.value = token
@@ -15,9 +17,14 @@ export const usePairStore = defineStore('pairStore', () => {
     swapToToken.value = token
   }
 
+  const setSwapToChain = (chain: Chain | null) => {
+    swapToChain.value = chain
+  }
+
   const clearSwapPair = () => {
     swapFromToken.value = null
     swapToToken.value = null
+    swapToChain.value = null
   }
 
   // Trade pairs
@@ -40,8 +47,10 @@ export const usePairStore = defineStore('pairStore', () => {
   return {
     swapFromToken,
     swapToToken,
+    swapToChain,
     setSwapFromToken,
     setSwapToToken,
+    setSwapToChain,
     clearSwapPair,
     tradeFromSymbol,
     tradeToSymbol,

--- a/src/stores/pairStore.ts
+++ b/src/stores/pairStore.ts
@@ -4,10 +4,9 @@ import type { NewTokenInfo } from '@/composables/useSwap'
 import type { Chain } from '@/mew_api/types'
 
 export const usePairStore = defineStore('pairStore', () => {
-  // Swap pairs
+  // Swap pairs (same-chain swap view)
   const swapFromToken = ref<NewTokenInfo | null>(null)
   const swapToToken = ref<NewTokenInfo | null>(null)
-  const swapToChain = ref<Chain | null>(null)
 
   const setSwapFromToken = (token: NewTokenInfo | null) => {
     swapFromToken.value = token
@@ -17,14 +16,32 @@ export const usePairStore = defineStore('pairStore', () => {
     swapToToken.value = token
   }
 
-  const setSwapToChain = (chain: Chain | null) => {
-    swapToChain.value = chain
-  }
-
   const clearSwapPair = () => {
     swapFromToken.value = null
     swapToToken.value = null
-    swapToChain.value = null
+  }
+
+  // Bridge pairs (cross-chain bridge view)
+  const bridgeFromToken = ref<NewTokenInfo | null>(null)
+  const bridgeToToken = ref<NewTokenInfo | null>(null)
+  const bridgeToChain = ref<Chain | null>(null)
+
+  const setBridgeFromToken = (token: NewTokenInfo | null) => {
+    bridgeFromToken.value = token
+  }
+
+  const setBridgeToToken = (token: NewTokenInfo | null) => {
+    bridgeToToken.value = token
+  }
+
+  const setBridgeToChain = (chain: Chain | null) => {
+    bridgeToChain.value = chain
+  }
+
+  const clearBridgePair = () => {
+    bridgeFromToken.value = null
+    bridgeToToken.value = null
+    bridgeToChain.value = null
   }
 
   // Trade pairs
@@ -47,11 +64,16 @@ export const usePairStore = defineStore('pairStore', () => {
   return {
     swapFromToken,
     swapToToken,
-    swapToChain,
     setSwapFromToken,
     setSwapToToken,
-    setSwapToChain,
     clearSwapPair,
+    bridgeFromToken,
+    bridgeToToken,
+    bridgeToChain,
+    setBridgeFromToken,
+    setBridgeToToken,
+    setBridgeToChain,
+    clearBridgePair,
     tradeFromSymbol,
     tradeToSymbol,
     setTradeFromSymbol,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The bridge now persists your chosen destination network so your chain selection is remembered.
  * Bridge token selections (from/to) are now stored and restored when switching into bridge mode.
  * Token and chain selections are synchronized between swap and bridge views so fields pre-populate appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->