### PR TITLE
feat: add sign out button to perpetuals portfolio

### DIFF
--- a/src/views/ViewPerps.vue
+++ b/src/views/ViewPerps.vue
@@ -33,11 +33,19 @@
 
     <!-- Authenticated -->
     <template v-else>
-      <h1
-        class="text-s-24 xs:text-s-32 font-bold col-span-1 lg:col-span-2 px-2"
+      <div
+        class="flex items-center justify-between col-span-1 lg:col-span-2 px-2"
       >
-        Perpetuals Portfolio
-      </h1>
+        <h1 class="text-s-24 xs:text-s-32 font-bold">
+          Perpetuals Portfolio
+        </h1>
+        <button
+          class="text-error text-s-14 font-medium hoverOpacity"
+          @click="logout"
+        >
+          Sign Out
+        </button>
+      </div>
       <div class="grid grid-cols-1 lg:grid-cols-[300px_1fr] gap-6 -mt-2">
         <perps-portfolio-summary
           @deposit="showDeposit = true"
@@ -79,7 +87,7 @@ const walletMenu = useWalletMenuStore()
 const walletStore = useWalletStore()
 const { isWatchOnly } = storeToRefs(walletStore)
 const accessStore = useAccessStore()
-const { token, isWalletConnected, isAuthenticating, authError, login } =
+const { token, isWalletConnected, isAuthenticating, authError, login, logout } =
   usePerpsAuth()
 const connectWallet = () => accessStore.openAccessDialog()
 const showDeposit = ref(false)


### PR DESCRIPTION
## Summary
- Adds a "Sign Out" button next to the "Perpetuals Portfolio" title on the perps page
- Uses the existing `logout()` from `usePerpsAuth` to clear auth token and localStorage

## Test plan
- [ ] Navigate to perps portfolio while authenticated
- [ ] Verify "Sign Out" button appears next to the title
- [ ] Click "Sign Out" and confirm user is logged out and sees the sign-in prompt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive Perpetuals trading platform with market discovery, position management, and order placement
  * Implemented portfolio tracking with balance summary, unrealized P&L, and historical charts
  * Added USDC deposit and withdrawal functionality
  * Introduced market detail views with price history, funding rates, and order/fill information
  * Added leverage and take-profit/stop-loss configuration controls

* **Style**
  * Enhanced button styling with new success theme variant
  * Improved dropdown and list item alignment and spacing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->