### PR TITLE
fix: 🐛 filter user rejection errors before sending to sentry

### DIFF
--- a/src/i18n/locales/swap/en.json
+++ b/src/i18n/locales/swap/en.json
@@ -7,7 +7,9 @@
       "select-chain": "Please select a chain.",
       "unsupported-chain": "Selected chain is not supported.",
       "tx-sign-failed": "Transaction signing failed. Please try again.",
-      "tx-send-success": "Swap executed successfully."
+      "tx-send-success": "Swap executed successfully.",
+      "canceled-by-user": "Swap canceled by user.",
+      "failed": "Swap failed."
     },
     "error": {
       "amount-required": "Amount is required.",

--- a/src/i18n/locales/trade/en.json
+++ b/src/i18n/locales/trade/en.json
@@ -1,0 +1,13 @@
+{
+  "trade": {
+    "toast": {
+      "approval-success": "Approval successful!",
+      "approval-success-secondary": "You can now trade {symbol}.",
+      "quote-loading": "Please wait for quote to load"
+    },
+    "error": {
+      "approval-failed": "Could not approve token",
+      "submit-failed": "Failed to submit trade order"
+    }
+  }
+}

--- a/src/modules/access/composables/useConnectWallet.ts
+++ b/src/modules/access/composables/useConnectWallet.ts
@@ -22,6 +22,7 @@ import { useGlobalStore } from '@/stores/globalStore'
 import { analytics, ConnectWalletEvent } from '@/analytics'
 import { captureException } from '@sentry/vue'
 import { SENTRY_MODULE_TAGS } from '@/sentry/constants'
+import { isUserRejectionError } from '@/utils/walletUtils'
 
 export const useConnectWallet = () => {
   const { t } = useI18n()
@@ -116,10 +117,7 @@ export const useConnectWallet = () => {
         })
         .catch(err => {
           let error = t('error_connecting')
-          if (
-            err.message &&
-            err.message.toLowerCase().includes('user rejected')
-          ) {
+          if (isUserRejectionError(err)) {
             error = t('common.error.user_canceled_request')
           }
           accessStore.setWeb3ConnectionError(error)
@@ -190,20 +188,15 @@ export const useConnectWallet = () => {
         })
         .catch(err => {
           let error = t('error_connecting')
-          if (
-            err.message &&
-            err.message.toLowerCase().includes('user rejected')
-          ) {
+          if (isUserRejectionError(err)) {
             error = t('common.error.user_canceled_request')
-          }
-          if (
+          } else if (
             err.message &&
             err.message.toLowerCase().includes('already pending')
           ) {
             error =
               'Request to connect already pending, please check your wallet extension'
-          }
-          if (
+          } else if (
             err.message &&
             err.message.toLowerCase().includes('unrecognized chain id')
           ) {
@@ -266,14 +259,10 @@ export const useConnectWallet = () => {
       .catch(err => {
         let error = t('error_connecting')
         let _type = ToastType.Warning
-        if (
-          err.message &&
-          err.message.toLowerCase().includes('user rejected')
-        ) {
+        if (isUserRejectionError(err)) {
           error = t('common.error.user_canceled_request')
           _type = ToastType.Info
-        }
-        if (
+        } else if (
           err.message &&
           err.message.toLowerCase().includes('proposal expired')
         ) {

--- a/src/modules/send/components/EvmTransactionConfirmation.vue
+++ b/src/modules/send/components/EvmTransactionConfirmation.vue
@@ -275,7 +275,7 @@ import { Hardfork } from '@ethereumjs/common'
 import { hexToBytes, bytesToHex } from '@ethereumjs/util'
 import { fromWei } from 'web3-utils'
 import { useI18n } from 'vue-i18n'
-import { isSignableWallet } from '@/utils/walletUtils'
+import { isSignableWallet, isUserRejectionError } from '@/utils/walletUtils'
 import { captureException } from '@sentry/vue'
 import { SENTRY_MODULE_TAGS } from '@/sentry/constants'
 import {
@@ -426,7 +426,14 @@ const confirmTransaction = async () => {
         emit('tx-sent', hash)
       })
       .catch(e => {
-        //TODO: implement error localization
+        if (isUserRejectionError(e)) {
+          toastStore.addToastMessage({
+            type: ToastType.Info,
+            text: t('common.error.user_canceled_request'),
+          })
+          return
+        }
+
         const msg =
           e instanceof Error && e.message
             ? e.message.toLowerCase()
@@ -435,41 +442,41 @@ const confirmTransaction = async () => {
               : typeof e === 'string'
                 ? e.toLowerCase()
                 : ''
-        
-        if (msg.includes('rejected') || msg.includes('denied')  || msg.includes('cancelled')) {
-          toastStore.addToastMessage({
-            type: ToastType.Info,
-            text: 'Transaction canceled by user',
-          })
-        } else {
-          const errorMessage = msg ? sanitizeErrorMessage(msg) : undefined
+        const errorMessage = msg ? sanitizeErrorMessage(msg) : undefined
 
-          analytics.trackSendErrorEvent(SendEventError.SIGN_ERROR, {
-            token: props.toToken?.symbol,
-            errorMsg: errorMessage || msg,
-          })
+        analytics.trackSendErrorEvent(SendEventError.SIGN_ERROR, {
+          token: props.toToken?.symbol,
+          errorMsg: errorMessage || msg,
+        })
 
-          toastStore.addToastMessage({
-            type: ToastType.Error,
-            text: t('send.toast.tx-send-failed'),
-            textSecondary: errorMessage,
-          })
+        toastStore.addToastMessage({
+          type: ToastType.Error,
+          text: t('send.toast.tx-send-failed'),
+          textSecondary: errorMessage,
+        })
 
-          captureException(e, {
-            ...SENTRY_MODULE_TAGS.SEND,
-            extra: {
-              title: 'Error sending transaction: TX Promise',
-              errorMessage: errorMessage,
-            },
-          })
-        }
+        captureException(e instanceof Error ? e : new Error(msg), {
+          ...SENTRY_MODULE_TAGS.SEND,
+          extra: {
+            title: 'Error sending transaction: TX Promise',
+            errorMessage: errorMessage,
+          },
+        })
       })
     signing.value = false
     showApproveMessage.value = false
   } catch (e) {
-    // possibly catch more errors
     signing.value = false
     showApproveMessage.value = false
+
+    if (isUserRejectionError(e)) {
+      toastStore.addToastMessage({
+        type: ToastType.Info,
+        text: t('common.error.user_canceled_request'),
+      })
+      return
+    }
+
     const errorMessage =
       e instanceof Error && e.message
         ? sanitizeErrorMessage(e.message.toLowerCase())
@@ -486,7 +493,7 @@ const confirmTransaction = async () => {
       text: t('send.toast.tx-send-failed'),
       textSecondary: errorMessage,
     })
-    captureException(e, {
+    captureException(e instanceof Error ? e : new Error(errorMessage || 'Unknown error'), {
       ...SENTRY_MODULE_TAGS.SEND,
       extra: {
         title: 'Error sending transaction',

--- a/src/modules/swap/ModuleSwap.vue
+++ b/src/modules/swap/ModuleSwap.vue
@@ -289,7 +289,7 @@ import {
 } from '@/providers/types'
 import { ToastType } from '@/types/notification'
 import configs from '@/configs'
-import { isSignableWallet } from '@/utils/walletUtils'
+import { isSignableWallet, isUserRejectionError } from '@/utils/walletUtils'
 import { captureException } from '@sentry/vue'
 import { SENTRY_MODULE_TAGS } from '@/sentry/constants'
 
@@ -742,50 +742,42 @@ const proceedWithSwap = async (quoteId: string) => {
         : typeof e === 'string'
           ? e
           : t('swap.toast.tx-sign-failed')
-    if (errorMessage.includes('user rejected')) {
+
+    if (isUserRejectionError(e)) {
       toastStore.addToastMessage({
         type: ToastType.Info,
-        text: 'Swap canceled by user',
+        text: t('swap.toast.canceled-by-user'),
       })
       analytics.trackSwapEventError(SwapEventError.SIGN_ERROR, {
         ...analyticsPayload,
         errorMsg: 'declined_by_user',
       })
+      return
+    }
+
+    // Only real errors reach this point
+    if (isDevMode) {
+      console.error('Error proceeding with swap:', e)
     } else {
-      if (isDevMode) {
-        console.error('Error proceeding with swap:', e)
-      } else {
-        analytics.trackSwapEventError(SwapEventError.SIGN_ERROR, {
-          ...analyticsPayload,
-          errorMsg: errorMessage,
-        })
-        captureException(e, {
-          ...SENTRY_MODULE_TAGS.SWAP,
-          extra: {
-            title: 'SWAP: Error proceeding with swap',
-            errorMessage,
-          },
-        })
-      }
-      if (
-        errorMessage.includes('rejected') ||
-        errorMessage.includes('denied') ||
-        errorMessage.includes('cancelled')
-      ) {
-        toastStore.addToastMessage({
-          type: ToastType.Info,
-          text: 'Transaction canceled by user',
-        })
-        return
-      }
-      generalError.value = errorMessage
-      toastStore.addToastMessage({
-        type: ToastType.Error,
-        text: 'Swap Failed',
-        textSecondary: errorMessage,
-        duration: 10000,
+      analytics.trackSwapEventError(SwapEventError.SIGN_ERROR, {
+        ...analyticsPayload,
+        errorMsg: errorMessage,
+      })
+      captureException(e instanceof Error ? e : new Error(errorMessage), {
+        ...SENTRY_MODULE_TAGS.SWAP,
+        extra: {
+          title: 'SWAP: Error proceeding with swap',
+          errorMessage,
+        },
       })
     }
+    generalError.value = errorMessage
+    toastStore.addToastMessage({
+      type: ToastType.Error,
+      text: t('swap.toast.failed'),
+      textSecondary: errorMessage,
+      duration: 10000,
+    })
   } finally {
     txProceeding.value = false
   }

--- a/src/modules/trade/composables/useTradeExecution.ts
+++ b/src/modules/trade/composables/useTradeExecution.ts
@@ -1,4 +1,5 @@
 import { ref, type Ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { parseUnits, formatUnits } from 'viem'
 import { formatFloatingPointValue } from '@/utils/numberFormatHelper'
 import { useToastStore } from '@/stores/toastStore'
@@ -17,6 +18,7 @@ import {
 } from '@/analytics'
 import Configs from '@/configs'
 import { useRewardsStore } from '@/stores/rewardsStore'
+import { isUserRejectionError } from '@/utils/walletUtils'
 
 const isDevMode = Configs.IS_DEV_MODE
 
@@ -49,6 +51,7 @@ export function useTradeExecution(options: UseTradeExecutionOptions) {
     needsApproval,
   } = options
 
+  const { t } = useI18n()
   const toastStore = useToastStore()
   const tradeOrdersStore = useTradeOrdersStore()
   const rewardsStore = useRewardsStore()
@@ -91,21 +94,14 @@ export function useTradeExecution(options: UseTradeExecutionOptions) {
       needsApproval.value = false
 
       toastStore.addToastMessage({
-        text: 'Approval successful! ',
-        textSecondary: `You can now trade ${fromTokenSelected.value.symbol}.`,
+        text: t('trade.toast.approval-success'),
+        textSecondary: t('trade.toast.approval-success-secondary', { symbol: fromTokenSelected.value.symbol }),
         type: ToastType.Success,
       })
     } catch (e) {
-      const errorMessage = (e as any).message
-        ? (e as any).message.toLowerCase()
-        : (e as any).details
-          ? (e as any).details
-          : typeof e === 'string'
-            ? e
-            : 'Could not approve token'
-      if (errorMessage.includes('user rejected')) {
+      if (isUserRejectionError(e)) {
         toastStore.addToastMessage({
-          text: 'Approval cancelled by user',
+          text: t('common.error.user_canceled_request'),
           type: ToastType.Info,
         })
         analytics.trackTradeEventError(TradeEventError.APPROVAL_ERROR, {
@@ -114,6 +110,15 @@ export function useTradeExecution(options: UseTradeExecutionOptions) {
         })
         return
       }
+
+      const errorMessage = (e as any).message
+        ? (e as any).message.toLowerCase()
+        : (e as any).details
+          ? (e as any).details
+          : typeof e === 'string'
+            ? e
+            : t('trade.error.approval-failed')
+
       analytics.trackTradeEventError(TradeEventError.APPROVAL_ERROR, {
         ...getAnalyticsPayload(),
         errorMsg: errorMessage,
@@ -121,7 +126,7 @@ export function useTradeExecution(options: UseTradeExecutionOptions) {
       if (isDevMode) {
         console.error('Error approving token:', e)
       } else {
-        captureException(e, {
+        captureException(e instanceof Error ? e : new Error(errorMessage), {
           ...SENTRY_MODULE_TAGS.TRADE,
           extra: {
             title: 'TRADE: Error approving token',
@@ -131,7 +136,7 @@ export function useTradeExecution(options: UseTradeExecutionOptions) {
       }
 
       toastStore.addToastMessage({
-        text: 'Could not approve token',
+        text: t('trade.error.approval-failed'),
         textSecondary: errorMessage,
         type: ToastType.Error,
       })
@@ -143,7 +148,7 @@ export function useTradeExecution(options: UseTradeExecutionOptions) {
   const openTradeModal = () => {
     if (!currentQuote.value) {
       toastStore.addToastMessage({
-        text: 'Please wait for quote to load',
+        text: t('trade.toast.quote-loading'),
       })
       return
     }
@@ -238,28 +243,30 @@ export function useTradeExecution(options: UseTradeExecutionOptions) {
         toTokenAddress: toTokenSelected.value.address,
       })
     } catch (e) {
+      if (isUserRejectionError(e)) {
+        analytics.trackTradeEventError(TradeEventError.SIGN_ERROR, {
+          ...analyticsPayload,
+          errorMsg: 'declined_by_user',
+        })
+        toastStore.addToastMessage({
+          text: t('common.error.user_canceled_request'),
+          type: ToastType.Info,
+        })
+        return
+      }
+
       const errorMessage = (e as any).message
         ? (e as any).message.toLowerCase()
         : (e as any).details
           ? (e as any).details
           : typeof e === 'string'
             ? e
-            : 'Failed to submit trade order'
-      if (errorMessage.includes('user rejected')) {
-        analytics.trackTradeEventError(TradeEventError.SIGN_ERROR, {
-          ...analyticsPayload,
-          errorMsg: 'declined_by_user',
-        })
-        toastStore.addToastMessage({
-          text: 'Trade cancelled by user',
-          type: ToastType.Info,
-        })
-        return
-      }
+            : t('trade.error.submit-failed')
+
       if (isDevMode) {
         console.error('Error submitting trade order:', e)
       } else {
-        captureException(e, {
+        captureException(e instanceof Error ? e : new Error(errorMessage), {
           ...SENTRY_MODULE_TAGS.TRADE,
           extra: {
             title: 'TRADE: Error submitting trade order',
@@ -273,7 +280,7 @@ export function useTradeExecution(options: UseTradeExecutionOptions) {
       }
 
       toastStore.addToastMessage({
-        text: 'Failed to submit trade order',
+        text: t('trade.error.submit-failed'),
         textSecondary: errorMessage,
         type: ToastType.Error,
       })

--- a/src/utils/walletUtils.ts
+++ b/src/utils/walletUtils.ts
@@ -10,3 +10,19 @@ export const isSignableWallet = (wallet: WalletInterface) => {
     type === WalletType.MNEMONIC
   )
 }
+
+/**
+ * Checks if an error is a user rejection (e.g. user cancelled transaction in wallet).
+ * Detects EIP-1193 code 4001 and common rejection message patterns.
+ */
+export const isUserRejectionError = (error: unknown): boolean => {
+  const err = error as { code?: number; message?: string }
+  const message = err?.message?.toLowerCase() ?? ''
+  return (
+    err?.code === 4001 ||
+    message.includes('rejected') ||
+    message.includes('denied') ||
+    message.includes('cancelled') ||
+    message.includes('canceled')
+  )
+}


### PR DESCRIPTION
### Fix

fix for [APP-MEW-WEB-NJ](https://myetherwallet-inc.sentry.io/issues/7402400165/?query=is%3Aunresolved&referrer=issue-stream&sort=freq)

## What
Filter wallet user rejection errors (EIP-1193 code 4001) before sending them to Sentry, and centralize the detection logic in a reusable helper.

## Why
Sentry was receiving ~200 events in 4 days from users simply cancelling transactions in MetaMask. These are expected user actions, not application errors, creating noise that can hide real issues.

## How
- Add `isUserRejectionError()` helper in `src/utils/walletUtils.ts` that detects EIP-1193 code 4001 and common rejection message patterns
- Refactor swap, trade, send, and access modules to use the helper and filter rejections before `captureException`
- Ensure `captureException` receives proper `Error` instances instead of plain objects
- Add missing i18n strings for trade and swap modules


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added localized error messages for swap cancellations and failures
  * Introduced localized notifications for trade approvals and submission errors

* **Refactor**
  * Improved error handling for wallet connections and transaction rejections
  * Enhanced consistency in user-facing error messages across the platform

<!-- end of auto-generated comment: release notes by coderabbit.ai -->