### PR TITLE
fix: 🐛 hardware wallet unhandled error

### DIFF
--- a/src/modules/access/ModuleAccessHardwareWallet.vue
+++ b/src/modules/access/ModuleAccessHardwareWallet.vue
@@ -267,34 +267,56 @@ const unlockWallet = async () => {
     selectedChain.value?.name as string
   ] as NetworkNames
 
-  if (!wallet.value) {
-    await hwWalletInstance!
-      .isConnected({
-        wallet: selectedHwWalletType.value as HWwalletType,
-        networkName: networkName as any,
-      })
-      .then(() => {
-        return new Promise(r => setTimeout(r, 1000))
-      })
-  }
-  activeStep.value = 1
-  paths.value = (await hwWalletInstance!.getSupportedPaths({
-    wallet: selectedHwWalletType.value as HWwalletType,
-    networkName: networkName as any,
-  })) as PathType[]
+  try {
+    if (!wallet.value) {
+      await hwWalletInstance!
+        .isConnected({
+          wallet: selectedHwWalletType.value as HWwalletType,
+          networkName: networkName as any,
+        })
+        .then(() => {
+          return new Promise(r => setTimeout(r, 1000))
+        })
+    }
+    paths.value = (await hwWalletInstance!.getSupportedPaths({
+      wallet: selectedHwWalletType.value as HWwalletType,
+      networkName: networkName as any,
+    })) as PathType[]
 
-  // if path is empty, set a path
-  // if currently selected path is not in the list, set the first one
-  if (
-    selectedDerivation.value?.path === '' ||
-    !paths.value.some(
-      // This handles Ledger case where user may have selected a different app or an app only supports certain paths
-      (path: PathType) => path.path === selectedDerivation.value?.path,
-    )
-  ) {
-    setSelectedDerivation(paths.value[0])
+    // Guard against empty paths array
+    if (paths.value.length === 0) {
+      throw new Error('No supported derivation paths found for this wallet')
+    }
+
+    // if path is empty, set a path
+    // if currently selected path is not in the list, set the first one
+    if (
+      selectedDerivation.value?.path === '' ||
+      !paths.value.some(
+        // This handles Ledger case where user may have selected a different app or an app only supports certain paths
+        (path: PathType) => path.path === selectedDerivation.value?.path,
+      )
+    ) {
+      setSelectedDerivation(paths.value[0])
+    }
+
+    // Only advance to step 2 after all validations pass
+    activeStep.value = 1
+    loadList()
+  } catch (e) {
+    const errorMessage = e instanceof Error ? e.message : String(e)
+    toastStore.addToastMessage({
+      type: ToastType.Error,
+      text: t('error_connecting'),
+      textSecondary: errorMessage,
+    })
+    // Don't report expected user errors to Sentry
+    if (!errorMessage.includes('Make sure you have')) {
+      captureException(e, SENTRY_MODULE_TAGS.ACCESS)
+    }
+  } finally {
+    connectingWallet.value = false
   }
-  loadList()
 }
 
 /**------------------------


### PR DESCRIPTION
### Fix

## What
Added proper error handling to the hardware wallet connection flow in the access module.

## Why
The `unlockWallet` function was missing try-catch, causing unhandled errors when hardware wallet connection failed. This could crash the app or leave the UI in an inconsistent state.

## How
- Wrapped the connection logic in a try-catch block
- Added validation for empty derivation paths array
- Moved step progression after all validations pass
- Added toast notifications for user-facing errors
- Added Sentry error reporting for unexpected errors
- Added `finally` block to reset loading state


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures connection state is always reset if an error occurs during hardware wallet setup.
  * Validates device derivation paths and prevents advancing when none are available.
  * Only advances after successful device validation and list loading.
  * Clearer, more informative error messages and selective reporting of unexpected errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->