### PR TITLE
fix: 🐛 make token links selectable by tab in crypto and balance tables

### DIFF
--- a/src/modules/crypto/ModuleExploreCrypto.vue
+++ b/src/modules/crypto/ModuleExploreCrypto.vue
@@ -291,7 +291,11 @@
                 </td>
                 <!-- Name & Symbol -->
                 <td class="px-1 py-1 rounded-l-12 xs:rounded-none" colspan="2">
-                  <div class="flex items-center gap-3">
+                  <router-link
+                    :to="getTokenRoute(token)"
+                    class="flex items-center gap-3"
+                    @click.stop
+                  >
                     <app-token-logo
                       :url="token.logoUrl"
                       :symbol="token.symbol"
@@ -324,7 +328,7 @@
                         {{ token.name }}
                       </p>
                     </div>
-                  </div>
+                  </router-link>
                 </td>
                 <!-- Market Cap -->
                 <td
@@ -1360,18 +1364,20 @@ const getSparkLinePoints = (token: DisplayToken) => {
  --------------------------------*/
 const router = useRouter()
 
-const goToTokenPage = (token: DisplayToken) => {
+const getTokenRoute = (token: DisplayToken) => {
   if (token.ondo !== null && token.ondo.primaryMarket.symbol) {
-    router.push({
+    return {
       name: STOCK_INFO_ROUTE_NAMES.crypto,
       params: { symbol: token.ondo.primaryMarket.symbol },
-    })
-    return
-  } else {
-    router.push({
-      name: TOKEN_INFO_ROUTE_NAMES.crypto,
-      params: { tokenId: token.coinId },
-    })
+    }
   }
+  return {
+    name: TOKEN_INFO_ROUTE_NAMES.crypto,
+    params: { tokenId: token.coinId },
+  }
+}
+
+const goToTokenPage = (token: DisplayToken) => {
+  router.push(getTokenRoute(token))
 }
 </script>

--- a/src/modules/portfolio/components/balances/TableTokenBalance.vue
+++ b/src/modules/portfolio/components/balances/TableTokenBalance.vue
@@ -277,7 +277,11 @@
             </td>
             <!-- Name -->
             <td class="px-1 py-1 rounded-l-12 xs:rounded-none" colspan="2">
-              <div class="flex items-center gap-3">
+              <router-link
+                :to="getTokenRoute(token)"
+                class="flex items-center gap-3"
+                @click.stop="onTokenLinkClick(token)"
+              >
                 <app-token-logo
                   :url="token.logo_url"
                   :symbol="token.symbol"
@@ -306,7 +310,7 @@
                     {{ getTokenName(token) }}
                   </p>
                 </div>
-              </div>
+              </router-link>
             </td>
             <!-- Market Cap -->
             <td
@@ -1091,19 +1095,28 @@ const buyBtn = (token?: DisplayToken, isMobile = false) => {
   window.open('https://ccswap.myetherwallet.com', '_blank')
 }
 
-const goToTokenPage = (token: DisplayToken) => {
+const getTokenRoute = (token: DisplayToken) => {
   if (token.ondo !== undefined) {
-    router.push({
+    return {
       name: STOCK_INFO_ROUTE_NAMES.home,
       params: { symbol: token.ondo.primaryMarket.symbol },
-    })
-    return
+    }
   }
-  tokenInfoStore.setTokenInfo(token)
-  router.push({
+  return {
     name: TOKEN_INFO_ROUTE_NAMES.home,
     params: { tokenId: token.coinId || token.symbol },
-  })
+  }
+}
+
+const onTokenLinkClick = (token: DisplayToken) => {
+  if (token.ondo === undefined) {
+    tokenInfoStore.setTokenInfo(token)
+  }
+}
+
+const goToTokenPage = (token: DisplayToken) => {
+  onTokenLinkClick(token)
+  router.push(getTokenRoute(token))
 }
 
 const getWatchlistId = (token: DisplayToken): string => {


### PR DESCRIPTION
### Fix

## What
Token links in crypto and balance tables are now keyboard-navigable using Tab, matching the existing behavior in the stocks table.

## Why
Token links were not selectable by Tab in the crypto and balance tables, breaking keyboard accessibility. The stocks table already had this functionality working with `<router-link>`.

## How
- Replaced `<div>` with `<router-link>` in the token name cell for both `ModuleExploreCrypto.vue` and `TableTokenBalance.vue`
- Extracted route generation logic into `getTokenRoute()` helper function
- Added `@click.stop` to prevent duplicate navigation from row click handler
- Preserved `tokenInfoStore.setTokenInfo()` side effect in balance table via `onTokenLinkClick()`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Token names in explore and portfolio views are now clickable links, directing users to relevant token information pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->