### PR TITLE
fix: wire up Long, Short, and Manage buttons in perps tables (MEW-1620)

### DIFF
--- a/src/modules/perps/components/PerpsMarketList.vue
+++ b/src/modules/perps/components/PerpsMarketList.vue
@@ -415,7 +415,7 @@
                   <app-base-button
                     v-if="getPosition(contract.market)"
                     size="small"
-                    @click.stop="$emit('openPosition', contract.market)"
+                    @click="$emit('openPosition', contract.market)"
                   >
                     Manage
                     {{
@@ -429,9 +429,7 @@
                       size="small"
                       class="min-w-[64px]"
                       theme="success"
-                      @click.stop="
-                        $emit('openPosition', contract.market, 'buy')
-                      "
+                      @click="$emit('openPosition', contract.market, 'buy')"
                     >
                       Long
                     </app-base-button>
@@ -439,9 +437,7 @@
                       size="small"
                       theme="error"
                       class="min-w-[64px]"
-                      @click.stop="
-                        $emit('openPosition', contract.market, 'sell')
-                      "
+                      @click="$emit('openPosition', contract.market, 'sell')"
                     >
                       Short
                     </app-base-button>

--- a/src/modules/perps/components/PerpsPositionsTable.vue
+++ b/src/modules/perps/components/PerpsPositionsTable.vue
@@ -228,7 +228,7 @@
                 <div class="hidden lg:flex flex-row gap-2 justify-end">
                   <AppBaseButton
                     size="small"
-                    @click.stop="$emit('openPosition', pos.market)"
+                    @click="$emit('openPosition', pos.market)"
                   >
                     Manage
                   </AppBaseButton>


### PR DESCRIPTION
## Summary
Clicking **Long**, **Short**, or **Manage** in the perpetual markets table — and **Manage** in the positions table — did nothing. The buttons looked fine but the click never reached its handler, so the side panel never opened and the info page never navigated.

The shared button component emits its click without the usual event object, which tripped up the event modifier on the caller. Removing that modifier lets the click go through. Small change: one line removed in two files.

## How to test
1. Open the app, sign in, and go to the **Perpetuals** page.
2. In the Markets table, click **Long** on any row → the perps side panel should open with that token selected and **Long** preselected; the page navigates to the perp info page.
3. Repeat with **Short** on another row → token selected, **Short** preselected.
4. For a market where you already have a position, click **Manage Long** / **Manage Short** → same flow, panel + info page open.
5. In the Positions table, click **Manage** on a position → panel opens to that market.
6. Resize to mobile → open a row's `⋮` menu → pick **Long** or **Short** → still works (these were never broken; regression check).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed click event handling on action buttons in perpetuals market and positions tables to allow proper event propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->