### PR TITLE
feat: implement fuzzy search for token and stock search (MEW-1596)

### DIFF
--- a/src/components/AppSwapSelectedToken.vue
+++ b/src/components/AppSwapSelectedToken.vue
@@ -263,7 +263,7 @@ import {
   formatFiatValue,
 } from '@/utils/numberFormatHelper'
 import { sortObjectArrayNumber, sortObjectArrayString } from '@/utils/sortArray'
-import { searchArrayByKeysStr } from '@/utils/searchArray'
+import { fuzzySearchByKeys } from '@/utils/searchArray'
 import { useChainsStore } from '@/stores/chainsStore'
 import { useI18n } from 'vue-i18n'
 import { useScroll } from '@vueuse/core'
@@ -473,7 +473,7 @@ const searchResults = computed<TokenBalanceWithUsd[]>(() => {
       : sortObjectArrayNumber(allItems, key, activeSortDirection.value)
 
   if (searchInput.value) {
-    return searchArrayByKeysStr(sorted, ['name', 'symbol'], searchInput.value)
+    return fuzzySearchByKeys(sorted, ['name', 'symbol'], searchInput.value)
   }
 
   return sorted.slice(0, endingPagination.value)

--- a/src/components/AppTokenSelect.vue
+++ b/src/components/AppTokenSelect.vue
@@ -201,7 +201,7 @@ import {
   formatFiatValue,
 } from '@/utils/numberFormatHelper'
 import { sortObjectArrayNumber, sortObjectArrayString } from '@/utils/sortArray'
-import { searchArrayByKeysStr } from '@/utils/searchArray'
+import { fuzzySearchByKeys } from '@/utils/searchArray'
 import { useChainsStore } from '@/stores/chainsStore'
 import { useI18n } from 'vue-i18n'
 
@@ -337,7 +337,7 @@ const searchResults = computed<TokenBalanceWithUsd[]>(() => {
       : sortObjectArrayNumber(items, key, activeSortDirection.value)
 
   if (searchInput.value) {
-    return searchArrayByKeysStr(sorted, ['name', 'symbol'], searchInput.value)
+    return fuzzySearchByKeys(sorted, ['name', 'symbol'], searchInput.value)
   }
 
   return sorted

--- a/src/modules/stocks/ModuleSearchStocks.vue
+++ b/src/modules/stocks/ModuleSearchStocks.vue
@@ -279,6 +279,7 @@ import {
 } from '@/utils/numberFormatHelper'
 import { type GetWebStocksSummaryResponse } from '@/mew_api/types'
 import { STOCK_INFO_ROUTE_NAMES } from '@/router/routeNames'
+import { fuzzySearchByKeys } from '@/utils/searchArray'
 
 const stocksStore = useStocksStore()
 const { trending: trendingTokens, isLoadingOverview } = storeToRefs(stocksStore)
@@ -297,24 +298,12 @@ const { data: searchData, isFetching } = useMEWFetch(searchUrl)
 const results = computed(() => {
   if (isLoading.value || !searchInput.value || searchInput.value === '')
     return []
-  const query = searchInput.value.toLowerCase()
   const data = searchData.value || []
-
-  const startsWithMatches: GetWebStocksSummaryResponse = []
-  const containsMatches: GetWebStocksSummaryResponse = []
-
-  data.forEach(item => {
-    const symbol = item.primaryMarket.symbol.toLowerCase()
-    const name = item.underlyingMarket.name.toLowerCase()
-
-    if (symbol.startsWith(query) || name.startsWith(query)) {
-      startsWithMatches.push(item)
-    } else if (symbol.includes(query) || name.includes(query)) {
-      containsMatches.push(item)
-    }
-  })
-
-  return [...startsWithMatches, ...containsMatches]
+  return fuzzySearchByKeys(
+    data,
+    ['primaryMarket.symbol', 'underlyingMarket.name'],
+    searchInput.value,
+  )
 })
 
 const showDropdown = ref(false)

--- a/src/utils/searchArray.ts
+++ b/src/utils/searchArray.ts
@@ -12,9 +12,9 @@ export const fuzzySearchByKeys = <T>(
   keys: string | string[],
   searchTerm: string,
 ): T[] => {
-  if (!searchTerm) return array
+  const searchLC = searchTerm.trim().toLowerCase()
+  if (!searchLC) return array
   const keyArray = Array.isArray(keys) ? keys : [keys]
-  const searchLC = searchTerm.toLowerCase()
 
   const prefixMatches: T[] = []
   const containsMatches: T[] = []
@@ -37,7 +37,15 @@ export const fuzzySearchByKeys = <T>(
       } else if (valLC.includes(searchLC)) {
         bestCategory = Math.min(bestCategory, 1)
       } else {
-        const dist = levenshtein(searchLC, valLC.slice(0, searchLC.length + 2))
+        const candidates = [
+          valLC,
+          ...valLC.split(/[\s._-]+/).filter(Boolean),
+        ]
+        const dist = Math.min(
+          ...candidates.map(candidate =>
+            levenshtein(searchLC, candidate.slice(0, searchLC.length + 2)),
+          ),
+        )
         if (dist <= maxDist) {
           bestCategory = Math.min(bestCategory, 2)
           bestScore = Math.min(bestScore, dist)

--- a/src/utils/searchArray.ts
+++ b/src/utils/searchArray.ts
@@ -1,4 +1,96 @@
 /**
+ * @param array - Array of objects to search
+ * @param keys - The key or keys of the object to search by (supports nested keys like 'a.b')
+ * @param searchTerm - The term to search for in the specified keys
+ * @description Fuzzy search with typo tolerance. Results sorted by relevance:
+ * 1. Prefix matches (startsWith)
+ * 2. Contains matches (includes)
+ * 3. Fuzzy matches (within edit distance threshold)
+ */
+export const fuzzySearchByKeys = <T>(
+  array: T[],
+  keys: string | string[],
+  searchTerm: string,
+): T[] => {
+  if (!searchTerm) return array
+  const keyArray = Array.isArray(keys) ? keys : [keys]
+  const searchLC = searchTerm.toLowerCase()
+
+  const prefixMatches: T[] = []
+  const containsMatches: T[] = []
+  const fuzzyMatches: Array<{ item: T; score: number }> = []
+  const seen = new Set<T>()
+
+  const maxDist = searchLC.length <= 3 ? 1 : 2
+
+  array.forEach(item => {
+    let bestCategory = 3 // 0=prefix, 1=contains, 2=fuzzy, 3=no match
+    let bestScore = Infinity
+
+    keyArray.forEach(key => {
+      const value = getNestedValue(item, key)
+      if (!value) return
+      const valLC = String(value).toLowerCase()
+
+      if (valLC.startsWith(searchLC)) {
+        bestCategory = Math.min(bestCategory, 0)
+      } else if (valLC.includes(searchLC)) {
+        bestCategory = Math.min(bestCategory, 1)
+      } else {
+        const dist = levenshtein(searchLC, valLC.slice(0, searchLC.length + 2))
+        if (dist <= maxDist) {
+          bestCategory = Math.min(bestCategory, 2)
+          bestScore = Math.min(bestScore, dist)
+        }
+      }
+    })
+
+    if (bestCategory < 3 && !seen.has(item)) {
+      seen.add(item)
+      if (bestCategory === 0) prefixMatches.push(item)
+      else if (bestCategory === 1) containsMatches.push(item)
+      else fuzzyMatches.push({ item, score: bestScore })
+    }
+  })
+
+  fuzzyMatches.sort((a, b) => a.score - b.score)
+  return [
+    ...prefixMatches,
+    ...containsMatches,
+    ...fuzzyMatches.map(m => m.item),
+  ]
+}
+
+const getNestedValue = (obj: unknown, path: string): unknown => {
+  return path.split('.').reduce((acc: unknown, key: string) => {
+    if (acc && typeof acc === 'object') {
+      return (acc as Record<string, unknown>)[key]
+    }
+    return undefined
+  }, obj)
+}
+
+const levenshtein = (a: string, b: string): number => {
+  const m = a.length
+  const n = b.length
+  const dp: number[] = Array.from({ length: n + 1 }, (_, i) => i)
+
+  for (let i = 1; i <= m; i++) {
+    let prev = i - 1
+    dp[0] = i
+    for (let j = 1; j <= n; j++) {
+      const temp = dp[j]
+      dp[j] =
+        a[i - 1] === b[j - 1]
+          ? prev
+          : 1 + Math.min(prev, dp[j], dp[j - 1])
+      prev = temp
+    }
+  }
+  return dp[n]
+}
+
+/**
  *
  * @param array - Array of objects to search
  * @param keys - The key or keys of the object to search by

--- a/src/utils/searchArray.ts
+++ b/src/utils/searchArray.ts
@@ -29,7 +29,7 @@ export const fuzzySearchByKeys = <T>(
 
     keyArray.forEach(key => {
       const value = getNestedValue(item, key)
-      if (!value) return
+      if (value === null || value === undefined) return
       const valLC = String(value).toLowerCase()
 
       if (valLC.startsWith(searchLC)) {

--- a/tests/unit/searchArray.spec.ts
+++ b/tests/unit/searchArray.spec.ts
@@ -201,6 +201,16 @@ describe('fuzzySearchByKeys', () => {
       const symbols = results.map(s => s.primaryMarket.symbol)
       expect(symbols).toContain('GOOGL')
     })
+
+    it('finds typos in later words of stock names', () => {
+      const results = fuzzySearchByKeys(
+        stocks,
+        ['primaryMarket.symbol', 'underlyingMarket.name'],
+        'Corporaton',
+      )
+      const names = results.map(s => s.underlyingMarket.name)
+      expect(names).toContain('Microsoft Corporation')
+    })
   })
 
   // -- Edge cases -----------------------------------------------------------
@@ -209,6 +219,16 @@ describe('fuzzySearchByKeys', () => {
     it('returns full array for empty search term', () => {
       const results = fuzzySearchByKeys(tokens, ['name', 'symbol'], '')
       expect(results).toHaveLength(tokens.length)
+    })
+
+    it('returns full array for whitespace-only search term', () => {
+      const results = fuzzySearchByKeys(tokens, ['name', 'symbol'], '   ')
+      expect(results).toHaveLength(tokens.length)
+    })
+
+    it('trims whitespace from search term', () => {
+      const results = fuzzySearchByKeys(tokens, ['name', 'symbol'], '  ETH  ')
+      expect(results[0].symbol).toBe('ETH')
     })
 
     it('returns empty array when searching empty array', () => {

--- a/tests/unit/searchArray.spec.ts
+++ b/tests/unit/searchArray.spec.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect } from 'vitest'
+import { fuzzySearchByKeys, searchArrayByKeysStr } from '@/utils/searchArray'
+
+// ---------------------------------------------------------------------------
+// Test data — mirrors real token / stock shapes used in the app
+// ---------------------------------------------------------------------------
+
+interface Token {
+  name: string
+  symbol: string
+  address?: string
+}
+
+const tokens: Token[] = [
+  { name: 'Ethereum', symbol: 'ETH', address: '0xeeee' },
+  { name: 'Tether USD', symbol: 'USDT', address: '0xdac1' },
+  { name: 'USD Coin', symbol: 'USDC', address: '0xa0b8' },
+  { name: 'Bitcoin', symbol: 'BTC', address: '0xbtc0' },
+  { name: 'Wrapped Bitcoin', symbol: 'WBTC', address: '0x2260' },
+  { name: 'Chainlink', symbol: 'LINK', address: '0x514a' },
+  { name: 'Uniswap', symbol: 'UNI', address: '0x1f98' },
+  { name: 'Aave', symbol: 'AAVE', address: '0x7fc6' },
+  { name: 'Polygon', symbol: 'MATIC', address: '0x7d1a' },
+  { name: 'Shiba Inu', symbol: 'SHIB', address: '0x95ad' },
+  { name: 'Dogecoin', symbol: 'DOGE', address: '0xdoge' },
+  { name: 'Solana', symbol: 'SOL', address: '0xsol0' },
+  { name: 'Polkadot', symbol: 'DOT', address: '0xdot0' },
+  { name: 'Ethereum Name Service', symbol: 'ENS', address: '0xens0' },
+  { name: 'Lido Staked Ether', symbol: 'stETH', address: '0xae7a' },
+]
+
+interface Stock {
+  primaryMarket: { symbol: string }
+  underlyingMarket: { name: string }
+}
+
+const stocks: Stock[] = [
+  { primaryMarket: { symbol: 'AAPL' }, underlyingMarket: { name: 'Apple Inc' } },
+  { primaryMarket: { symbol: 'GOOGL' }, underlyingMarket: { name: 'Alphabet Inc' } },
+  { primaryMarket: { symbol: 'MSFT' }, underlyingMarket: { name: 'Microsoft Corporation' } },
+  { primaryMarket: { symbol: 'AMZN' }, underlyingMarket: { name: 'Amazon.com Inc' } },
+  { primaryMarket: { symbol: 'TSLA' }, underlyingMarket: { name: 'Tesla Inc' } },
+  { primaryMarket: { symbol: 'META' }, underlyingMarket: { name: 'Meta Platforms Inc' } },
+  { primaryMarket: { symbol: 'NVDA' }, underlyingMarket: { name: 'NVIDIA Corporation' } },
+]
+
+// ---------------------------------------------------------------------------
+// fuzzySearchByKeys
+// ---------------------------------------------------------------------------
+
+describe('fuzzySearchByKeys', () => {
+  // -- Exact & prefix matches -----------------------------------------------
+
+  describe('prefix matches', () => {
+    it('finds token by exact symbol', () => {
+      const results = fuzzySearchByKeys(tokens, ['name', 'symbol'], 'ETH')
+      expect(results[0].symbol).toBe('ETH')
+    })
+
+    it('finds token by name prefix', () => {
+      const results = fuzzySearchByKeys(tokens, ['name', 'symbol'], 'Ether')
+      expect(results[0].name).toBe('Ethereum')
+    })
+
+    it('is case-insensitive', () => {
+      const results = fuzzySearchByKeys(tokens, ['name', 'symbol'], 'eth')
+      expect(results[0].symbol).toBe('ETH')
+    })
+
+    it('prefix matches come before contains matches', () => {
+      // "ETH" should match Ethereum (prefix on symbol) before stETH (contains)
+      const results = fuzzySearchByKeys(tokens, ['name', 'symbol'], 'eth')
+      const ethIdx = results.findIndex(t => t.symbol === 'ETH')
+      const stethIdx = results.findIndex(t => t.symbol === 'stETH')
+      expect(ethIdx).toBeLessThan(stethIdx)
+    })
+  })
+
+  // -- Contains matches -----------------------------------------------------
+
+  describe('contains matches', () => {
+    it('finds token where search term is in the middle of name', () => {
+      const results = fuzzySearchByKeys(tokens, ['name', 'symbol'], 'coin')
+      const names = results.map(t => t.name)
+      expect(names).toContain('USD Coin')
+      expect(names).toContain('Dogecoin')
+    })
+
+    it('finds "Bitcoin" when searching "itcoin"', () => {
+      const results = fuzzySearchByKeys(tokens, ['name', 'symbol'], 'itcoin')
+      const names = results.map(t => t.name)
+      expect(names).toContain('Bitcoin')
+      expect(names).toContain('Wrapped Bitcoin')
+    })
+  })
+
+  // -- Fuzzy / typo tolerance -----------------------------------------------
+
+  describe('typo tolerance', () => {
+    it('finds Ethereum with common misspelling "etherium"', () => {
+      const results = fuzzySearchByKeys(tokens, ['name', 'symbol'], 'etherium')
+      const names = results.map(t => t.name)
+      expect(names).toContain('Ethereum')
+    })
+
+    it('finds Tether with typo "teter"', () => {
+      const results = fuzzySearchByKeys(tokens, ['name', 'symbol'], 'teter')
+      const names = results.map(t => t.name)
+      expect(names).toContain('Tether USD')
+    })
+
+    it('finds Bitcoin with typo "bitcon"', () => {
+      const results = fuzzySearchByKeys(tokens, ['name', 'symbol'], 'bitcon')
+      const names = results.map(t => t.name)
+      expect(names).toContain('Bitcoin')
+    })
+
+    it('finds Chainlink with typo "chainlik"', () => {
+      const results = fuzzySearchByKeys(tokens, ['name', 'symbol'], 'chainlik')
+      const names = results.map(t => t.name)
+      expect(names).toContain('Chainlink')
+    })
+
+    it('tolerates 1 edit for short queries (≤3 chars)', () => {
+      // "UDT" is 1 edit from "USDT"
+      const results = fuzzySearchByKeys(tokens, ['name', 'symbol'], 'UDT')
+      const symbols = results.map(t => t.symbol)
+      expect(symbols).toContain('USDT')
+    })
+
+    it('does not match wildly different strings', () => {
+      const results = fuzzySearchByKeys(tokens, ['name', 'symbol'], 'zzzzz')
+      expect(results).toHaveLength(0)
+    })
+
+    it('does not match with too many typos', () => {
+      // "xyzrium" is 3+ edits from "Ethereum"
+      const results = fuzzySearchByKeys(tokens, ['name', 'symbol'], 'xyzrium')
+      const names = results.map(t => t.name)
+      expect(names).not.toContain('Ethereum')
+    })
+  })
+
+  // -- Result ordering ------------------------------------------------------
+
+  describe('result ordering', () => {
+    it('orders: prefix > contains > fuzzy', () => {
+      // Search "sol" — Solana is prefix match on symbol
+      const results = fuzzySearchByKeys(tokens, ['name', 'symbol'], 'sol')
+      expect(results[0].symbol).toBe('SOL')
+    })
+
+    it('fuzzy matches are sorted by edit distance', () => {
+      const items = [
+        { name: 'abcde', symbol: 'X1' },  // dist 2 from "abcXX"
+        { name: 'abcXe', symbol: 'X2' },  // dist 1 from "abcXX"
+      ]
+      const results = fuzzySearchByKeys(items, ['name'], 'abcXX')
+      // closer match first
+      expect(results[0].symbol).toBe('X2')
+    })
+  })
+
+  // -- Nested keys (stock data) ---------------------------------------------
+
+  describe('nested keys', () => {
+    it('searches nested stock symbol', () => {
+      const results = fuzzySearchByKeys(
+        stocks,
+        ['primaryMarket.symbol', 'underlyingMarket.name'],
+        'AAPL',
+      )
+      expect(results[0].primaryMarket.symbol).toBe('AAPL')
+    })
+
+    it('searches nested stock name', () => {
+      const results = fuzzySearchByKeys(
+        stocks,
+        ['primaryMarket.symbol', 'underlyingMarket.name'],
+        'Tesla',
+      )
+      expect(results[0].underlyingMarket.name).toBe('Tesla Inc')
+    })
+
+    it('finds stock with typo "Tesle"', () => {
+      const results = fuzzySearchByKeys(
+        stocks,
+        ['primaryMarket.symbol', 'underlyingMarket.name'],
+        'Tesle',
+      )
+      const names = results.map(s => s.underlyingMarket.name)
+      expect(names).toContain('Tesla Inc')
+    })
+
+    it('finds stock with typo "Gogle"', () => {
+      const results = fuzzySearchByKeys(
+        stocks,
+        ['primaryMarket.symbol', 'underlyingMarket.name'],
+        'Gogle',
+      )
+      const symbols = results.map(s => s.primaryMarket.symbol)
+      expect(symbols).toContain('GOOGL')
+    })
+  })
+
+  // -- Edge cases -----------------------------------------------------------
+
+  describe('edge cases', () => {
+    it('returns full array for empty search term', () => {
+      const results = fuzzySearchByKeys(tokens, ['name', 'symbol'], '')
+      expect(results).toHaveLength(tokens.length)
+    })
+
+    it('returns empty array when searching empty array', () => {
+      const results = fuzzySearchByKeys([], ['name'], 'test')
+      expect(results).toHaveLength(0)
+    })
+
+    it('handles single key as string', () => {
+      const results = fuzzySearchByKeys(tokens, 'symbol', 'ETH')
+      expect(results[0].symbol).toBe('ETH')
+    })
+
+    it('handles items with missing key values', () => {
+      const items = [
+        { name: 'Ethereum', symbol: 'ETH' },
+        { name: undefined as unknown as string, symbol: 'UNKNOWN' },
+      ]
+      const results = fuzzySearchByKeys(items, ['name', 'symbol'], 'Ether')
+      expect(results).toHaveLength(1)
+      expect(results[0].symbol).toBe('ETH')
+    })
+
+    it('does not return duplicates', () => {
+      // "ETH" matches both name (Ethereum) and symbol (ETH) — should appear once
+      const results = fuzzySearchByKeys(tokens, ['name', 'symbol'], 'ETH')
+      const ethCount = results.filter(t => t.symbol === 'ETH').length
+      expect(ethCount).toBe(1)
+    })
+
+    it('handles single-character search', () => {
+      const results = fuzzySearchByKeys(tokens, ['symbol'], 'E')
+      const symbols = results.map(t => t.symbol)
+      expect(symbols).toContain('ETH')
+      expect(symbols).toContain('ENS')
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// searchArrayByKeysStr (existing function — regression tests)
+// ---------------------------------------------------------------------------
+
+describe('searchArrayByKeysStr', () => {
+  it('finds by prefix match', () => {
+    const results = searchArrayByKeysStr(tokens, ['name', 'symbol'], 'ETH')
+    expect(results[0].symbol).toBe('ETH')
+  })
+
+  it('finds by contains match', () => {
+    const results = searchArrayByKeysStr(tokens, ['name', 'symbol'], 'coin')
+    const names = results.map(t => t.name)
+    expect(names).toContain('USD Coin')
+    expect(names).toContain('Bitcoin')
+  })
+
+  it('is case-insensitive', () => {
+    const results = searchArrayByKeysStr(tokens, ['name', 'symbol'], 'eth')
+    expect(results[0].symbol).toBe('ETH')
+  })
+
+  it('prefix matches come before contains', () => {
+    const results = searchArrayByKeysStr(tokens, ['name', 'symbol'], 'eth')
+    const ethIdx = results.findIndex(t => t.symbol === 'ETH')
+    const stethIdx = results.findIndex(t => t.symbol === 'stETH')
+    expect(ethIdx).toBeLessThan(stethIdx)
+  })
+
+  it('does not return duplicates', () => {
+    const results = searchArrayByKeysStr(tokens, ['name', 'symbol'], 'ETH')
+    const ethCount = results.filter(t => t.symbol === 'ETH').length
+    expect(ethCount).toBe(1)
+  })
+
+  it('handles single key', () => {
+    const results = searchArrayByKeysStr(tokens, 'symbol', 'BTC')
+    expect(results[0].symbol).toBe('BTC')
+  })
+})


### PR DESCRIPTION
## Summary
- Add typo-tolerant fuzzy search (Levenshtein distance) to token selectors in swap, trade, and send modals, and to the stocks page search field
- Prefix and contains matches remain prioritized; fuzzy matches appear after
- No new dependencies — zero-dependency implementation in `src/utils/searchArray.ts`

## How to test
1. **Swap/Trade modal**: Open token selector, search with typos like "etherium", "teter", "bitcon" — should find the correct tokens
2. **Send modal**: Same typo searches in the token picker
3. **Stocks page**: Top search field — try "Tesle", "Gogle", "Appl" — should find matching stocks
4. **Exact searches still work**: "ETH", "USDT", "Bitcoin" should return results in the same order as before
5. **Run unit tests**: `npx vitest run tests/unit/searchArray.spec.ts` — 31 tests covering prefix, contains, fuzzy, nested keys, and edge cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved search for tokens and stocks: fuzzy matching that tolerates typos, searches nested fields, and prioritizes prefix/closer matches for more relevant ordering.

* **Bug Fixes / Improvements**
  * Token and stock selectors now use the new fuzzy search behavior for filtered results.

* **Tests**
  * Added unit tests covering fuzzy/exact behavior, result ordering, nested-key support, duplicate suppression, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->