### PR TITLE
fix: 🐛 retry network errors purchase fetch

### DIFF
--- a/src/composables/useFetchMewApi.ts
+++ b/src/composables/useFetchMewApi.ts
@@ -52,6 +52,7 @@ export const useFetchMewApi = (
           resumePoll()
         }
         delay.value = 1000
+        retryCount.value = 0
         return ctx
       },
       updateDataOnError: true,
@@ -72,12 +73,9 @@ export const useFetchMewApi = (
           pausePoll()
         }
         // If the request fails,  retry the request
-        if (
-          _hasRetry &&
-          retryCount.value < 3 &&
-          response?.status &&
-          response?.status >= 500
-        ) {
+        const isNetworkError = !response
+        const isServerError = response?.status && response.status >= 500
+        if (_hasRetry && retryCount.value < 3 && (isNetworkError || isServerError)) {
           retryCount.value++
           // wait for delay
           await new Promise(resolve => setTimeout(resolve, delay.value))
@@ -92,7 +90,8 @@ export const useFetchMewApi = (
             captureException(ctx.error)
           }
           ctx.error = data?.message || 'Unknown Error. Failed to fetch.'
-
+          retryCount.value = 0
+          delay.value = 1000
           return ctx
         }
       },

--- a/src/stores/purchaseStore.ts
+++ b/src/stores/purchaseStore.ts
@@ -3,8 +3,6 @@ import { ref, computed } from 'vue'
 import { useFetchMewApi } from '@/composables/useFetchMewApi'
 import type { PurchaseInfo } from '@/types/buyToken'
 import configs from '@/configs'
-import { captureException } from '@sentry/vue'
-
 const isDevMode = configs.IS_DEV_MODE
 
 export const usePurchaseStore = defineStore('purchase', () => {
@@ -36,12 +34,6 @@ export const usePurchaseStore = defineStore('purchase', () => {
     } catch (error) {
       if (isDevMode) {
         console.error('Failed to fetch purchase info:', error)
-      } else {
-        captureException(error, {
-          extra: {
-            title: 'PURCHASE STORE: Failed to fetch purchase info',
-          },
-        })
       }
     } finally {
       isFetching.value = false


### PR DESCRIPTION
### Fix

Retry network errors on purchase info fetch

Sentry: APP-MEW-WEB-99 — TypeError: Failed to fetch (835+ events / 90 days)

Root cause: useFetchMewApi only retried on 5xx responses. Network-level errors (CORS, DNS, ad-blockers) produce no response object, so retries were never triggered.

Changes:
•  useFetchMewApi.ts: Expanded retry condition to cover network errors (!response), not just 5xx.
•  purchaseStore.ts: Removed duplicate captureException — already handled in the composable after retries are exhausted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry behavior for fetch failures: retries now cover network errors and server 5xx responses, with retry limits and reset of retry state after success or when retries stop.

* **Chores**
  * Removed automatic error reporting to the external tracking service; failures are now logged locally in development only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->