### PR TITLE
fix: 🐛 prevent race condition in swap getQuotes call

### DIFF
--- a/src/composables/useSwap.ts
+++ b/src/composables/useSwap.ts
@@ -244,7 +244,7 @@ export const useSwap = (): {
   const getQuote = async (
     params: QuoteParam,
   ): Promise<ProviderQuoteResponse[] | undefined> => {
-    if (!swapInstance.value) {
+    if (!swapInstance.value || !swapLoaded.value) {
       return undefined
     }
 

--- a/src/modules/swap/ModuleSwap.vue
+++ b/src/modules/swap/ModuleSwap.vue
@@ -1314,6 +1314,7 @@ watch(
     }
 
     if (
+      swapLoaded.value &&
       !BigNumber(fromAmount.value).isNaN() &&
       !BigNumber(fromAmount.value).isZero() &&
       toTokenSelected.value


### PR DESCRIPTION
### Fix

fix for [APP-MEW-WEB-AJ](https://myetherwallet-inc.sentry.io/issues/7367991868/?query=is%3Aunresolved&referrer=issue-stream&sort=freq)

### What
Added guards to prevent `getQuote` from being called before the swap provider is fully initialized.

### Why
Fixes Sentry error `TypeError: Cannot read properties of undefined (reading 'map')` (239 events in production). The error occurred because `fetchQuotes` was called before `@enkryptcom/swap` finished initializing its internal providers array.

### How
- Added `swapLoaded.value` check in `useSwap.ts` `getQuote()` function to return early if not initialized
- Added `swapLoaded.value` guard in `ModuleSwap.vue` watcher before triggering `debounceFetchQuotes()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced swap quote fetching to ensure it only occurs when the swap system is fully loaded, preventing errors and ensuring reliable quote retrieval during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->