### PR TITLE
fix: 🐛 reload page on failed dynamic imports

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -27,4 +27,20 @@ router.beforeEach((to, from, next) => {
     }
   }
 })
+
+router.onError((error, to) => {
+  const message = error instanceof Error ? error.message : String(error)
+  const isChunkError =
+    message.includes('Failed to fetch dynamically imported module') ||
+    message.includes('Unable to preload CSS')
+
+  if (isChunkError) {
+    const reloadKey = `chunk-reload:${to.fullPath}`
+    if (!sessionStorage.getItem(reloadKey)) {
+      sessionStorage.setItem(reloadKey, '1')
+      window.location.href = to.fullPath
+    }
+  }
+})
+
 export default router


### PR DESCRIPTION
## Fix

Adds router.onError handler to detect failed dynamic imports and CSS preload errors, then reloads the page to fetch updated assets.

Fixes Sentry issue #7351571874 - users with cached app failing to load chunks after deployments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error recovery for transient resource-load failures: the app now automatically attempts a full-page reload for certain module or stylesheet loading errors and ensures only one reload per route to avoid repeated reload loops. This helps users recover from temporary network or loading issues, preventing being stuck on a broken page; no user action required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->