### PR TITLE
fix: perps uPnl/Pnl percentage display and negative values (MEW-1642)

### DIFF
--- a/src/modules/perps/components/PerpsBalanceDetailsDialog.vue
+++ b/src/modules/perps/components/PerpsBalanceDetailsDialog.vue
@@ -43,7 +43,12 @@ import {
   usePerpsBalance,
   usePerpsPortfolioSummary,
 } from '../composables/usePerpsAuth'
-import { pnlColor, marginRatioColor } from '../utils/formatters'
+import {
+  pnlColor,
+  marginRatioColor,
+  formatPnl,
+  formatPnlPercent,
+} from '../utils/formatters'
 import { formatFiatValue } from '@/utils/numberFormatHelper'
 
 const props = defineProps<{
@@ -77,12 +82,12 @@ const balanceRows = computed(() => [
   { label: 'Leverage', value: `${balance.value?.leverage ?? '0'}x` },
   {
     label: 'Unrealized PnL',
-    value: fmt(balance.value?.unrealizedPnl),
+    value: `${formatPnl(balance.value?.unrealizedPnl ?? '0')} (${formatPnlPercent(balance.value?.unrealizedPnl, balance.value?.marginBalance)})`,
     colorClass: pnlColor(balance.value?.unrealizedPnl ?? '0'),
   },
   {
     label: 'Realized PnL',
-    value: fmt(balance.value?.realizedPnl),
+    value: `${formatPnl(balance.value?.realizedPnl ?? '0')} (${formatPnlPercent(balance.value?.realizedPnl, balance.value?.marginBalance)})`,
     colorClass: pnlColor(balance.value?.realizedPnl ?? '0'),
   },
   {

--- a/src/modules/perps/components/PerpsPortfolioSummary.vue
+++ b/src/modules/perps/components/PerpsPortfolioSummary.vue
@@ -82,7 +82,11 @@ import AppBtnText from '@/components/AppBtnText.vue'
 import AppSheet from '@/components/AppSheet.vue'
 import PerpsBalanceDetailsDialog from './PerpsBalanceDetailsDialog.vue'
 import { usePerpsBalance } from '../composables/usePerpsAuth'
-import { pnlColor, marginRatioColor } from '../utils/formatters'
+import {
+  pnlColor,
+  marginRatioColor,
+  formatPnlPercent,
+} from '../utils/formatters'
 import { formatFiatValue } from '@/utils/numberFormatHelper'
 
 defineEmits<{
@@ -110,13 +114,9 @@ const usedMargin = computed(
 )
 const marginRatio = computed(() => balance.value?.marginRatio ?? '0')
 
-const pnlPercent = computed(() => {
-  const margin = parseFloat(marginBalance.value)
-  const pnl = parseFloat(unrealizedPnl.value)
-  if (!margin || isNaN(pnl)) return '0.00%'
-  const pct = (pnl / margin) * 100
-  return `${pct >= 0 ? '+' : ''}${pct.toFixed(2)}%`
-})
+const pnlPercent = computed(() =>
+  formatPnlPercent(unrealizedPnl.value, balance.value?.marginBalance),
+)
 
 const pnlColorClass = computed(() => pnlColor(unrealizedPnl.value))
 const marginRatioColorClass = computed(() =>

--- a/src/modules/perps/utils/formatters.ts
+++ b/src/modules/perps/utils/formatters.ts
@@ -31,6 +31,16 @@ export function formatPercent(val: number): string {
   return `${val >= 0 ? '+' : ''}${val.toFixed(2)}%`
 }
 
+export function formatPnlPercent(
+  pnl: string | number | undefined,
+  margin: string | number | undefined,
+): string {
+  const m = typeof margin === 'number' ? margin : parseFloat(margin ?? '')
+  const p = typeof pnl === 'number' ? pnl : parseFloat(pnl ?? '')
+  if (!m || isNaN(p)) return '0.00%'
+  return formatPercent((p / m) * 100)
+}
+
 export function formatVolume(vol?: string): string {
   if (!vol) return '—'
   const num = parseFloat(vol)
@@ -55,8 +65,7 @@ export function formatDate(val: string): string {
 export function formatRoe(val: string): string {
   const n = parseFloat(val)
   if (isNaN(n)) return '0.00%'
-  const pct = n * 100
-  return `${pct >= 0 ? '' : ''}${pct.toFixed(2)}%`
+  return formatPercent(n * 100)
 }
 
 export function pnlColor(val: string): string {

--- a/src/modules/perps/utils/formatters.ts
+++ b/src/modules/perps/utils/formatters.ts
@@ -38,6 +38,7 @@ export function formatPnlPercent(
   const m = typeof margin === 'number' ? margin : parseFloat(margin ?? '')
   const p = typeof pnl === 'number' ? pnl : parseFloat(pnl ?? '')
   if (!m || isNaN(p)) return '0.00%'
+  if (p === 0) return '0.00%'
   return formatPercent((p / m) * 100)
 }
 


### PR DESCRIPTION
## Summary

Fixes [MEW-1642](https://myetherwallet.atlassian.net/browse/MEW-1642) — **Percentage color and Number for uPnl and Pnl**.

In the Perpetuals Portfolio Overview and the "View More" (Portfolio Details) dialog:
- **uPnl percentage always rendered as `0.00%`** — `pnlPercent` was computed with `parseFloat("$1,234.56")` against the formatted margin string, which returns `NaN`. Now reads raw `balance.marginBalance`.
- **Negative PnL dollar values rendered as `"$< 0.0001"`** in the details dialog — the shared `formatFiatValue` helper falls through to that branch for anything `< SmallNumberBreakpoint` (including negatives). Swapped to the perps-local `formatPnl`, which correctly signs positives/negatives via `toLocaleString` currency style.
- **Unrealized/Realized PnL in the details dialog now include the percentage** next to the dollar amount: `+$89.63 (+1.23%)` / `-$89.63 (-1.23%)`, matching the acceptance criterion that they "be shown as percentages".
- Extracted a `formatPnlPercent(pnl, margin)` helper in `src/modules/perps/utils/formatters.ts` so the summary and dialog share the same math.
- Cleaned up `formatRoe` — the `+` ternary was `${pct >= 0 ? '' : ''}` (both empty); now delegates to `formatPercent`.

Colors were already bound to the raw `unrealizedPnl` / `realizedPnl` via `pnlColor()`, so sign-based color was correct; it just always sat on a `0.00%` label, which is why they *looked* off. They now appear on a meaningful percentage.

## Changes

- `src/modules/perps/utils/formatters.ts` — add `formatPnlPercent`; fix `formatRoe` sign
- `src/modules/perps/components/PerpsPortfolioSummary.vue` — `pnlPercent` uses raw `marginBalance`
- `src/modules/perps/components/PerpsBalanceDetailsDialog.vue` — uPnl/Pnl rows render `formatPnl` + `formatPnlPercent`

## Test plan

- [ ] Open Perps page with an account that has a **positive** unrealized PnL — summary shows correct `+X.XX%` in green, details dialog shows `+$X.XX (+X.XX%)`
- [ ] Repeat with a **negative** unrealized PnL — summary shows `-X.XX%` in red, dialog shows `-$X.XX (-X.XX%)` (not `$< 0.0001`)
- [ ] Repeat for **realized PnL** in the dialog
- [ ] Verify color turns neutral when PnL is exactly 0
- [ ] Positions table uPnl/RoE still renders correctly (`formatRoe` change)
- [ ] No regression in other `formatFiatValue` usages (changes are scoped to perps)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Profit/Loss displays in balance details and portfolio summaries now present comprehensive metrics showing both absolute dollar amounts and calculated percentages for clearer performance insights on both realized and unrealized trading gains and losses.

* **Refactor**
  * Profit/loss percentage calculation and formatting logic has been consolidated into dedicated utility functions for consistent reuse across all financial display components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->