### PR TITLE
fix: 🐛 swap init syntax error safari

### DIFF
--- a/src/modules/trade/providers/ondoHelpers.ts
+++ b/src/modules/trade/providers/ondoHelpers.ts
@@ -7,9 +7,11 @@ const TRADING_RESTRICTED_HELP_URL =
   'https://help.myetherwallet.com/en/articles/13641432-restrictions-on-tokenized-stock-trading-in-mew'
 
 const _getMarketStatus = (): Promise<GetWebSwapOndoMarketStatusResponse> => {
-  return fetch(getAPIPath(`/v1/web/swap/ondo/status/market`)).then(
-    res => res.json() as Promise<GetWebSwapOndoMarketStatusResponse>,
-  )
+  return fetch(getAPIPath(`/v1/web/swap/ondo/status/market`)).then(res => {
+    if (!res.ok)
+      throw new Error(`Failed to fetch market status: ${res.status}`)
+    return res.json() as Promise<GetWebSwapOndoMarketStatusResponse>
+  })
 }
 
 const getMarketStatus = throttle(_getMarketStatus, 1000)
@@ -17,7 +19,12 @@ const getMarketStatus = throttle(_getMarketStatus, 1000)
 const getRestrictedTokenAddresses = (): Promise<string[]> => {
   return fetch(
     `https://raw.githubusercontent.com/enkryptcom/dynamic-data/refs/heads/main/configs/filtered-rwa-addresses.json`,
-  ).then(res => res.json() as Promise<string[]>)
+  )
+    .then(res => {
+      if (!res.ok) return []
+      return res.json() as Promise<string[]>
+    })
+    .catch(() => [])
 }
 
 const isTradingRestricted = async (): Promise<boolean> => {


### PR DESCRIPTION
## Fix

Sentry issue APP-MEW-WEB-7F — SyntaxError: The string did not match the expected pattern (198 events, Safari only).

When https://raw.githubusercontent.com/enkryptcom/dynamic-data/main/swaplists/ETH.json returns a 503, the @enkryptcom/swap library attempts to parse the HTML error body as JSON via res.json() without checking res.ok. Safari throws a SyntaxError which bubbles up through initSwapper and gets reported to Sentry.

Changes
Added res.ok validation in ondoHelpers.ts before calling res.json() on:
•  _getMarketStatus 
•  getRestrictedTokenAddresses

This prevents the same class of error in our own code (parsing non-JSON responses from failed HTTP requests).

Note
The root cause is in the @enkryptcom/swap library which doesn't check res.ok before parsing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of trading API failures: clearer error messages when market-status checks fail.
  * Safe fallback when token-restriction lookups fail: returns an empty restriction list instead of causing parsing errors, preventing crashes and improving reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->