### PR TITLE
feat: add skeleton loading states to perps tables

### DIFF
--- a/src/components/AppTableSkeleton.vue
+++ b/src/components/AppTableSkeleton.vue
@@ -1,5 +1,5 @@
 <template>
-  <table class="w-full table-fixed">
+  <table class="w-full">
     <thead v-if="hasHeaders">
       <tr
         class="text-left text-s-11 uppercase text-info tracking-sp-06 font-bold"

--- a/src/components/AppTableSkeleton.vue
+++ b/src/components/AppTableSkeleton.vue
@@ -21,89 +21,12 @@
       </tr>
     </thead>
     <tbody>
-      <tr v-for="row in rows" :key="row" class="h-14">
+      <tr v-for="row in rows" :key="row">
         <td
-          v-for="(col, i) in columns"
-          :key="i"
-          class="px-1 py-3"
-          :class="[
-            col.hidden,
-            col.align === 'right' ? 'text-right' : 'text-left',
-            i === 0 ? 'sm:pl-4 rounded-l-12' : '',
-            i === columns.length - 1 ? 'sm:pr-4 rounded-r-12' : '',
-            col.class,
-          ]"
-          :style="col.width ? { width: col.width } : {}"
+          :colspan="columns.length"
+          class="px-1 sm:px-4 py-2"
         >
-          <!-- Icon + text (name column) -->
-          <div v-if="col.type === 'name'" class="flex items-center gap-3">
-            <div
-              class="size-8 rounded-full bg-grey-10 animate-pulse shrink-0"
-            ></div>
-            <div class="flex flex-col gap-1.5 min-w-0">
-              <div
-                class="h-3.5 bg-grey-10 animate-pulse rounded-full"
-                :style="{ width: nameWidth(row) }"
-              ></div>
-              <div
-                class="h-2.5 w-12 bg-grey-10 animate-pulse rounded-full"
-              ></div>
-            </div>
-          </div>
-
-          <!-- Plain text bar -->
-          <div
-            v-else-if="!col.type || col.type === 'text'"
-            class="animate-pulse rounded-full bg-grey-10 h-3.5"
-            :class="col.align === 'right' ? 'ml-auto' : ''"
-            :style="{ width: textWidth(row, i) }"
-          ></div>
-
-          <!-- Chart / sparkline area -->
-          <div
-            v-else-if="col.type === 'chart'"
-            class="flex flex-col items-end gap-1.5"
-          >
-            <div
-              class="h-3 w-10 bg-grey-10 animate-pulse rounded-full"
-            ></div>
-            <div
-              class="h-6 w-[70px] bg-grey-10 animate-pulse rounded"
-            ></div>
-          </div>
-
-          <!-- Button pair (Long / Short) -->
-          <div
-            v-else-if="col.type === 'buttons'"
-            class="flex gap-2 justify-end"
-          >
-            <div
-              class="h-8 w-16 bg-grey-10 animate-pulse rounded-full"
-            ></div>
-            <div
-              class="h-8 w-16 bg-grey-10 animate-pulse rounded-full"
-            ></div>
-          </div>
-
-          <!-- Single action button -->
-          <div
-            v-else-if="col.type === 'action'"
-            class="flex justify-end"
-          >
-            <div
-              class="h-8 w-20 bg-grey-10 animate-pulse rounded-full"
-            ></div>
-          </div>
-
-          <!-- Small icon only (star, chevron) -->
-          <div
-            v-else-if="col.type === 'icon'"
-            class="flex justify-center"
-          >
-            <div
-              class="size-5 bg-grey-10 animate-pulse rounded-full"
-            ></div>
-          </div>
+          <div class="h-10 bg-grey-10 animate-pulse rounded-12"></div>
         </td>
       </tr>
     </tbody>
@@ -114,16 +37,12 @@
 import { computed } from 'vue'
 
 export interface SkeletonColumn {
-  /** Column type determines the placeholder shape */
-  type?: 'text' | 'name' | 'chart' | 'buttons' | 'action' | 'icon'
   /** Text alignment */
   align?: 'left' | 'right' | 'center'
   /** Fixed width (CSS value, e.g. '40px', '200px') */
   width?: string
   /** Responsive visibility classes (e.g. 'hidden md:table-cell') */
   hidden?: string
-  /** Additional CSS classes */
-  class?: string
   /** Header label — renders a <thead> row when at least one column has this */
   header?: string
 }
@@ -137,26 +56,9 @@ const props = withDefaults(
   }>(),
   {
     rows: 5,
-    columns: () => [
-      { type: 'name' },
-      { type: 'text', align: 'right' },
-      { type: 'text', align: 'right' },
-      { type: 'text', align: 'right' },
-    ],
+    columns: () => [{ header: '' }, { header: '' }, { header: '' }],
   },
 )
 
 const hasHeaders = computed(() => props.columns.some(c => c.header))
-
-/** Vary name widths per row to look organic */
-function nameWidth(row: number): string {
-  const widths = ['72px', '56px', '64px', '80px', '48px', '60px', '68px', '52px']
-  return widths[(row - 1) % widths.length]
-}
-
-/** Vary text bar widths per row+col to look organic */
-function textWidth(row: number, col: number): string {
-  const widths = ['48px', '56px', '40px', '64px', '52px', '44px', '60px']
-  return widths[(row + col) % widths.length]
-}
 </script>

--- a/src/components/AppTableSkeleton.vue
+++ b/src/components/AppTableSkeleton.vue
@@ -1,0 +1,162 @@
+<template>
+  <table class="w-full table-fixed">
+    <thead v-if="hasHeaders">
+      <tr
+        class="text-left text-s-11 uppercase text-info tracking-sp-06 font-bold"
+      >
+        <th
+          v-for="(col, i) in columns"
+          :key="i"
+          class="px-1 py-2 font-bold"
+          :class="[
+            col.hidden,
+            col.align === 'right' ? 'text-right' : 'text-left',
+            i === 0 ? 'sm:pl-4' : '',
+            i === columns.length - 1 ? 'sm:pr-4' : '',
+          ]"
+          :style="col.width ? { width: col.width } : {}"
+        >
+          {{ col.header }}
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr v-for="row in rows" :key="row" class="h-14">
+        <td
+          v-for="(col, i) in columns"
+          :key="i"
+          class="px-1 py-3"
+          :class="[
+            col.hidden,
+            col.align === 'right' ? 'text-right' : 'text-left',
+            i === 0 ? 'sm:pl-4 rounded-l-12' : '',
+            i === columns.length - 1 ? 'sm:pr-4 rounded-r-12' : '',
+            col.class,
+          ]"
+          :style="col.width ? { width: col.width } : {}"
+        >
+          <!-- Icon + text (name column) -->
+          <div v-if="col.type === 'name'" class="flex items-center gap-3">
+            <div
+              class="size-8 rounded-full bg-grey-10 animate-pulse shrink-0"
+            ></div>
+            <div class="flex flex-col gap-1.5 min-w-0">
+              <div
+                class="h-3.5 bg-grey-10 animate-pulse rounded-full"
+                :style="{ width: nameWidth(row) }"
+              ></div>
+              <div
+                class="h-2.5 w-12 bg-grey-10 animate-pulse rounded-full"
+              ></div>
+            </div>
+          </div>
+
+          <!-- Plain text bar -->
+          <div
+            v-else-if="!col.type || col.type === 'text'"
+            class="animate-pulse rounded-full bg-grey-10 h-3.5"
+            :class="col.align === 'right' ? 'ml-auto' : ''"
+            :style="{ width: textWidth(row, i) }"
+          ></div>
+
+          <!-- Chart / sparkline area -->
+          <div
+            v-else-if="col.type === 'chart'"
+            class="flex flex-col items-end gap-1.5"
+          >
+            <div
+              class="h-3 w-10 bg-grey-10 animate-pulse rounded-full"
+            ></div>
+            <div
+              class="h-6 w-[70px] bg-grey-10 animate-pulse rounded"
+            ></div>
+          </div>
+
+          <!-- Button pair (Long / Short) -->
+          <div
+            v-else-if="col.type === 'buttons'"
+            class="flex gap-2 justify-end"
+          >
+            <div
+              class="h-8 w-16 bg-grey-10 animate-pulse rounded-full"
+            ></div>
+            <div
+              class="h-8 w-16 bg-grey-10 animate-pulse rounded-full"
+            ></div>
+          </div>
+
+          <!-- Single action button -->
+          <div
+            v-else-if="col.type === 'action'"
+            class="flex justify-end"
+          >
+            <div
+              class="h-8 w-20 bg-grey-10 animate-pulse rounded-full"
+            ></div>
+          </div>
+
+          <!-- Small icon only (star, chevron) -->
+          <div
+            v-else-if="col.type === 'icon'"
+            class="flex justify-center"
+          >
+            <div
+              class="size-5 bg-grey-10 animate-pulse rounded-full"
+            ></div>
+          </div>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+export interface SkeletonColumn {
+  /** Column type determines the placeholder shape */
+  type?: 'text' | 'name' | 'chart' | 'buttons' | 'action' | 'icon'
+  /** Text alignment */
+  align?: 'left' | 'right' | 'center'
+  /** Fixed width (CSS value, e.g. '40px', '200px') */
+  width?: string
+  /** Responsive visibility classes (e.g. 'hidden md:table-cell') */
+  hidden?: string
+  /** Additional CSS classes */
+  class?: string
+  /** Header label — renders a <thead> row when at least one column has this */
+  header?: string
+}
+
+const props = withDefaults(
+  defineProps<{
+    /** Number of skeleton rows to display */
+    rows?: number
+    /** Column configuration array */
+    columns?: SkeletonColumn[]
+  }>(),
+  {
+    rows: 5,
+    columns: () => [
+      { type: 'name' },
+      { type: 'text', align: 'right' },
+      { type: 'text', align: 'right' },
+      { type: 'text', align: 'right' },
+    ],
+  },
+)
+
+const hasHeaders = computed(() => props.columns.some(c => c.header))
+
+/** Vary name widths per row to look organic */
+function nameWidth(row: number): string {
+  const widths = ['72px', '56px', '64px', '80px', '48px', '60px', '68px', '52px']
+  return widths[(row - 1) % widths.length]
+}
+
+/** Vary text bar widths per row+col to look organic */
+function textWidth(row: number, col: number): string {
+  const widths = ['48px', '56px', '40px', '64px', '52px', '44px', '60px']
+  return widths[(row + col) % widths.length]
+}
+</script>

--- a/src/components/AppTableSkeleton.vue
+++ b/src/components/AppTableSkeleton.vue
@@ -10,7 +10,11 @@
           class="px-1 py-2 font-bold"
           :class="[
             col.hidden,
-            col.align === 'right' ? 'text-right' : 'text-left',
+            col.align === 'right'
+              ? 'text-right'
+              : col.align === 'center'
+                ? 'text-center'
+                : 'text-left',
             i === 0 ? 'sm:pl-4' : '',
             i === columns.length - 1 ? 'sm:pr-4' : '',
           ]"
@@ -23,7 +27,7 @@
     <tbody>
       <tr v-for="row in rows" :key="row">
         <td
-          :colspan="columns.length"
+          :colspan="columns.length || 1"
           class="px-1 sm:px-4 py-2"
         >
           <div class="h-10 bg-grey-10 animate-pulse rounded-12"></div>

--- a/src/modules/perps/components/PerpsMarketList.vue
+++ b/src/modules/perps/components/PerpsMarketList.vue
@@ -533,7 +533,7 @@ const marketSkeletonColumns: SkeletonColumn[] = [
   { header: '24H', align: 'right', hidden: 'hidden xs:table-cell' },
   { header: 'Volume', align: 'right', hidden: 'hidden 2xl:table-cell' },
   { header: 'Market Cap', align: 'right', hidden: 'hidden md:table-cell' },
-  { header: 'Actions', align: 'right', width: '200px', hidden: 'hidden lg:table-cell' },
+  { header: '', align: 'right', width: '200px', hidden: 'hidden lg:table-cell' },
 ]
 
 const searchQuery = ref('')

--- a/src/modules/perps/components/PerpsMarketList.vue
+++ b/src/modules/perps/components/PerpsMarketList.vue
@@ -527,13 +527,13 @@ function getPosition(market: string) {
 }
 
 const marketSkeletonColumns: SkeletonColumn[] = [
-  { header: '', width: '40px', hidden: 'hidden xs:table-cell' },
+  { header: '', hidden: 'hidden xs:table-cell xs:w-10' },
   { header: 'Name' },
   { header: 'Price', align: 'right' },
   { header: '24H', align: 'right', hidden: 'hidden xs:table-cell' },
   { header: 'Volume', align: 'right', hidden: 'hidden 2xl:table-cell' },
   { header: 'Market Cap', align: 'right', hidden: 'hidden md:table-cell' },
-  { header: '', align: 'right', width: '200px', hidden: 'hidden lg:table-cell' },
+  { header: '', align: 'right', hidden: 'hidden lg:table-cell lg:w-[200px] 2xl:w-[240px]' },
 ]
 
 const searchQuery = ref('')

--- a/src/modules/perps/components/PerpsMarketList.vue
+++ b/src/modules/perps/components/PerpsMarketList.vue
@@ -57,9 +57,11 @@
       </div>
 
       <!-- Loading -->
-      <div v-if="contractsLoading" class="text-center py-8 text-info text-s-14">
-        Loading markets...
-      </div>
+      <app-table-skeleton
+        v-if="contractsLoading"
+        :rows="8"
+        :columns="marketSkeletonColumns"
+      />
 
       <!-- Error -->
       <div
@@ -489,6 +491,9 @@ import {
   ArrowLongDownIcon,
   EllipsisVerticalIcon,
 } from '@heroicons/vue/24/solid'
+import AppTableSkeleton, {
+  type SkeletonColumn,
+} from '@/components/AppTableSkeleton.vue'
 import AppBtnGroup from '@/components/AppBtnGroup.vue'
 import AppSelect from '@/components/AppSelect.vue'
 import TableSparkline from '@/components/TableSparkline.vue'
@@ -520,6 +525,22 @@ const { positions } = usePerpsPositions()
 function getPosition(market: string) {
   return positions.value.find(p => p.market === market) || null
 }
+
+const marketSkeletonColumns: SkeletonColumn[] = [
+  { type: 'icon', width: '40px', hidden: 'hidden xs:table-cell' },
+  { type: 'name', header: 'Name' },
+  { type: 'text', align: 'right', header: 'Price' },
+  { type: 'chart', align: 'right', hidden: 'hidden xs:table-cell', header: '24H' },
+  { type: 'text', align: 'right', hidden: 'hidden 2xl:table-cell', header: 'Volume' },
+  { type: 'text', align: 'right', hidden: 'hidden md:table-cell', header: 'Market Cap' },
+  {
+    type: 'buttons',
+    hidden: 'hidden lg:table-cell',
+    width: '200px',
+    header: 'Actions',
+    align: 'right',
+  },
+]
 
 const searchQuery = ref('')
 const watchlist = ref<Set<string>>(new Set())

--- a/src/modules/perps/components/PerpsMarketList.vue
+++ b/src/modules/perps/components/PerpsMarketList.vue
@@ -527,19 +527,13 @@ function getPosition(market: string) {
 }
 
 const marketSkeletonColumns: SkeletonColumn[] = [
-  { type: 'icon', width: '40px', hidden: 'hidden xs:table-cell' },
-  { type: 'name', header: 'Name' },
-  { type: 'text', align: 'right', header: 'Price' },
-  { type: 'chart', align: 'right', hidden: 'hidden xs:table-cell', header: '24H' },
-  { type: 'text', align: 'right', hidden: 'hidden 2xl:table-cell', header: 'Volume' },
-  { type: 'text', align: 'right', hidden: 'hidden md:table-cell', header: 'Market Cap' },
-  {
-    type: 'buttons',
-    hidden: 'hidden lg:table-cell',
-    width: '200px',
-    header: 'Actions',
-    align: 'right',
-  },
+  { header: '', width: '40px', hidden: 'hidden xs:table-cell' },
+  { header: 'Name' },
+  { header: 'Price', align: 'right' },
+  { header: '24H', align: 'right', hidden: 'hidden xs:table-cell' },
+  { header: 'Volume', align: 'right', hidden: 'hidden 2xl:table-cell' },
+  { header: 'Market Cap', align: 'right', hidden: 'hidden md:table-cell' },
+  { header: 'Actions', align: 'right', width: '200px', hidden: 'hidden lg:table-cell' },
 ]
 
 const searchQuery = ref('')

--- a/src/modules/perps/components/PerpsPositionsTable.vue
+++ b/src/modules/perps/components/PerpsPositionsTable.vue
@@ -53,12 +53,11 @@
       </div>
 
       <!-- Loading -->
-      <div
+      <app-table-skeleton
         v-if="loading && positions.length === 0"
-        class="text-center py-8 text-info text-s-14"
-      >
-        Loading positions...
-      </div>
+        :rows="3"
+        :columns="positionsSkeletonColumns"
+      />
 
       <!-- Positions tab -->
       <template v-else-if="activeTab === 'positions'">
@@ -444,12 +443,11 @@
 
       <!-- Fills tab -->
       <template v-else-if="activeTab === 'fills'">
-        <div
+        <app-table-skeleton
           v-if="fillsLoading && fills.length === 0"
-          class="text-center py-8 text-info text-s-14"
-        >
-          Loading fills...
-        </div>
+          :rows="3"
+          :columns="fillsSkeletonColumns"
+        />
         <div
           v-else-if="fills.length === 0"
           class="text-center py-8 text-info text-s-14"
@@ -720,6 +718,9 @@ import AppSheet from '@/components/AppSheet.vue'
 import AppTokenLogo from '@/components/AppTokenLogo.vue'
 import AppPopUpMenu from '@/components/AppPopUpMenu.vue'
 import AppBtnIcon from '@/components/AppBtnIcon.vue'
+import AppTableSkeleton, {
+  type SkeletonColumn,
+} from '@/components/AppTableSkeleton.vue'
 import PerpsPositionDialog from './PerpsPositionDialog.vue'
 import PerpsFillDetailsDialog from './PerpsFillDetailsDialog.vue'
 import PerpsOrderDialog from './PerpsOrderDialog.vue'
@@ -746,6 +747,28 @@ const USDC_LOGO =
 defineEmits<{
   openPosition: [market: string]
 }>()
+
+const positionsSkeletonColumns: SkeletonColumn[] = [
+  { type: 'name', header: 'Market' },
+  { type: 'text', align: 'right', header: 'Value' },
+  { type: 'text', align: 'right', hidden: 'hidden xs:table-cell', header: 'uPnl' },
+  { type: 'text', align: 'right', hidden: 'hidden 2xl:table-cell', header: 'Entry Price' },
+  { type: 'text', align: 'right', hidden: 'hidden lg:table-cell', header: 'Mark Price' },
+  { type: 'text', align: 'right', hidden: 'hidden sm:table-cell', header: 'Liq Price' },
+  { type: 'text', align: 'right', hidden: 'hidden 2xl:table-cell', header: 'Margin Used' },
+  { type: 'text', align: 'right', hidden: 'hidden 3xl:table-cell', header: 'Total Funding' },
+  { type: 'action', hidden: 'hidden lg:table-cell', header: 'Actions', align: 'right' },
+]
+
+const fillsSkeletonColumns: SkeletonColumn[] = [
+  { type: 'name', header: 'Market' },
+  { type: 'text', align: 'left', hidden: 'hidden lg:table-cell', header: 'Direction' },
+  { type: 'text', align: 'right', hidden: 'hidden xs:table-cell', header: 'Time' },
+  { type: 'text', align: 'right', header: 'Price' },
+  { type: 'text', align: 'right', hidden: 'hidden sm:table-cell', header: 'Size' },
+  { type: 'text', align: 'right', hidden: 'hidden md:table-cell', header: 'PnL' },
+  { type: 'icon', width: '48px' },
+]
 
 const { positions, loading } = usePerpsPositions()
 

--- a/src/modules/perps/components/PerpsPositionsTable.vue
+++ b/src/modules/perps/components/PerpsPositionsTable.vue
@@ -52,9 +52,9 @@
         </app-select>
       </div>
 
-      <!-- Loading -->
+      <!-- Positions loading -->
       <app-table-skeleton
-        v-if="loading && positions.length === 0"
+        v-if="activeTab === 'positions' && loading && positions.length === 0"
         :rows="3"
         :columns="positionsSkeletonColumns"
       />

--- a/src/modules/perps/components/PerpsPositionsTable.vue
+++ b/src/modules/perps/components/PerpsPositionsTable.vue
@@ -251,12 +251,11 @@
             </template>
           </app-btn-group>
         </div>
-        <div
+        <app-table-skeleton
           v-if="ordersLoading && orders.length === 0"
-          class="text-center py-8 text-info text-s-14"
-        >
-          Loading orders...
-        </div>
+          :rows="5"
+          :columns="ordersSkeletonColumns"
+        />
         <div
           v-else-if="filteredOrders.length === 0"
           class="text-center py-8 text-info text-s-14"
@@ -569,12 +568,11 @@
 
       <!-- Deposits & Withdrawals tab -->
       <template v-else-if="activeTab === 'deposits'">
-        <div
+        <app-table-skeleton
           v-if="dwLoading && deposits.length === 0 && withdrawals.length === 0"
-          class="text-center py-8 text-info text-s-14"
-        >
-          Loading...
-        </div>
+          :rows="5"
+          :columns="dwSkeletonColumns"
+        />
         <div
           v-else-if="deposits.length === 0 && withdrawals.length === 0"
           class="text-center py-8 text-info text-s-14"
@@ -767,6 +765,26 @@ const fillsSkeletonColumns: SkeletonColumn[] = [
   { header: 'Price', align: 'right' },
   { header: 'Size', align: 'right', hidden: 'hidden sm:table-cell' },
   { header: 'PnL', align: 'right', hidden: 'hidden md:table-cell' },
+]
+
+const ordersSkeletonColumns: SkeletonColumn[] = [
+  { header: 'Market' },
+  { header: 'Side', hidden: 'hidden xl:table-cell', width: '100px' },
+  { header: 'Time', hidden: 'hidden xs:table-cell' },
+  { header: 'Status', hidden: 'hidden lg:table-cell' },
+  { header: 'Type', hidden: 'hidden 2xl:table-cell' },
+  { header: 'Price', align: 'right' },
+  { header: 'Filled / Size', align: 'right', hidden: 'hidden sm:table-cell' },
+  { header: '', width: '48px' },
+]
+
+const dwSkeletonColumns: SkeletonColumn[] = [
+  { header: 'Type', hidden: 'hidden xs:table-cell' },
+  { header: 'Asset' },
+  { header: 'Time', hidden: 'hidden sm:table-cell' },
+  { header: 'USD Value', align: 'right', hidden: 'hidden md:table-cell' },
+  { header: 'Amount', align: 'right' },
+  { header: 'Status', align: 'right', hidden: 'hidden xs:table-cell' },
 ]
 
 const { positions, loading } = usePerpsPositions()

--- a/src/modules/perps/components/PerpsPositionsTable.vue
+++ b/src/modules/perps/components/PerpsPositionsTable.vue
@@ -749,25 +749,24 @@ defineEmits<{
 }>()
 
 const positionsSkeletonColumns: SkeletonColumn[] = [
-  { type: 'name', header: 'Market' },
-  { type: 'text', align: 'right', header: 'Value' },
-  { type: 'text', align: 'right', hidden: 'hidden xs:table-cell', header: 'uPnl' },
-  { type: 'text', align: 'right', hidden: 'hidden 2xl:table-cell', header: 'Entry Price' },
-  { type: 'text', align: 'right', hidden: 'hidden lg:table-cell', header: 'Mark Price' },
-  { type: 'text', align: 'right', hidden: 'hidden sm:table-cell', header: 'Liq Price' },
-  { type: 'text', align: 'right', hidden: 'hidden 2xl:table-cell', header: 'Margin Used' },
-  { type: 'text', align: 'right', hidden: 'hidden 3xl:table-cell', header: 'Total Funding' },
-  { type: 'action', hidden: 'hidden lg:table-cell', header: 'Actions', align: 'right' },
+  { header: 'Market' },
+  { header: 'Value', align: 'right' },
+  { header: 'uPnl', align: 'right', hidden: 'hidden xs:table-cell' },
+  { header: 'Entry Price', align: 'right', hidden: 'hidden 2xl:table-cell' },
+  { header: 'Mark Price', align: 'right', hidden: 'hidden lg:table-cell' },
+  { header: 'Liq Price', align: 'right', hidden: 'hidden sm:table-cell' },
+  { header: 'Margin Used', align: 'right', hidden: 'hidden 2xl:table-cell' },
+  { header: 'Total Funding', align: 'right', hidden: 'hidden 3xl:table-cell' },
+  { header: 'Actions', align: 'right' },
 ]
 
 const fillsSkeletonColumns: SkeletonColumn[] = [
-  { type: 'name', header: 'Market' },
-  { type: 'text', align: 'left', hidden: 'hidden lg:table-cell', header: 'Direction' },
-  { type: 'text', align: 'right', hidden: 'hidden xs:table-cell', header: 'Time' },
-  { type: 'text', align: 'right', header: 'Price' },
-  { type: 'text', align: 'right', hidden: 'hidden sm:table-cell', header: 'Size' },
-  { type: 'text', align: 'right', hidden: 'hidden md:table-cell', header: 'PnL' },
-  { type: 'icon', width: '48px' },
+  { header: 'Market' },
+  { header: 'Direction', hidden: 'hidden lg:table-cell' },
+  { header: 'Time', hidden: 'hidden xs:table-cell' },
+  { header: 'Price', align: 'right' },
+  { header: 'Size', align: 'right', hidden: 'hidden sm:table-cell' },
+  { header: 'PnL', align: 'right', hidden: 'hidden md:table-cell' },
 ]
 
 const { positions, loading } = usePerpsPositions()


### PR DESCRIPTION
## Summary
- Add reusable `AppTableSkeleton` component with configurable column headers and thick rounded skeleton bars
- Add skeleton loading states to all perps tables: Positions, Fills, Orders, Markets, and Deposits/Withdrawals
- Skeleton renders real table headers (with alignment, responsive visibility, widths) and full-width `h-10` animated pulse bars per row

## Test plan
- [ ] Verify skeleton displays while positions data loads
- [ ] Verify skeleton displays while fills data loads
- [ ] Verify skeleton displays while orders data loads
- [ ] Verify skeleton displays while markets data loads
- [ ] Verify skeleton displays while deposits/withdrawals data loads
- [ ] Verify responsive column visibility matches real tables
- [x] Verify skeleton disappears once data loads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable animated table skeleton used across the Perps module. Market List and Positions Table (Positions, Orders, Fills, Deposits/Withdrawals tabs) now display structured, column-aligned placeholder animations instead of plain loading text. The skeleton is configurable (rows and column layout, alignment, widths, and responsive visibility) to mirror each table’s columns and improve loading UX.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->