### PR TITLE
feat: improve perps portfolio chart tooltip

### DIFF
--- a/src/modules/perps/components/PerpsPortfolioChart.vue
+++ b/src/modules/perps/components/PerpsPortfolioChart.vue
@@ -45,6 +45,7 @@
       :top-data="activeSeries.has('invested') ? chartPointsInvested : []"
       :bottom-data="activeSeries.has('pnl') ? chartPointsPnl : []"
       :dispalay-y-axis="true"
+      :series-labels="tooltipLabels"
       class="h-full !shrink"
     />
     <div v-else class="text-center py-8 text-info text-s-14">
@@ -75,6 +76,11 @@ const seriesOptions: { key: SeriesKey; label: string; color: string }[] = [
   { key: 'invested', label: 'Net Invested', color: '#9D00FF' },
   { key: 'pnl', label: 'PnL', color: 'rgb(5,192,165)' },
 ]
+
+const tooltipLabels = seriesOptions.map(s => ({
+  label: s.label,
+  color: s.color,
+}))
 
 const activeSeries = reactive<Set<SeriesKey>>(
   new Set(['value', 'invested', 'pnl']),

--- a/src/modules/portfolio/components/history/HistoryChart.vue
+++ b/src/modules/portfolio/components/history/HistoryChart.vue
@@ -1,10 +1,16 @@
 <template>
   <div class="chart-wrapper flex relative">
-    <Line ref="historyChart" :data="chartData" :options="chartOptions" />
+    <Line
+      ref="historyChart"
+      :data="chartData"
+      :options="chartOptions"
+      :plugins="plugins"
+    />
     <div
       v-if="customTooltip"
       ref="tooltipEl"
       class="chart-custom-tooltip"
+      :class="`chart-custom-tooltip--${customTooltip.placement}`"
       :style="customTooltip.style"
     >
       <div class="tooltip-title">{{ customTooltip.title }}</div>
@@ -52,6 +58,7 @@ interface TooltipState {
   title: string
   rows: { label: string; value: string; color: string }[]
   style: Record<string, string>
+  placement: 'top' | 'bottom'
 }
 
 const props = defineProps<{
@@ -97,10 +104,37 @@ const bottomPoints = computed(() => props.bottomData?.map(d => d.value) || [])
 const chartWidth = ref<number>(0)
 const chartHeight = ref<number>(0)
 const gradient = ref<CanvasGradient | null>(null)
+const plugins = [
+  {
+    id: 'verticalLine',
+    afterDraw: (chart: Chart) => {
+      if ((chart.tooltip?.opacity ?? 0) > 0) {
+        const x = chart.tooltip!.caretX
+        const ctx = chart.ctx
+        const topY = chart.chartArea.top
+        const bottomY = chart.chartArea.bottom
+
+        ctx.save()
+        ctx.setLineDash([5, 5])
+        ctx.beginPath()
+        ctx.moveTo(x, topY)
+        ctx.lineTo(x, bottomY)
+        ctx.lineWidth = 1
+        ctx.strokeStyle = 'rgba(0,90,229,0.65)'
+        ctx.stroke()
+        ctx.restore()
+      }
+    },
+  },
+]
+
 const chartData = computed<ChartData<'line'>>(() => {
   const lineSettings = {
     borderWidth: 1.5,
     pointRadius: 0,
+    pointHoverRadius: 5,
+    pointHoverBorderWidth: 2,
+    pointHoverBorderColor: '#fff',
     tension: 0.5, // low smoothing to keep detail
   }
   const dataSet: ChartData<'line'> = {
@@ -179,6 +213,14 @@ const yBounds = computed(() => {
 const chartOptions = computed<ChartOptions<'line'>>(() => ({
   responsive: true,
   maintainAspectRatio: false,
+  interaction: {
+    mode: 'index',
+    intersect: false,
+  },
+  hover: {
+    mode: 'index',
+    intersect: false,
+  },
   plugins: {
     tooltip: props.seriesLabels
       ? {
@@ -220,11 +262,9 @@ const chartOptions = computed<ChartOptions<'line'>>(() => ({
               })
             })
 
-            const left = tooltip.caretX
-            const top = tooltip.caretY
             const chartRect = chart.canvas.getBoundingClientRect()
-            const wrapperRect =
-              chart.canvas.parentElement?.getBoundingClientRect()
+            const wrapperEl = chart.canvas.parentElement
+            const wrapperRect = wrapperEl?.getBoundingClientRect()
             const offsetLeft = wrapperRect
               ? chartRect.left - wrapperRect.left
               : 0
@@ -232,12 +272,30 @@ const chartOptions = computed<ChartOptions<'line'>>(() => ({
               ? chartRect.top - wrapperRect.top
               : 0
 
+            const estRowHeight = 22
+            const estTooltipHeight = 46 + rows.length * estRowHeight
+            const estTooltipWidth = tooltipEl.value?.offsetWidth ?? 200
+            const gap = 12
+
+            const caretX = tooltip.caretX
+            const caretY = tooltip.caretY
+
+            const placement: 'top' | 'bottom' =
+              caretY - estTooltipHeight - gap < 0 ? 'bottom' : 'top'
+
+            const wrapperWidth = wrapperRect?.width ?? chartRect.width
+            const halfWidth = estTooltipWidth / 2
+            const minLeft = halfWidth - offsetLeft + 4
+            const maxLeft = wrapperWidth - halfWidth - offsetLeft - 4
+            const clampedCaretX = Math.min(Math.max(caretX, minLeft), maxLeft)
+
             customTooltip.value = {
               title,
               rows,
+              placement,
               style: {
-                left: left + offsetLeft + 'px',
-                top: top + offsetTop + 'px',
+                left: clampedCaretX + offsetLeft + 'px',
+                top: caretY + offsetTop + 'px',
               },
             }
           },
@@ -353,10 +411,17 @@ canvas {
   background: rgba(0, 0, 0, 0.85);
   border-radius: 8px;
   padding: 10px 14px;
-  transform: translate(-50%, calc(-100% - 12px));
   white-space: nowrap;
   z-index: 10;
   font-family: Roboto, sans-serif;
+}
+
+.chart-custom-tooltip--top {
+  transform: translate(-50%, calc(-100% - 12px));
+}
+
+.chart-custom-tooltip--bottom {
+  transform: translate(-50%, 12px);
 }
 
 .tooltip-title {

--- a/src/modules/portfolio/components/history/HistoryChart.vue
+++ b/src/modules/portfolio/components/history/HistoryChart.vue
@@ -1,6 +1,24 @@
 <template>
-  <div class="flex">
+  <div class="chart-wrapper flex relative">
     <Line ref="historyChart" :data="chartData" :options="chartOptions" />
+    <div
+      v-if="customTooltip"
+      ref="tooltipEl"
+      class="chart-custom-tooltip"
+      :style="customTooltip.style"
+    >
+      <div class="tooltip-title">{{ customTooltip.title }}</div>
+      <div
+        v-for="row in customTooltip.rows"
+        :key="row.label"
+        class="tooltip-row"
+      >
+        <span class="tooltip-label">{{
+          row.label
+        }}</span>
+        <span class="tooltip-value">{{ row.value }}</span>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -24,12 +42,26 @@ interface DataPoint {
   timestamp: number
   value: number
 }
+
+interface SeriesLabel {
+  label: string
+  color: string
+}
+
+interface TooltipState {
+  title: string
+  rows: { label: string; value: string; color: string }[]
+  style: Record<string, string>
+}
+
 const props = defineProps<{
   /** 7 days * 24 hours = 168 values (oldest -> newest) */
   data: DataPoint[]
   topData?: DataPoint[]
   bottomData?: DataPoint[]
   dispalayYAxis?: boolean
+  /** Labels for [data, topData, bottomData] series in tooltip */
+  seriesLabels?: SeriesLabel[]
 }>()
 
 /**
@@ -52,6 +84,9 @@ const colors = {
   bgGrey: 'rgba(0,0,0,0.05)',
   tooltipBg: 'rgba(0,0,0,0.7)',
 }
+
+const customTooltip = ref<TooltipState | null>(null)
+const tooltipEl = ref<HTMLElement | null>(null)
 
 const points = computed(() => props.data.map(d => d.value))
 const labels = computed(() => props.data.map(d => d.timestamp))
@@ -145,50 +180,113 @@ const chartOptions = computed<ChartOptions<'line'>>(() => ({
   responsive: true,
   maintainAspectRatio: false,
   plugins: {
-    tooltip: {
-      filter: function (tooltipItem) {
-        // Disable tooltip for Dataset 2 (which has index 1)
-        return tooltipItem.datasetIndex !== 1
-      },
-      padding: 10,
-      backgroundColor: colors.tooltipBg,
-      boxPadding: 10,
-      bodySpacing: 3,
-      intersect: false,
-      titleSpacing: 3,
-      displayColors: false,
-      titleFont: {
-        size: 12,
-        fontFamily: 'Roboto , sans-serif',
-        weight: 'normal',
-      },
-      bodyFont: {
-        size: 16,
-        fontFamily: 'Roboto , sans-serif',
-      },
-      callbacks: {
-        label: function (context) {
-          let label = context.dataset.label || ''
-          if (label) {
-            label += ': '
-          }
-          if (context.parsed.y !== null) {
-            return '$' + formatFiatValue(context.parsed.y).value
-          }
-          return label
+    tooltip: props.seriesLabels
+      ? {
+          enabled: false,
+          intersect: false,
+          external: function (context) {
+            const { tooltip, chart } = context
+            if (tooltip.opacity === 0) {
+              customTooltip.value = null
+              return
+            }
+            const dataIndex = tooltip.dataPoints?.[0]?.dataIndex
+            if (dataIndex == null) return
+
+            const date = new Date(labels.value[dataIndex] || '')
+            const title = date.toLocaleDateString('en-US', {
+              day: '2-digit',
+              month: 'short',
+              year: 'numeric',
+              hour: '2-digit',
+              minute: '2-digit',
+            })
+
+            const allData = [
+              props.data,
+              props.topData,
+              props.bottomData,
+            ]
+            const rows: TooltipState['rows'] = []
+            props.seriesLabels!.forEach((s, i) => {
+              const seriesData = allData[i]
+              if (!seriesData || seriesData.length === 0) return
+              const val = seriesData[dataIndex]?.value
+              if (val == null) return
+              rows.push({
+                label: s.label,
+                color: s.color,
+                value: '$' + formatFiatValue(val).value,
+              })
+            })
+
+            const left = tooltip.caretX
+            const top = tooltip.caretY
+            const chartRect = chart.canvas.getBoundingClientRect()
+            const wrapperRect =
+              chart.canvas.parentElement?.getBoundingClientRect()
+            const offsetLeft = wrapperRect
+              ? chartRect.left - wrapperRect.left
+              : 0
+            const offsetTop = wrapperRect
+              ? chartRect.top - wrapperRect.top
+              : 0
+
+            customTooltip.value = {
+              title,
+              rows,
+              style: {
+                left: left + offsetLeft + 'px',
+                top: top + offsetTop + 'px',
+              },
+            }
+          },
+        }
+      : {
+          filter: function (tooltipItem) {
+            return tooltipItem.datasetIndex !== 1
+          },
+          padding: 10,
+          backgroundColor: colors.tooltipBg,
+          boxPadding: 10,
+          bodySpacing: 3,
+          intersect: false,
+          titleSpacing: 3,
+          displayColors: false,
+          titleFont: {
+            size: 12,
+            fontFamily: 'Roboto , sans-serif',
+            weight: 'normal',
+          },
+          bodyFont: {
+            size: 16,
+            fontFamily: 'Roboto , sans-serif',
+          },
+          callbacks: {
+            label: function (context) {
+              let label = context.dataset.label || ''
+              if (label) {
+                label += ': '
+              }
+              if (context.parsed.y !== null) {
+                return '$' + formatFiatValue(context.parsed.y).value
+              }
+              return label
+            },
+            title: function (context) {
+              if (context.length === 0) {
+                return ''
+              }
+              const date = new Date(
+                labels.value[context[0].dataIndex] || '',
+              )
+              return date.toLocaleDateString('en-US', {
+                minute: 'numeric',
+                hour: 'numeric',
+              })
+            },
+          },
         },
-        title: function (context) {
-          if (context.length === 0) {
-            return ''
-          }
-          const date = new Date(labels.value[context[0].dataIndex] || '')
-          return date.toLocaleDateString('en-US', {
-            minute: 'numeric',
-            hour: 'numeric',
-          })
-        },
-      },
-    },
   },
   scales: {
     x: {
@@ -243,5 +341,45 @@ const chartOptions = computed<ChartOptions<'line'>>(() => ({
 /* Crisp lines in tiny canvases */
 canvas {
   image-rendering: -webkit-optimize-contrast;
+}
+
+.chart-wrapper {
+  position: relative;
+}
+
+.chart-custom-tooltip {
+  position: absolute;
+  pointer-events: none;
+  background: rgba(0, 0, 0, 0.85);
+  border-radius: 8px;
+  padding: 10px 14px;
+  transform: translate(-50%, calc(-100% - 12px));
+  white-space: nowrap;
+  z-index: 10;
+  font-family: Roboto, sans-serif;
+}
+
+.tooltip-title {
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.7);
+  margin-bottom: 6px;
+}
+
+.tooltip-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.tooltip-label {
+  font-weight: 400;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.tooltip-value {
+  color: #fff;
+  font-weight: 500;
 }
 </style>

--- a/src/modules/portfolio/components/history/HistoryChart.vue
+++ b/src/modules/portfolio/components/history/HistoryChart.vue
@@ -19,9 +19,7 @@
         :key="row.label"
         class="tooltip-row"
       >
-        <span class="tooltip-label">{{
-          row.label
-        }}</span>
+        <span class="tooltip-label">{{ row.label }}</span>
         <span class="tooltip-value">{{ row.value }}</span>
       </div>
     </div>
@@ -235,20 +233,25 @@ const chartOptions = computed<ChartOptions<'line'>>(() => ({
             const dataIndex = tooltip.dataPoints?.[0]?.dataIndex
             if (dataIndex == null) return
 
-            const date = new Date(labels.value[dataIndex] || '')
-            const title = date.toLocaleDateString('en-US', {
-              day: '2-digit',
-              month: 'short',
-              year: 'numeric',
-              hour: '2-digit',
-              minute: '2-digit',
-            })
+            const allData = [props.data, props.topData, props.bottomData]
 
-            const allData = [
-              props.data,
-              props.topData,
-              props.bottomData,
-            ]
+            const timestamp = allData
+              .map(series => series?.[dataIndex]?.timestamp)
+              .find(ts => ts != null)
+            let title = ''
+            if (timestamp != null) {
+              const date = new Date(timestamp)
+              if (!isNaN(date.getTime())) {
+                title = date.toLocaleString('en-US', {
+                  day: '2-digit',
+                  month: 'short',
+                  year: 'numeric',
+                  hour: '2-digit',
+                  minute: '2-digit',
+                  hour12: true,
+                })
+              }
+            }
             const rows: TooltipState['rows'] = []
             props.seriesLabels!.forEach((s, i) => {
               const seriesData = allData[i]
@@ -268,9 +271,7 @@ const chartOptions = computed<ChartOptions<'line'>>(() => ({
             const offsetLeft = wrapperRect
               ? chartRect.left - wrapperRect.left
               : 0
-            const offsetTop = wrapperRect
-              ? chartRect.top - wrapperRect.top
-              : 0
+            const offsetTop = wrapperRect ? chartRect.top - wrapperRect.top : 0
 
             const estRowHeight = 22
             const estTooltipHeight = 46 + rows.length * estRowHeight
@@ -335,9 +336,7 @@ const chartOptions = computed<ChartOptions<'line'>>(() => ({
               if (context.length === 0) {
                 return ''
               }
-              const date = new Date(
-                labels.value[context[0].dataIndex] || '',
-              )
+              const date = new Date(labels.value[context[0].dataIndex] || '')
               return date.toLocaleDateString('en-US', {
                 minute: 'numeric',
                 hour: 'numeric',

--- a/src/modules/portfolio/components/history/HistoryChart.vue
+++ b/src/modules/portfolio/components/history/HistoryChart.vue
@@ -19,6 +19,10 @@
         :key="row.label"
         class="tooltip-row"
       >
+        <span
+          class="tooltip-dot"
+          :style="{ backgroundColor: row.color }"
+        ></span>
         <span class="tooltip-label">{{ row.label }}</span>
         <span class="tooltip-value">{{ row.value }}</span>
       </div>
@@ -435,6 +439,14 @@ canvas {
   gap: 8px;
   font-size: 14px;
   line-height: 1.6;
+}
+
+.tooltip-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
 }
 
 .tooltip-label {


### PR DESCRIPTION
## Summary
- Replaces single-series tooltip with custom HTML tooltip showing all three series (Value, Net Invested, PnL)
- Date format updated to "DD Mon YYYY, HH:MM AM/PM"
- Series labels styled in muted gray, values in white, on dark background
- Added optional `seriesLabels` prop to HistoryChart — existing portfolio usage is unaffected

## Test plan
- [ ] Hover over the perps portfolio chart and verify tooltip shows all three series with dollar values
- [ ] Verify date format matches "09 Apr 2026, 05:00 PM" style
- [ ] Toggle series on/off and verify tooltip only shows active series data
- [ ] Verify portfolio history chart (non-perps) tooltip still works as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-row, externally rendered chart tooltip with manual positioning and clamped placement
  * Dashed vertical indicator line when hovering chart data
  * Tooltip accepts per-series labels for clearer multi-series display

* **Improvements**
  * Hover interactions use index-based mode for snappier response and improved point styling
  * Y-axis visibility can be toggled; tooltip overflow avoided for better layout stability
<!-- end of auto-generated comment: release notes by coderabbit.ai -->