### PR TITLE
fix: 🐛 improve network error handling in sentry and rewards api

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -30,6 +30,11 @@ if (dsn) {
     app,
     dsn,
     release: 'myetherwallet@' + configs.APP_VERSION,
+    ignoreErrors: [
+      'TypeError: Failed to fetch',
+      'TypeError: NetworkError when attempting to fetch resource',
+      'TypeError: Load failed',
+    ],
     integrations: [
       browserTracingIntegration({ router }),
       replayIntegration(),

--- a/src/stores/rewardsStore.ts
+++ b/src/stores/rewardsStore.ts
@@ -24,7 +24,7 @@ const fetchRewards = async <T>(url: string): Promise<T> => {
     },
   })
   if (!response.ok) {
-    const error = await response.json()
+    const error = await response.json().catch(() => ({}))
     throw new Error(error.message || 'Rewards API fetch failed')
   }
   return (await response.json()) as T


### PR DESCRIPTION
### Fix

fix for [APP-MEW-WEB-30](https://myetherwallet-inc.sentry.io/issues/7356605103/?query=is%3Aunresolved&referrer=issue-stream&sort=freq#contexts)

## What
Improved error handling for network-related failures in Sentry configuration and Rewards API.

## Why
- Network fetch errors (Failed to fetch, NetworkError, Load failed) were polluting Sentry with unactionable noise from user connectivity issues.
- The Rewards API was throwing confusing errors when the server responded with non-JSON error bodies (e.g., HTML 500 pages).

## How
- Added `ignoreErrors` config to Sentry to filter out common user browser network errors
- Added defensive `.catch()` to `response.json()` in rewards fetch to handle non-JSON error responses gracefully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved error reporting by filtering specific network-related error patterns
* Enhanced rewards API resilience with more robust error response handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->