### PR TITLE
feat: ✨ rewards update

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -72,11 +72,11 @@ const isLoadingComplete = ref(false)
 
 const popupStore = useAnalyticsStore()
 const { consent } = storeToRefs(popupStore)
-
 watch(
   () => consent.value,
   (newVal, oldVal) => {
     if (newVal && !oldVal) {
+      console.log(userProperties.value)
       analytics.setUserProperties({
         ...userProperties.value,
         network: selectedChain.value?.name,

--- a/src/analytics/amplitude.ts
+++ b/src/analytics/amplitude.ts
@@ -114,6 +114,9 @@ export class Analytics {
     if (properties.canClaimRewards !== undefined) {
       identify.set('canClaimRewards', properties.canClaimRewards)
     }
+    if (properties.canTrade !== undefined) {
+      identify.set('canTrade', properties.canTrade)
+    }
 
     this.amplitude.identify(identify)
   }

--- a/src/analytics/user.ts
+++ b/src/analytics/user.ts
@@ -45,4 +45,5 @@ export type UserProperties = {
   isPartnerHolder?: boolean
   hasBalance?: boolean
   canClaimRewards?: boolean
+  canTrade?: boolean
 }

--- a/src/modules/rewards/RewardsLearnMore.vue
+++ b/src/modules/rewards/RewardsLearnMore.vue
@@ -28,8 +28,8 @@
             Earn $5 USDC on Every Eligible Swap
           </h3>
           <p class="text-s-14 text-info mt-3 leading-p-160">
-            Complete a swap or trade on Ethereum over $25 and receive $5 USDC —
-            available to the first 500 unique users.
+            Complete a swap or trade on Ethereum over $50 and receive $5 USDC —
+            available to the first 10 unique users each hour.
           </p>
 
           <!-- How It Works -->
@@ -200,24 +200,28 @@ watch(isOpenModel, val => {
 const howItWorks = [
   {
     icon: 'swap',
-    text: 'Make a swap or trade of $25 or more on the Ethereum network',
+    text: 'Make a swap or trade of $50 or more on the Ethereum network',
   },
   {
     icon: 'currency-dollar',
-    text: 'The first 500 eligible swaps or trades get $5 USDC',
+    text: 'The first 10 eligible swaps or trades every hour get $5 USDC',
   },
   {
     icon: 'gift',
-    text: 'One reward per wallet per 72 hour period, sent directly to your wallet',
+    text: 'One reward per wallet per campaign period, sent directly to your wallet',
   },
 ]
 
 const availability = [
   {
     icon: 'clock',
-    text: 'Limited to 500 rewards per 72 hour period (No Bots!)',
+    text: 'Limited to 10 rewards per hour (No Bots!)',
   },
   { icon: 'trending-down', text: 'Live counter shows remaining rewards' },
+  {
+    icon: 'calendar',
+    text: 'If rewards run out, try again the next hour. Campaign resets in 7 days, April 28 5pm PST',
+  },
   {
     icon: 'user',
     text: 'Minimum of 0.001 ETH balance required prior to March 31st, 2026',

--- a/src/modules/rewards/RewardsPortfolio.vue
+++ b/src/modules/rewards/RewardsPortfolio.vue
@@ -31,7 +31,7 @@
           You've been<br />rewarded with<br />$5 USDC
         </p>
         <p class="text-s-14 text-[#334155] leading-snug mt-2">
-          Remember to earn another<br />reward tomorrow!
+          Remember to earn another<br />reward with next campaign!
         </p>
         <div
           class="mt-3 inline-flex items-center gap-1.5 bg-white/60 rounded-full px-3 py-1 w-fit -mr-5 -ml-2"
@@ -122,8 +122,8 @@
           class="text-s-16 text-[#334155] leading-p-110 mt-2 max-w-[240px] sm:max-w-none lg-max:max-w-[160px] 2xl:max-w-auto 3xl:max-w-auto 2xl:flex-1 text-center xs:text-start"
           :class="[isOpenSideMenu ? 'xl:max-w-none' : 'xl:max-w-[180px]']"
         >
-          First 500 swaps in the next 72 hours <br class="hidden 2xl:flex" />
-          over $25 get $5 USDC
+          First 10 swaps every hour <br class="hidden 2xl:flex" />
+          over $50 get $5 USDC
         </p>
       </div>
     </div>

--- a/src/modules/rewards/RewardsSmallBanner.vue
+++ b/src/modules/rewards/RewardsSmallBanner.vue
@@ -4,7 +4,9 @@
       class="rewards-banner-bg flex items-center justify-between gap-1 rounded-full px-2 py-2 cursor-pointer text-[10px] mb-3 md:-mx-1"
       @click="onLearnMore"
     >
-      <p class="font-medium">First 500 swaps or trades over $25 get $5 USDC</p>
+      <p class="font-medium">
+        First 10 swaps or trades each hour over $50 get $5 USDC
+      </p>
       <button class="font-bold underline whitespace-nowrap hoverOpacity">
         Learn More
       </button>

--- a/src/modules/swap/ModuleSwap.vue
+++ b/src/modules/swap/ModuleSwap.vue
@@ -727,7 +727,7 @@ const proceedWithSwap = async (quoteId: string) => {
 
       const fromUsdValue =
         parseFloat(fromAmount.value) * (fromTokenSelected.value?.price || 0)
-      if (fromUsdValue > 25) {
+      if (fromUsdValue > 50) {
         const canEarn = await rewardsStore.checkAvailabilityAfterTransaction()
         canEarnReward = canEarn ? true : undefined
       }

--- a/src/modules/trade/composables/useTradeExecution.ts
+++ b/src/modules/trade/composables/useTradeExecution.ts
@@ -195,7 +195,7 @@ export function useTradeExecution(options: UseTradeExecutionOptions) {
       let canEarnReward: undefined | boolean = undefined
       const fromUsdValue =
         parseFloat(fromAmount.value) * (fromTokenSelected.value?.price || 0)
-      if (fromUsdValue > 25) {
+      if (fromUsdValue > 50) {
         const canEarn = await rewardsStore.checkAvailabilityAfterTransaction()
         canEarnReward = canEarn ? true : undefined
       }

--- a/src/stores/rewardsStore.ts
+++ b/src/stores/rewardsStore.ts
@@ -164,7 +164,7 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
   /** User Rewards */
   const todaysReward = computed(() => {
     const reward = rewards.value[0]
-    if (reward && isRewardFromToday(reward)) return reward
+    if (reward && isRewardEarnedDuringCampaign(reward)) return reward
     return null
   })
   const hasRewards = computed(() => rewards.value.length > 0)
@@ -197,15 +197,12 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
   /** Poll rewards when eligible until today's reward is found */
   let rewardsPollInterval: ReturnType<typeof setInterval> | null = null
 
-  const isRewardFromToday = (reward: RewardItem): boolean => {
+  const isRewardEarnedDuringCampaign = (reward: RewardItem): boolean => {
+    const CAMPAIGN_START = new Date('2026-04-22T00:00:00.000Z')
+    const CAMPAIGN_END = new Date('2026-04-29T00:00:00.000Z')
     if (!reward.rewardBroadcastAt) return false
     const rewardDate = new Date(reward.rewardBroadcastAt)
-    const now = new Date()
-    return (
-      rewardDate.getUTCFullYear() === now.getUTCFullYear() &&
-      rewardDate.getUTCMonth() === now.getUTCMonth() &&
-      rewardDate.getUTCDate() === now.getUTCDate()
-    )
+    return rewardDate >= CAMPAIGN_START && rewardDate < CAMPAIGN_END
   }
 
   const stopRewardsPoll = () => {
@@ -219,14 +216,14 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
     stopRewardsPoll()
     rewardsPollInterval = setInterval(async () => {
       await fetchUserRewards()
-      if (rewards.value[0] && isRewardFromToday(rewards.value[0])) {
+      if (rewards.value[0] && isRewardEarnedDuringCampaign(rewards.value[0])) {
         setEarnedPotentialReward(false)
         analytics.setUserProperties({ canClaimRewards: false })
         analytics.trackRewardsEvent(RewardsEvent.REWARD_EARNED)
       }
       if (
         rewards.value[0] &&
-        isRewardFromToday(rewards.value[0]) &&
+        isRewardEarnedDuringCampaign(rewards.value[0]) &&
         rewards.value[0].rewardStatus === 'SUCCESS'
       ) {
         const toastStore = useToastStore()
@@ -246,7 +243,7 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
         // Check immediately if we already have today's reward
         if (
           rewards.value[0] &&
-          isRewardFromToday(rewards.value[0]) &&
+          isRewardEarnedDuringCampaign(rewards.value[0]) &&
           rewards.value[0].rewardStatus === 'SUCCESS'
         )
           return
@@ -311,6 +308,6 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
     canClaimReward,
     isLoading,
     hadInitialLoad,
-    isRewardFromToday,
+    isRewardEarnedDuringCampaign,
   }
 })

--- a/src/stores/walletStore.ts
+++ b/src/stores/walletStore.ts
@@ -14,7 +14,7 @@ import { useToastStore } from './toastStore'
 import { ToastType } from '@/types/notification'
 import type BaseEvmWallet from '@/providers/ethereum/baseEvmWallet'
 import type { WalletType } from '@/providers/types'
-import { checkAddressRestriction } from '@/modules/trade/providers/ondoHelpers'
+import { checkAddressRestriction, isTradingRestricted } from '@/modules/trade/providers/ondoHelpers'
 import {
   analytics,
   WalletStatus,
@@ -50,6 +50,8 @@ export const useWalletStore = defineStore('walletStore', () => {
   ): Promise<void> => {
     const _address = await newWallet.getAddress()
     const isRestricted = await checkAddressRestriction(_address)
+    const tradingRestricted = await isTradingRestricted()
+    userProperties.canTrade = tradingRestricted && !isRestricted
     if (!isRestricted) {
       if (newWallet instanceof WatchOnlyWallet) {
         isWatchOnly.value = true


### PR DESCRIPTION
<!-- NOTE: Remove the parts that's not relevant -->

### Devop

* \[ ] Added entry to ./changelog
* \[ ] Add PR label

### Feature

* \[ ] Added entry to ./changelog
* \[ ] Is this a user submitted feature request?
  * \[ ] Link to issue:
* \[ ] Add test cases or procedure
* \[ ] Add PR label

### Fix

* \[ ] Added entry to ./changelog
* \[ ] Is this a user submitted bug?
  * \[ ] Link to issue:
* \[ ] Add PR label

### Release

* \[ ] Merged changelog generation branch
* \[ ] Created a release
  * \[ ] Link to release:
* \[ ] Add PR label
* \[ ] Updated package.json version


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Minimum swap/trade to qualify for rewards increased from $25 to $50.
  * Reward quota changed from first 500 users to first 10 eligible swaps/trades each hour.
  * Reward frequency changed from once per 72 hours to once per campaign period.
  * Messaging updated across banners, portfolio, and Learn More pages; availability note added to retry next hour and campaign resets in 7 days (April 28, 5pm PST).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->