### PR TITLE
fix: 🐛 add defensive check for missing assets in purchase store

### DIFF
--- a/src/stores/purchaseStore.ts
+++ b/src/stores/purchaseStore.ts
@@ -10,10 +10,10 @@ export const usePurchaseStore = defineStore('purchase', () => {
   const isFetching = ref(false)
 
   const buyableCoinIds = computed(() => {
-    if (!purchaseInfo.value) return new Set<string>()
+    if (!purchaseInfo.value?.assets) return new Set<string>()
     const ids = new Set<string>()
     purchaseInfo.value.assets.forEach(chain => {
-      chain.assets.forEach(asset => {
+      chain.assets?.forEach(asset => {
         if (asset.coingecko_id) {
           ids.add(asset.coingecko_id)
         }


### PR DESCRIPTION
### Fix
Fix for [APP-MEW-WEB-94](https://myetherwallet-inc.sentry.io/issues/7366906516/?query=is%3Aunresolved&referrer=issue-stream&sort=freq) AND [APP-MEW-WEB-H1](https://myetherwallet-inc.sentry.io/issues/7382728727/?query=is%3Aunresolved&referrer=issue-stream&sort=freq)
## What
Added optional chaining to check for `assets` property in `buyableCoinIds` computed.

## Why
Prevents potential runtime error when `purchaseInfo` exists but `assets` is undefined or missing from the API response.

## How
- Added optional chaining (`?.assets`) in `buyableCoinIds` guard clause
- Returns empty Set early if `assets` is not present


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the app could fail when processing incomplete purchase data, ensuring proper validation before accessing purchase information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->