### PR TITLE
feat: perps toast helper composable (foundation)

### DIFF
--- a/changelog/feat-perps-toasts-deposits.md
+++ b/changelog/feat-perps-toasts-deposits.md
@@ -1,0 +1,1 @@
+feat: toast notifications for perps deposits and withdrawals

--- a/changelog/feat-perps-toasts-foundation.md
+++ b/changelog/feat-perps-toasts-foundation.md
@@ -1,0 +1,1 @@
+feat: add usePerpsToasts helper composable — central wrapper for all perps toast copy

--- a/changelog/feat-perps-toasts-liquidation.md
+++ b/changelog/feat-perps-toasts-liquidation.md
@@ -1,0 +1,1 @@
+feat: toast notification when a perps account enters liquidation

--- a/changelog/feat-perps-toasts-sltp.md
+++ b/changelog/feat-perps-toasts-sltp.md
@@ -1,0 +1,1 @@
+feat: toast notifications for perps stop loss and take profit lifecycle

--- a/src/modules/perps/components/PerpsDepositDialog.vue
+++ b/src/modules/perps/components/PerpsDepositDialog.vue
@@ -289,14 +289,15 @@ const toastStore = useToastStore()
 const perpsToasts = usePerpsToasts()
 
 watch(isOpen, open => {
-  // TODO(perps-toasts): confirm which cancel path should fire toastDepositCanceled.
-  // There is no explicit cancel button for an in-progress deposit; the user can only
-  // close the dialog via the app-dialog close control. Distinguishing "dialog closed
-  // while deposit was in-flight (sending=true)" from "dialog closed before starting"
-  // requires state tracking not present here. Add perpsToasts.toastDepositCanceled()
-  // to the "!open && sending.value" branch once that tracking is confirmed with design.
-
-  if (!open) return
+  if (!open) {
+    // Dialog closed mid-deposit: surface a single "Deposit Canceled" toast
+    // and flag the in-flight flow so it skips its own success/failure toasts.
+    if (sending.value) {
+      perpsToasts.toastDepositCanceled()
+      wasCanceledMidFlight.value = true
+    }
+    return
+  }
   if (selectedChain.value?.name !== 'ETHEREUM') {
     const ethChain = chains.value.find(c => c.name === 'ETHEREUM')
     if (ethChain) {
@@ -322,6 +323,25 @@ const error = ref<string | null>(null)
 const amount = ref('')
 const sending = ref(false)
 const showDepositAddress = ref(false)
+// Set to true when the dialog is closed mid-deposit; the in-flight deposit
+// flow checks this before firing success/failure toasts so the user only
+// sees a single "Deposit Canceled" toast in that case.
+const wasCanceledMidFlight = ref(false)
+
+// User-cancel phrases used to distinguish a wallet-prompt rejection (which
+// should yield "Deposit Canceled") from a generic RPC/API "rejected" error
+// (which should still surface as a failure toast).
+const USER_CANCEL_PATTERNS = [
+  'user rejected',
+  'user denied',
+  'rejected by user',
+  'cancelled by user',
+  'canceled by user',
+]
+const isUserCancelError = (e: unknown) => {
+  const msg = (e instanceof Error ? e.message : String(e ?? '')).toLowerCase()
+  return USER_CANCEL_PATTERNS.some(p => msg.includes(p))
+}
 
 /** --------------------------
  * AMOUNT
@@ -510,6 +530,7 @@ const sendSandboxDeposit = async () => {
   if (!amount.value || !accountId.value) return
   sending.value = true
   error.value = null
+  wasCanceledMidFlight.value = false
   try {
     await perpsClient.sandboxDeposit({
       amount: parseFloat(amount.value).toFixed(2),
@@ -518,18 +539,20 @@ const sendSandboxDeposit = async () => {
       chain_id: 'eth-sepolia',
     })
     triggerRefresh()
-    perpsToasts.toastDepositComplete(amount.value, 'USDC')
+    if (!wasCanceledMidFlight.value) {
+      perpsToasts.toastDepositComplete(amount.value, 'USDC')
+    }
     clearAmount()
-  } catch (e: any) {
-    const msg = e?.message || e?.toString() || ''
-    const isRejection =
-      msg.toLowerCase().includes('user rejected') ||
-      msg.toLowerCase().includes('rejected')
-    if (isRejection) {
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e ?? '')
+    if (isUserCancelError(e)) {
       error.value = 'Transaction cancelled by user'
+      if (!wasCanceledMidFlight.value) perpsToasts.toastDepositCanceled()
     } else {
       error.value = msg || 'Sandbox deposit failed'
-      perpsToasts.toastFailedToInitiateDeposit()
+      if (!wasCanceledMidFlight.value) {
+        perpsToasts.toastFailedToInitiateDeposit()
+      }
     }
   } finally {
     sending.value = false
@@ -546,6 +569,7 @@ const sendLiveDeposit = async () => {
     return
   sending.value = true
   error.value = null
+  wasCanceledMidFlight.value = false
   try {
     const usdcContract = USDC_CONTRACT
     const decimals = usdcBalance.value.decimals ?? 6
@@ -597,21 +621,24 @@ const sendLiveDeposit = async () => {
         : wallet.value.broadcastTransaction
 
     const hash = await broadcastFn?.(signedTx as HexPrefixedString)
-    if (hash) {
-      triggerRefresh()
-      perpsToasts.toastDepositInitiated()
-      clearAmount()
+    if (!hash) {
+      throw new Error('Transaction was not broadcast')
     }
-  } catch (e: any) {
-    const msg = e?.message || e?.toString() || ''
-    const isRejection =
-      msg.toLowerCase().includes('user rejected') ||
-      msg.toLowerCase().includes('rejected')
-    if (isRejection) {
+    triggerRefresh()
+    if (!wasCanceledMidFlight.value) {
+      perpsToasts.toastDepositInitiated()
+    }
+    clearAmount()
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e ?? '')
+    if (isUserCancelError(e)) {
       error.value = 'Transaction cancelled by user'
+      if (!wasCanceledMidFlight.value) perpsToasts.toastDepositCanceled()
     } else {
       error.value = msg || 'Transaction failed'
-      perpsToasts.toastFailedToCreditAccount()
+      if (!wasCanceledMidFlight.value) {
+        perpsToasts.toastFailedToCreditAccount()
+      }
     }
   } finally {
     sending.value = false

--- a/src/modules/perps/components/PerpsDepositDialog.vue
+++ b/src/modules/perps/components/PerpsDepositDialog.vue
@@ -290,12 +290,10 @@ const perpsToasts = usePerpsToasts()
 
 watch(isOpen, open => {
   if (!open) {
-    // Dialog closed mid-deposit: surface a single "Deposit Canceled" toast
-    // and flag the in-flight flow so it skips its own success/failure toasts.
-    if (sending.value) {
-      perpsToasts.toastDepositCanceled()
-      wasCanceledMidFlight.value = true
-    }
+    // TODO(perps): once the SDK exposes a way to cancel an in-flight deposit
+    // (sandbox API call / live broadcast), hook it up here and surface a
+    // single "Deposit Canceled" toast. For now the request runs to completion
+    // regardless of whether the dialog is closed.
     return
   }
   if (selectedChain.value?.name !== 'ETHEREUM') {
@@ -323,10 +321,6 @@ const error = ref<string | null>(null)
 const amount = ref('')
 const sending = ref(false)
 const showDepositAddress = ref(false)
-// Set to true when the dialog is closed mid-deposit; the in-flight deposit
-// flow checks this before firing success/failure toasts so the user only
-// sees a single "Deposit Canceled" toast in that case.
-const wasCanceledMidFlight = ref(false)
 
 // User-cancel phrases used to distinguish a wallet-prompt rejection (which
 // should yield "Deposit Canceled") from a generic RPC/API "rejected" error
@@ -530,7 +524,6 @@ const sendSandboxDeposit = async () => {
   if (!amount.value || !accountId.value) return
   sending.value = true
   error.value = null
-  wasCanceledMidFlight.value = false
   try {
     await perpsClient.sandboxDeposit({
       amount: parseFloat(amount.value).toFixed(2),
@@ -538,25 +531,17 @@ const sendSandboxDeposit = async () => {
       deposit_destination: { id: accountId.value, wallet: 'margin' },
       chain_id: 'eth-sepolia',
     })
-    // Clear `sending` before the success toast so a dialog-close mid-await
-    // can't cause the isOpen watcher to also fire a "Deposit Canceled" toast
-    // for the same flow. The finally block remains idempotent.
-    sending.value = false
     triggerRefresh()
-    if (!wasCanceledMidFlight.value) {
-      perpsToasts.toastDepositComplete(amount.value, 'USDC')
-    }
+    perpsToasts.toastDepositComplete(amount.value, 'USDC')
     clearAmount()
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : String(e ?? '')
     if (isUserCancelError(e)) {
       error.value = 'Transaction cancelled by user'
-      if (!wasCanceledMidFlight.value) perpsToasts.toastDepositCanceled()
+      perpsToasts.toastDepositCanceled()
     } else {
       error.value = msg || 'Sandbox deposit failed'
-      if (!wasCanceledMidFlight.value) {
-        perpsToasts.toastFailedToInitiateDeposit()
-      }
+      perpsToasts.toastFailedToInitiateDeposit()
     }
   } finally {
     sending.value = false
@@ -573,7 +558,6 @@ const sendLiveDeposit = async () => {
     return
   sending.value = true
   error.value = null
-  wasCanceledMidFlight.value = false
   try {
     const usdcContract = USDC_CONTRACT
     const decimals = usdcBalance.value.decimals ?? 6
@@ -628,24 +612,17 @@ const sendLiveDeposit = async () => {
     if (!hash) {
       throw new Error('Transaction was not broadcast')
     }
-    // See sendSandboxDeposit: clear `sending` before the success toast to
-    // avoid a close-mid-await race that would also fire "Deposit Canceled".
-    sending.value = false
     triggerRefresh()
-    if (!wasCanceledMidFlight.value) {
-      perpsToasts.toastDepositInitiated()
-    }
+    perpsToasts.toastDepositInitiated()
     clearAmount()
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : String(e ?? '')
     if (isUserCancelError(e)) {
       error.value = 'Transaction cancelled by user'
-      if (!wasCanceledMidFlight.value) perpsToasts.toastDepositCanceled()
+      perpsToasts.toastDepositCanceled()
     } else {
       error.value = msg || 'Transaction failed'
-      if (!wasCanceledMidFlight.value) {
-        perpsToasts.toastFailedToCreditAccount()
-      }
+      perpsToasts.toastFailedToCreditAccount()
     }
   } finally {
     sending.value = false

--- a/src/modules/perps/components/PerpsDepositDialog.vue
+++ b/src/modules/perps/components/PerpsDepositDialog.vue
@@ -538,6 +538,10 @@ const sendSandboxDeposit = async () => {
       deposit_destination: { id: accountId.value, wallet: 'margin' },
       chain_id: 'eth-sepolia',
     })
+    // Clear `sending` before the success toast so a dialog-close mid-await
+    // can't cause the isOpen watcher to also fire a "Deposit Canceled" toast
+    // for the same flow. The finally block remains idempotent.
+    sending.value = false
     triggerRefresh()
     if (!wasCanceledMidFlight.value) {
       perpsToasts.toastDepositComplete(amount.value, 'USDC')
@@ -624,6 +628,9 @@ const sendLiveDeposit = async () => {
     if (!hash) {
       throw new Error('Transaction was not broadcast')
     }
+    // See sendSandboxDeposit: clear `sending` before the success toast to
+    // avoid a close-mid-await race that would also fire "Deposit Canceled".
+    sending.value = false
     triggerRefresh()
     if (!wasCanceledMidFlight.value) {
       perpsToasts.toastDepositInitiated()

--- a/src/modules/perps/components/PerpsDepositDialog.vue
+++ b/src/modules/perps/components/PerpsDepositDialog.vue
@@ -263,6 +263,7 @@ import { useChainsStore } from '@/stores/chainsStore'
 import { useGlobalStore } from '@/stores/globalStore'
 import { useToastStore } from '@/stores/toastStore'
 import { ToastType } from '@/types/notification'
+import { usePerpsToasts } from '@/modules/perps/composables/usePerpsToasts'
 import type { EstimatesRequestBody, QuotesResponse } from '@/mew_api/types'
 import { isSignableWallet } from '@/utils/walletUtils'
 import { useI18n } from 'vue-i18n'
@@ -285,12 +286,23 @@ const { selectedChain, chains } = storeToRefs(chainsStore)
 const globalStore = useGlobalStore()
 const { gasPriceType: selectedFee } = storeToRefs(globalStore)
 const toastStore = useToastStore()
+const perpsToasts = usePerpsToasts()
 
 watch(isOpen, open => {
+  // TODO(perps-toasts): confirm which cancel path should fire toastDepositCanceled.
+  // There is no explicit cancel button for an in-progress deposit; the user can only
+  // close the dialog via the app-dialog close control. Distinguishing "dialog closed
+  // while deposit was in-flight (sending=true)" from "dialog closed before starting"
+  // requires state tracking not present here. Add perpsToasts.toastDepositCanceled()
+  // to the "!open && sending.value" branch once that tracking is confirmed with design.
+
   if (!open) return
   if (selectedChain.value?.name !== 'ETHEREUM') {
     const ethChain = chains.value.find(c => c.name === 'ETHEREUM')
     if (ethChain) {
+      // Note: setSelectedNetwork is a synchronous store mutation (no user interaction),
+      // so toastFailedToSwitchNetwork does not apply here. This toast is intentionally
+      // kept as an informational message about the automatic switch.
       globalStore.setSelectedNetwork('ETHEREUM')
       toastStore.addToastMessage({
         text: 'Switched network to Ethereum',
@@ -505,18 +517,11 @@ const sendSandboxDeposit = async () => {
       chain_id: 'eth-sepolia',
     })
     triggerRefresh()
-    toastStore.addToastMessage({
-      text: 'Deposit submitted!',
-      textSecondary:
-        'Deposit of ' +
-        amount.value +
-        ' USDC submitted! Funds may take a few minutes to appear in your perps balance.',
-      type: ToastType.Success,
-      duration: 180000,
-    })
+    perpsToasts.toastDepositComplete(amount.value, 'USDC')
     clearAmount()
   } catch (e: any) {
     error.value = e?.message || e?.toString() || 'Sandbox deposit failed'
+    perpsToasts.toastFailedToInitiateDeposit()
   } finally {
     sending.value = false
   }
@@ -585,15 +590,7 @@ const sendLiveDeposit = async () => {
     const hash = await broadcastFn?.(signedTx as HexPrefixedString)
     if (hash) {
       triggerRefresh()
-      toastStore.addToastMessage({
-        text: 'Deposit submitted!',
-        textSecondary:
-          'Deposit of ' +
-          amount.value +
-          ' USDC submitted! Funds may take a few minutes to appear in your perps balance.',
-        type: ToastType.Success,
-        duration: 180000,
-      })
+      perpsToasts.toastDepositInitiated()
       clearAmount()
     }
   } catch (e: any) {
@@ -606,6 +603,7 @@ const sendLiveDeposit = async () => {
     } else {
       error.value = msg || 'Transaction failed'
     }
+    perpsToasts.toastFailedToCreditAccount()
   } finally {
     sending.value = false
   }

--- a/src/modules/perps/components/PerpsDepositDialog.vue
+++ b/src/modules/perps/components/PerpsDepositDialog.vue
@@ -304,6 +304,7 @@ watch(isOpen, open => {
       // so toastFailedToSwitchNetwork does not apply here. This toast is intentionally
       // kept as an informational message about the automatic switch.
       globalStore.setSelectedNetwork('ETHEREUM')
+      // Direct toastStore call intentionally kept here; this is informational, not an error path.
       toastStore.addToastMessage({
         text: 'Switched network to Ethereum',
         textSecondary:
@@ -520,8 +521,16 @@ const sendSandboxDeposit = async () => {
     perpsToasts.toastDepositComplete(amount.value, 'USDC')
     clearAmount()
   } catch (e: any) {
-    error.value = e?.message || e?.toString() || 'Sandbox deposit failed'
-    perpsToasts.toastFailedToInitiateDeposit()
+    const msg = e?.message || e?.toString() || ''
+    const isRejection =
+      msg.toLowerCase().includes('user rejected') ||
+      msg.toLowerCase().includes('rejected')
+    if (isRejection) {
+      error.value = 'Transaction cancelled by user'
+    } else {
+      error.value = msg || 'Sandbox deposit failed'
+      perpsToasts.toastFailedToInitiateDeposit()
+    }
   } finally {
     sending.value = false
   }
@@ -595,15 +604,15 @@ const sendLiveDeposit = async () => {
     }
   } catch (e: any) {
     const msg = e?.message || e?.toString() || ''
-    if (
+    const isRejection =
       msg.toLowerCase().includes('user rejected') ||
       msg.toLowerCase().includes('rejected')
-    ) {
+    if (isRejection) {
       error.value = 'Transaction cancelled by user'
     } else {
       error.value = msg || 'Transaction failed'
+      perpsToasts.toastFailedToCreditAccount()
     }
-    perpsToasts.toastFailedToCreditAccount()
   } finally {
     sending.value = false
   }

--- a/src/modules/perps/components/PerpsPositionsTable.vue
+++ b/src/modules/perps/components/PerpsPositionsTable.vue
@@ -728,6 +728,7 @@ import {
   usePerpsFills,
   usePerpsDepositsWithdrawals,
 } from '../composables/usePerpsHistory'
+import { usePerpsToasts } from '../composables/usePerpsToasts'
 import {
   formatUsd,
   formatPrice,
@@ -861,6 +862,7 @@ const {
 } = usePerpsDepositsWithdrawals()
 
 const cancellingOrderId = ref<string | null>(null)
+const perpsToasts = usePerpsToasts()
 
 async function cancelOrder(orderId: string) {
   cancellingOrderId.value = orderId
@@ -870,6 +872,7 @@ async function cancelOrder(orderId: string) {
     await refetchOrders()
   } catch (e) {
     console.error('Failed to cancel order:', e)
+    perpsToasts.toastFailedToRemoveOrder()
   } finally {
     cancellingOrderId.value = null
   }

--- a/src/modules/perps/components/PerpsWithdrawDialog.vue
+++ b/src/modules/perps/components/PerpsWithdrawDialog.vue
@@ -1,9 +1,12 @@
 <template>
-  <app-dialog v-model:is-open="isOpen" @close-dialog="$emit('close')">
-    <div class="p-6">
-      <p class="font-bold text-s-20 mb-4">Withdraw USDC</p>
-
-      <div v-if="walletAddress">
+  <app-dialog
+    v-model:is-open="isOpen"
+    title="Withdraw USDC"
+    has-content-gutter
+    @close-dialog="$emit('close')"
+  >
+    <template #content>
+      <div class="pb-6" v-if="walletAddress">
         <!-- Withdraw to -->
         <div class="bg-surface rounded-12 p-4 mb-4">
           <p
@@ -74,7 +77,7 @@
           Done
         </button>
       </div>
-    </div>
+    </template>
   </app-dialog>
 </template>
 

--- a/src/modules/perps/components/PerpsWithdrawDialog.vue
+++ b/src/modules/perps/components/PerpsWithdrawDialog.vue
@@ -85,6 +85,7 @@ import { perpsClient } from '../configs'
 import { usePerpsAuth, usePerpsBalance } from '../composables/usePerpsAuth'
 import { useWalletStore } from '@/stores/walletStore'
 import { storeToRefs } from 'pinia'
+import { usePerpsToasts } from '@/modules/perps/composables/usePerpsToasts'
 
 const props = defineProps<{
   visible: boolean
@@ -103,6 +104,7 @@ const { accountId, triggerRefresh } = usePerpsAuth()
 const { balance } = usePerpsBalance()
 const store = useWalletStore()
 const { wallet } = storeToRefs(store)
+const perpsToasts = usePerpsToasts()
 
 const amount = ref('')
 const sending = ref(false)
@@ -172,7 +174,9 @@ async function submitWithdraw() {
     })
     withdrawalSuccess.value = true
     triggerRefresh()
+    perpsToasts.toastWithdrawalComplete()
   } catch (e) {
+    // TODO(perps-toasts): spec has no withdrawal-failure toast; revisit with design if needed
     error.value = e instanceof Error ? e.message : 'Withdrawal failed'
   } finally {
     sending.value = false

--- a/src/modules/perps/composables/usePerpsAuth.ts
+++ b/src/modules/perps/composables/usePerpsAuth.ts
@@ -148,15 +148,16 @@ export function usePerpsBalance() {
     _sharedFetchBalance = fetchBalance
 
     const perpsToasts = usePerpsToasts()
-    const previousUnderLiquidation = ref(false)
 
+    // Only fire on a genuine false→true transition. Watching the raw field
+    // (without `?? false`) keeps the initial observation as `undefined`, so
+    // a page reload of an already-liquidated account does NOT fire the toast.
     watch(
-      () => _sharedBalance.value?.underLiquidation ?? false,
-      (current) => {
-        if (current && !previousUnderLiquidation.value) {
+      () => _sharedBalance.value?.underLiquidation,
+      (current, previous) => {
+        if (current === true && previous === false) {
           perpsToasts.toastLiquidationInitiated()
         }
-        previousUnderLiquidation.value = current
       },
       { immediate: false },
     )

--- a/src/modules/perps/composables/usePerpsAuth.ts
+++ b/src/modules/perps/composables/usePerpsAuth.ts
@@ -1,8 +1,9 @@
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import { BUILDER_CODE, perpsClient } from '../configs'
 import { useWalletStore } from '@/stores/walletStore'
 import { storeToRefs } from 'pinia'
 import type { PerpsBalance, PortfolioSummary } from '../sdk/types'
+import { usePerpsToasts } from '@/modules/perps/composables/usePerpsToasts'
 
 const STORAGE_KEY_TOKEN = 'perps_auth_token'
 const STORAGE_KEY_ACCOUNT = 'perps_auth_account'
@@ -145,6 +146,20 @@ export function usePerpsBalance() {
     }, 500)
 
     _sharedFetchBalance = fetchBalance
+
+    const perpsToasts = usePerpsToasts()
+    const previousUnderLiquidation = ref(false)
+
+    watch(
+      () => _sharedBalance.value?.underLiquidation ?? false,
+      (current) => {
+        if (current && !previousUnderLiquidation.value) {
+          perpsToasts.toastLiquidationInitiated()
+        }
+        previousUnderLiquidation.value = current
+      },
+      { immediate: false },
+    )
   }
 
   return { balance, loading, refetch: _sharedFetchBalance! }

--- a/src/modules/perps/composables/usePerpsToasts.ts
+++ b/src/modules/perps/composables/usePerpsToasts.ts
@@ -210,7 +210,7 @@ export function usePerpsToasts() {
   const toastFailedToRemoveOrder = () => {
     toastStore.addToastMessage({
       type: ToastType.Error,
-      text: 'Failed to remove order',
+      text: 'Failed to Remove Order',
     })
   }
 
@@ -232,7 +232,9 @@ export function usePerpsToasts() {
   }
 
   const fillLine = (args: FillArgs) => {
-    const verb = humanSide(args.side) === 'Long' ? 'Bought' : 'Sold'
+    const human = humanSide(args.side)
+    const verb =
+      human === 'Long' ? 'Bought' : human === 'Short' ? 'Sold' : human
     return `${verb} ${args.filledSize}/${args.size} ${humanCategory(args.category)}: ${args.market} at ${formatPrice(args.fillPrice)}`
   }
 
@@ -279,7 +281,7 @@ export function usePerpsToasts() {
   const toastFailedToCloseAllPositions = () => {
     toastStore.addToastMessage({
       type: ToastType.Error,
-      text: 'Failed to close all positions',
+      text: 'Failed to Close All Positions',
     })
   }
 

--- a/src/modules/perps/composables/usePerpsToasts.ts
+++ b/src/modules/perps/composables/usePerpsToasts.ts
@@ -2,8 +2,8 @@ import { useToastStore } from '@/stores/toastStore'
 import { ToastType } from '@/types/notification'
 import { formatPrice, formatUsd } from '@/modules/perps/utils/formatters'
 
-type Side = 'long' | 'short' | 'buy' | 'sell' | string
-type OrderCategory = 'market' | 'limit' | 'stopMarket' | 'takeProfitMarket' | string
+type Side = 'long' | 'short' | 'buy' | 'sell' | (string & {})
+type OrderCategory = 'market' | 'limit' | 'stopMarket' | 'takeProfitMarket' | (string & {})
 
 function humanSide(side: Side): string {
   const s = (side || '').toLowerCase()
@@ -38,6 +38,31 @@ function orderLine(args: {
   const isMarket = (args.category || '').toLowerCase() === 'market'
   if (isMarket || args.price == null || args.price === '') return base
   return `${base} at ${formatPrice(args.price)}`
+}
+
+export type SlTpArgs = {
+  direction: Side
+  netQuantity: string | number
+  base: string
+  quote: string
+  triggerPrice: string | number
+}
+
+export type OrderArgs = {
+  side: Side
+  size: string | number
+  category: OrderCategory
+  market: string
+  price?: string | number
+}
+
+export type FillArgs = {
+  side: Side
+  filledSize: string | number
+  size: string | number
+  category: OrderCategory
+  market: string
+  fillPrice: string | number
 }
 
 export function usePerpsToasts() {
@@ -107,14 +132,6 @@ export function usePerpsToasts() {
   }
 
   // --- Stop Loss & Take Profit ---
-  type SlTpArgs = {
-    direction: Side
-    netQuantity: string | number
-    base: string
-    quote: string
-    triggerPrice: string | number
-  }
-
   const slTpLine = (args: SlTpArgs) =>
     `${humanSide(args.direction).toUpperCase()} ${args.netQuantity} PERPS: ${args.base}${args.quote} at ${formatUsd(args.triggerPrice as string | number)}`
 
@@ -164,6 +181,9 @@ export function usePerpsToasts() {
     })
   }
 
+  // Spec classifies SL/TP Removed as `failure` type.
+  // Kept as ToastType.Error here for spec fidelity; revisit with design
+  // if Red UI on a user-initiated remove is wrong.
   const toastStopLossRemoved = (args: SlTpArgs) => {
     toastStore.addToastMessage({
       type: ToastType.Error,
@@ -195,14 +215,6 @@ export function usePerpsToasts() {
   }
 
   // --- Orders & Trading (non-TWAP) ---
-  type OrderArgs = {
-    side: Side
-    size: string | number
-    category: OrderCategory
-    market: string
-    price?: string | number
-  }
-
   const toastOrderCanceled = (args: OrderArgs) => {
     toastStore.addToastMessage({
       type: ToastType.Success,
@@ -217,15 +229,6 @@ export function usePerpsToasts() {
       text: 'Order Placed',
       textSecondary: orderLine(args),
     })
-  }
-
-  type FillArgs = {
-    side: Side
-    filledSize: string | number
-    size: string | number
-    category: OrderCategory
-    market: string
-    fillPrice: string | number
   }
 
   const fillLine = (args: FillArgs) => {

--- a/src/modules/perps/composables/usePerpsToasts.ts
+++ b/src/modules/perps/composables/usePerpsToasts.ts
@@ -1,0 +1,323 @@
+import { useToastStore } from '@/stores/toastStore'
+import { ToastType } from '@/types/notification'
+import { formatPrice, formatUsd } from '@/modules/perps/utils/formatters'
+
+type Side = 'long' | 'short' | 'buy' | 'sell' | string
+type OrderCategory = 'market' | 'limit' | 'stopMarket' | 'takeProfitMarket' | string
+
+function humanSide(side: Side): string {
+  const s = (side || '').toLowerCase()
+  if (s === 'buy' || s === 'long') return 'Long'
+  if (s === 'sell' || s === 'short') return 'Short'
+  return side
+}
+
+function humanCategory(category: OrderCategory): string {
+  switch ((category || '').toLowerCase()) {
+    case 'market':
+      return 'Market'
+    case 'limit':
+      return 'Limit'
+    case 'stopmarket':
+      return 'Stop Market'
+    case 'takeprofitmarket':
+      return 'Take Profit Market'
+    default:
+      return category
+  }
+}
+
+function orderLine(args: {
+  side: Side
+  size: string | number
+  category: OrderCategory
+  market: string
+  price?: string | number
+}): string {
+  const base = `${humanSide(args.side)} ${args.size} ${humanCategory(args.category)}: ${args.market}`
+  const isMarket = (args.category || '').toLowerCase() === 'market'
+  if (isMarket || args.price == null || args.price === '') return base
+  return `${base} at ${formatPrice(args.price)}`
+}
+
+export function usePerpsToasts() {
+  const toastStore = useToastStore()
+
+  // --- Deposits & Withdrawals ---
+  const toastDepositComplete = (size?: string | number, coin = 'USDC') => {
+    toastStore.addToastMessage({
+      type: ToastType.Success,
+      text: 'Deposit Complete',
+      textSecondary:
+        size != null ? `${size} ${coin} added to your Trading Account` : undefined,
+    })
+  }
+
+  const toastWithdrawalComplete = () => {
+    toastStore.addToastMessage({
+      type: ToastType.Success,
+      text: 'Withdrawal Complete',
+    })
+  }
+
+  const toastDepositInitiated = () => {
+    toastStore.addToastMessage({
+      type: ToastType.Success,
+      text: 'Deposit Initiated',
+    })
+  }
+
+  const toastFailedToCreditAccount = () => {
+    toastStore.addToastMessage({
+      type: ToastType.Error,
+      text: 'Failed to Credit Account',
+    })
+  }
+
+  const toastDepositCanceled = () => {
+    toastStore.addToastMessage({
+      type: ToastType.Error,
+      text: 'Deposit Canceled',
+    })
+  }
+
+  const toastFailedToInitiateDeposit = () => {
+    toastStore.addToastMessage({
+      type: ToastType.Error,
+      text: 'Failed to Initiate Deposit',
+    })
+  }
+
+  const toastFailedToSwitchNetwork = () => {
+    toastStore.addToastMessage({
+      type: ToastType.Error,
+      text: 'Failed to Switch Network',
+    })
+  }
+
+  // --- Liquidation ---
+  const toastLiquidationInitiated = () => {
+    toastStore.addToastMessage({
+      type: ToastType.Warning,
+      text: 'Liquidation Initiated',
+      textSecondary:
+        'Your account is temporarily locked and your open positions are being sold',
+      isInfinite: true,
+    })
+  }
+
+  // --- Stop Loss & Take Profit ---
+  type SlTpArgs = {
+    direction: Side
+    netQuantity: string | number
+    base: string
+    quote: string
+    triggerPrice: string | number
+  }
+
+  const slTpLine = (args: SlTpArgs) =>
+    `${humanSide(args.direction).toUpperCase()} ${args.netQuantity} PERPS: ${args.base}${args.quote} at ${formatUsd(args.triggerPrice as string | number)}`
+
+  const toastStopLossAdded = (args: SlTpArgs) => {
+    toastStore.addToastMessage({
+      type: ToastType.Success,
+      text: 'Stop Loss Added',
+      textSecondary: slTpLine(args),
+    })
+  }
+
+  const toastTakeProfitAdded = (args: SlTpArgs) => {
+    toastStore.addToastMessage({
+      type: ToastType.Success,
+      text: 'Take Profit Added',
+      textSecondary: slTpLine(args),
+    })
+  }
+
+  const toastStopLossModified = (args: SlTpArgs) => {
+    toastStore.addToastMessage({
+      type: ToastType.Success,
+      text: 'Stop Loss Modified',
+      textSecondary: slTpLine(args),
+    })
+  }
+
+  const toastTakeProfitModified = (args: SlTpArgs) => {
+    toastStore.addToastMessage({
+      type: ToastType.Success,
+      text: 'Take Profit Modified',
+      textSecondary: slTpLine(args),
+    })
+  }
+
+  const toastStopLossInvalid = () => {
+    toastStore.addToastMessage({
+      type: ToastType.Error,
+      text: 'Stop Loss Invalid',
+    })
+  }
+
+  const toastTakeProfitInvalid = () => {
+    toastStore.addToastMessage({
+      type: ToastType.Error,
+      text: 'Take Profit Invalid',
+    })
+  }
+
+  const toastStopLossRemoved = (args: SlTpArgs) => {
+    toastStore.addToastMessage({
+      type: ToastType.Error,
+      text: 'Stop Loss Removed',
+      textSecondary: slTpLine(args),
+    })
+  }
+
+  const toastTakeProfitRemoved = (args: SlTpArgs) => {
+    toastStore.addToastMessage({
+      type: ToastType.Error,
+      text: 'Take Profit Removed',
+      textSecondary: slTpLine(args),
+    })
+  }
+
+  const toastFailedToRemoveSlTp = () => {
+    toastStore.addToastMessage({
+      type: ToastType.Error,
+      text: 'Failed to Remove Stop Loss / Take Profit',
+    })
+  }
+
+  const toastFailedToRemoveOrder = () => {
+    toastStore.addToastMessage({
+      type: ToastType.Error,
+      text: 'Failed to remove order',
+    })
+  }
+
+  // --- Orders & Trading (non-TWAP) ---
+  type OrderArgs = {
+    side: Side
+    size: string | number
+    category: OrderCategory
+    market: string
+    price?: string | number
+  }
+
+  const toastOrderCanceled = (args: OrderArgs) => {
+    toastStore.addToastMessage({
+      type: ToastType.Success,
+      text: 'Order Canceled',
+      textSecondary: orderLine(args),
+    })
+  }
+
+  const toastOrderPlaced = (args: OrderArgs) => {
+    toastStore.addToastMessage({
+      type: ToastType.Success,
+      text: 'Order Placed',
+      textSecondary: orderLine(args),
+    })
+  }
+
+  type FillArgs = {
+    side: Side
+    filledSize: string | number
+    size: string | number
+    category: OrderCategory
+    market: string
+    fillPrice: string | number
+  }
+
+  const fillLine = (args: FillArgs) => {
+    const verb = humanSide(args.side) === 'Long' ? 'Bought' : 'Sold'
+    return `${verb} ${args.filledSize}/${args.size} ${humanCategory(args.category)}: ${args.market} at ${formatPrice(args.fillPrice)}`
+  }
+
+  const toastOrderFilled = (args: FillArgs) => {
+    toastStore.addToastMessage({
+      type: ToastType.Success,
+      text: 'Order Filled',
+      textSecondary: fillLine(args),
+    })
+  }
+
+  const toastOrderPartiallyFilled = (args: FillArgs) => {
+    toastStore.addToastMessage({
+      type: ToastType.Success,
+      text: 'Order Partially Filled',
+      textSecondary: fillLine(args),
+    })
+  }
+
+  const toastCancelFailedInvalidOrderId = () => {
+    toastStore.addToastMessage({
+      type: ToastType.Error,
+      text: 'Cancel Failed',
+      textSecondary: 'Invalid order ID',
+    })
+  }
+
+  const toastCancelFailed = () => {
+    toastStore.addToastMessage({
+      type: ToastType.Error,
+      text: 'Cancel Failed',
+      textSecondary: 'Failed to cancel order',
+    })
+  }
+
+  const toastCancelFailedGeneric = () => {
+    toastStore.addToastMessage({
+      type: ToastType.Error,
+      text: 'Cancel Failed',
+      textSecondary: 'An error occurred while cancelling the order',
+    })
+  }
+
+  const toastFailedToCloseAllPositions = () => {
+    toastStore.addToastMessage({
+      type: ToastType.Error,
+      text: 'Failed to close all positions',
+    })
+  }
+
+  const toastFailedToCancelOrders = () => {
+    toastStore.addToastMessage({
+      type: ToastType.Error,
+      text: 'Failed to Cancel Orders',
+    })
+  }
+
+  return {
+    // Deposits & Withdrawals
+    toastDepositComplete,
+    toastWithdrawalComplete,
+    toastDepositInitiated,
+    toastFailedToCreditAccount,
+    toastDepositCanceled,
+    toastFailedToInitiateDeposit,
+    toastFailedToSwitchNetwork,
+    // Liquidation
+    toastLiquidationInitiated,
+    // Stop Loss & Take Profit
+    toastStopLossAdded,
+    toastTakeProfitAdded,
+    toastStopLossModified,
+    toastTakeProfitModified,
+    toastStopLossInvalid,
+    toastTakeProfitInvalid,
+    toastStopLossRemoved,
+    toastTakeProfitRemoved,
+    toastFailedToRemoveSlTp,
+    toastFailedToRemoveOrder,
+    // Orders & Trading
+    toastOrderCanceled,
+    toastOrderPlaced,
+    toastOrderFilled,
+    toastOrderPartiallyFilled,
+    toastCancelFailedInvalidOrderId,
+    toastCancelFailed,
+    toastCancelFailedGeneric,
+    toastFailedToCloseAllPositions,
+    toastFailedToCancelOrders,
+  }
+}

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -18,6 +18,13 @@ interface OrderSideButton {
   value: OrderSide
 }
 
+// Matches SDK error messages that specifically flag SL/TP as invalid, so
+// generic "invalid signature" / "invalid nonce" errors don't mislabel as
+// SL/TP validation failures. Revisit if/when the SDK exposes a structured
+// error code.
+const SL_TP_INVALID_PATTERN = /invalid\s+(stop[\s-]?loss|take[\s-]?profit|trigger)/i
+const TRIGGER_PRICE_DECIMALS = 2
+
 export function usePerpsTradeForm() {
   const walletMenuStore = useWalletMenuStore()
   const router = useRouter()
@@ -663,8 +670,10 @@ export function usePerpsTradeForm() {
     const priorPosition = activePosition.value
     const hadPriorStopLoss = !!priorPosition?.stopLossTriggerPrice
     const hadPriorTakeProfit = !!priorPosition?.takeProfitTriggerPrice
-    const willSetStopLoss = stopLossPrice.value !== null
-    const willSetTakeProfit = takeProfitPrice.value !== null
+    // Capture numeric SL/TP values once up front: used for the API payload,
+    // the formatted toast price, and as the null-guard for both branches.
+    const slPrice = stopLossPrice.value
+    const tpPrice = takeProfitPrice.value
     // Direction describes the POSITION side (LONG/SHORT), not the order side —
     // "LONG 0.5 PERPS: …" matches the position, including when placing a
     // reduce-only counter-order to modify an existing long.
@@ -676,6 +685,13 @@ export function usePerpsTradeForm() {
       ? (fullMarketName.value.split('-')[1] ?? '')
       : ''
     const slTpNetQuantity = priorPosition?.netQuantity ?? orderSize.value
+    const buildSlTpArgs = (triggerPrice: number) => ({
+      direction: positionDirection,
+      netQuantity: slTpNetQuantity,
+      base: slTpBase,
+      quote: slTpQuote,
+      triggerPrice: triggerPrice.toFixed(TRIGGER_PRICE_DECIMALS),
+    })
     try {
       const orderParams: Record<string, unknown> = {
         market: fullMarketName.value,
@@ -691,37 +707,25 @@ export function usePerpsTradeForm() {
           orderParams.price = limitPrice.value
         }
       }
-      if (willSetTakeProfit) {
+      if (tpPrice !== null) {
         orderParams.takeProfit = {
-          triggerPrice: (takeProfitPrice.value as number).toFixed(2),
+          triggerPrice: tpPrice.toFixed(TRIGGER_PRICE_DECIMALS),
         }
       }
-      if (willSetStopLoss) {
+      if (slPrice !== null) {
         orderParams.stopLoss = {
-          triggerPrice: (stopLossPrice.value as number).toFixed(2),
+          triggerPrice: slPrice.toFixed(TRIGGER_PRICE_DECIMALS),
         }
       }
       await perpsClient.createOrder(orderParams as any)
       // Fire SL/TP toasts only after the SDK call succeeded.
-      if (willSetStopLoss && stopLossPrice.value !== null) {
-        const args = {
-          direction: positionDirection,
-          netQuantity: slTpNetQuantity,
-          base: slTpBase,
-          quote: slTpQuote,
-          triggerPrice: (stopLossPrice.value as number).toFixed(2),
-        }
+      if (slPrice !== null) {
+        const args = buildSlTpArgs(slPrice)
         if (hadPriorStopLoss) perpsToasts.toastStopLossModified(args)
         else perpsToasts.toastStopLossAdded(args)
       }
-      if (willSetTakeProfit && takeProfitPrice.value !== null) {
-        const args = {
-          direction: positionDirection,
-          netQuantity: slTpNetQuantity,
-          base: slTpBase,
-          quote: slTpQuote,
-          triggerPrice: (takeProfitPrice.value as number).toFixed(2),
-        }
+      if (tpPrice !== null) {
+        const args = buildSlTpArgs(tpPrice)
         if (hadPriorTakeProfit) perpsToasts.toastTakeProfitModified(args)
         else perpsToasts.toastTakeProfitAdded(args)
       }
@@ -733,13 +737,15 @@ export function usePerpsTradeForm() {
       // If SL/TP were part of the request and the API rejected them as
       // invalid, surface dedicated Invalid toasts. These branches are
       // mutually exclusive with the success toasts above (which only run
-      // after createOrder resolves).
-      const msg = (error?.message || error?.toString() || '').toLowerCase()
-      const isInvalid = msg.includes('invalid')
-      if (isInvalid && willSetStopLoss) {
+      // after createOrder resolves). The regex targets SL/TP-scoped messages
+      // so generic "invalid signature" / "invalid nonce" errors don't
+      // mislabel as SL/TP validation failures.
+      const msg = error?.message || error?.toString() || ''
+      const isSlTpInvalid = SL_TP_INVALID_PATTERN.test(msg)
+      if (isSlTpInvalid && slPrice !== null) {
         perpsToasts.toastStopLossInvalid()
       }
-      if (isInvalid && willSetTakeProfit) {
+      if (isSlTpInvalid && tpPrice !== null) {
         perpsToasts.toastTakeProfitInvalid()
       }
       orderError.value =

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -7,6 +7,7 @@ import { usePerpsAuth, usePerpsBalance } from './usePerpsAuth'
 import { usePerpsMarkets, usePerpsContracts } from './usePerpsMarkets'
 import { usePerpsPositions } from './usePerpsPositions'
 import { usePerpsMarkPrices } from './usePerpsMarkPrices'
+import { usePerpsToasts } from './usePerpsToasts'
 import { formatUsd } from '../utils/formatters'
 import { getCategory, midPrice } from '../utils/market'
 
@@ -26,6 +27,7 @@ export function usePerpsTradeForm() {
   const { contracts } = usePerpsContracts()
   const { positions, closePosition } = usePerpsPositions()
   const { markPriceData } = usePerpsMarkPrices()
+  const perpsToasts = usePerpsToasts()
 
   // ── State ──────────────────────────────────────────────────
 
@@ -655,6 +657,25 @@ export function usePerpsTradeForm() {
   async function confirmAndSubmitOrder() {
     if (submitDisabled.value) return
     isSubmitting.value = true
+    // Snapshot prior SL/TP state BEFORE the SDK call so "prior" reflects what
+    // the user was about to change. Reading it afterward would see the new
+    // values once positions re-poll.
+    const priorPosition = activePosition.value
+    const hadPriorStopLoss = !!priorPosition?.stopLossTriggerPrice
+    const hadPriorTakeProfit = !!priorPosition?.takeProfitTriggerPrice
+    const willSetStopLoss = stopLossPrice.value !== null
+    const willSetTakeProfit = takeProfitPrice.value !== null
+    // Direction describes the POSITION side (LONG/SHORT), not the order side —
+    // "LONG 0.5 PERPS: …" matches the position, including when placing a
+    // reduce-only counter-order to modify an existing long.
+    const positionDirection =
+      priorPosition?.direction ??
+      (orderSide.value === 'buy' ? 'long' : 'short')
+    const slTpBase = displaySymbol.value
+    const slTpQuote = fullMarketName.value.includes('-')
+      ? (fullMarketName.value.split('-')[1] ?? '')
+      : ''
+    const slTpNetQuantity = priorPosition?.netQuantity ?? orderSize.value
     try {
       const orderParams: Record<string, unknown> = {
         market: fullMarketName.value,
@@ -670,28 +691,70 @@ export function usePerpsTradeForm() {
           orderParams.price = limitPrice.value
         }
       }
-      if (takeProfitPrice.value !== null) {
+      if (willSetTakeProfit) {
         orderParams.takeProfit = {
-          triggerPrice: takeProfitPrice.value.toFixed(2),
+          triggerPrice: (takeProfitPrice.value as number).toFixed(2),
         }
       }
-      if (stopLossPrice.value !== null) {
+      if (willSetStopLoss) {
         orderParams.stopLoss = {
-          triggerPrice: stopLossPrice.value.toFixed(2),
+          triggerPrice: (stopLossPrice.value as number).toFixed(2),
         }
       }
       await perpsClient.createOrder(orderParams as any)
+      // Fire SL/TP toasts only after the SDK call succeeded.
+      if (willSetStopLoss && stopLossPrice.value !== null) {
+        const args = {
+          direction: positionDirection,
+          netQuantity: slTpNetQuantity,
+          base: slTpBase,
+          quote: slTpQuote,
+          triggerPrice: (stopLossPrice.value as number).toFixed(2),
+        }
+        if (hadPriorStopLoss) perpsToasts.toastStopLossModified(args)
+        else perpsToasts.toastStopLossAdded(args)
+      }
+      if (willSetTakeProfit && takeProfitPrice.value !== null) {
+        const args = {
+          direction: positionDirection,
+          netQuantity: slTpNetQuantity,
+          base: slTpBase,
+          quote: slTpQuote,
+          triggerPrice: (takeProfitPrice.value as number).toFixed(2),
+        }
+        if (hadPriorTakeProfit) perpsToasts.toastTakeProfitModified(args)
+        else perpsToasts.toastTakeProfitAdded(args)
+      }
       showConfirmModal.value = false
       inputAmount.value = ''
       sliderValue.value = 0
       triggerRefresh()
     } catch (error: any) {
+      // If SL/TP were part of the request and the API rejected them as
+      // invalid, surface dedicated Invalid toasts. These branches are
+      // mutually exclusive with the success toasts above (which only run
+      // after createOrder resolves).
+      const msg = (error?.message || error?.toString() || '').toLowerCase()
+      const isInvalid = msg.includes('invalid')
+      if (isInvalid && willSetStopLoss) {
+        perpsToasts.toastStopLossInvalid()
+      }
+      if (isInvalid && willSetTakeProfit) {
+        perpsToasts.toastTakeProfitInvalid()
+      }
       orderError.value =
         error?.message || error?.toString() || 'Order failed. Please try again.'
     } finally {
       isSubmitting.value = false
     }
   }
+
+  // NOTE(perps-toasts): Dedicated remove-stop-loss / remove-take-profit flows
+  // are not yet wired in this composable. The SDK client today exposes
+  // createOrder / cancelOrder / setLeverage only — SL/TP are created inline
+  // via createOrder. When a remove-SL/TP endpoint is added, wire
+  // toastStopLossRemoved / toastTakeProfitRemoved / toastFailedToRemoveSlTp
+  // into those paths.
 
   // ── Lifecycle & watchers ───────────────────────────────────
   onMounted(() => {

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -23,7 +23,6 @@ interface OrderSideButton {
 // SL/TP validation failures. Revisit if/when the SDK exposes a structured
 // error code.
 const SL_TP_INVALID_PATTERN = /invalid\s+(stop[\s-]?loss|take[\s-]?profit|trigger)/i
-const TRIGGER_PRICE_DECIMALS = 2
 
 export function usePerpsTradeForm() {
   const walletMenuStore = useWalletMenuStore()
@@ -177,6 +176,17 @@ export function usePerpsTradeForm() {
     const market = markets.value.find(m => m.market === fullMarketName.value)
     return parseFloat(market?.baseIncrement || '0.0001')
   })
+
+  const activeMarketQuoteIncrement = computed(() => {
+    const market = markets.value.find(m => m.market === fullMarketName.value)
+    return parseFloat(market?.quoteIncrement || '0.01')
+  })
+
+  // API requires limit/trigger prices to align with quoteIncrement
+  // (/v1/markets). Using a hardcoded 2-decimal rounding rejects on markets
+  // with finer precision (e.g. quoteIncrement "0.0001").
+  const formatQuotePrice = (value: number): string =>
+    floorToIncrement(value, activeMarketQuoteIncrement.value)
 
   const orderSize = computed(() => {
     if (!currentPrice.value) return '0'
@@ -414,7 +424,7 @@ export function usePerpsTradeForm() {
     orderType.value = type
     showOrderTypeDropdown.value = false
     if (type === 'limit' && currentPrice.value) {
-      limitPrice.value = currentPrice.value.toFixed(2)
+      limitPrice.value = formatQuotePrice(currentPrice.value)
       activeLimitPill.value = null
     }
   }
@@ -423,7 +433,7 @@ export function usePerpsTradeForm() {
     if (!currentPrice.value) return
     activeLimitPill.value = pct
     const price = currentPrice.value * (1 + pct / 100)
-    limitPrice.value = price.toFixed(2)
+    limitPrice.value = formatQuotePrice(price)
   }
 
   // ── Market selector ────────────────────────────────────────
@@ -690,7 +700,7 @@ export function usePerpsTradeForm() {
       netQuantity: slTpNetQuantity,
       base: slTpBase,
       quote: slTpQuote,
-      triggerPrice: triggerPrice.toFixed(TRIGGER_PRICE_DECIMALS),
+      triggerPrice: formatQuotePrice(triggerPrice),
     })
     try {
       const orderParams: Record<string, unknown> = {
@@ -709,12 +719,12 @@ export function usePerpsTradeForm() {
       }
       if (tpPrice !== null) {
         orderParams.takeProfit = {
-          triggerPrice: tpPrice.toFixed(TRIGGER_PRICE_DECIMALS),
+          triggerPrice: formatQuotePrice(tpPrice),
         }
       }
       if (slPrice !== null) {
         orderParams.stopLoss = {
-          triggerPrice: slPrice.toFixed(TRIGGER_PRICE_DECIMALS),
+          triggerPrice: formatQuotePrice(slPrice),
         }
       }
       await perpsClient.createOrder(orderParams as any)
@@ -741,12 +751,21 @@ export function usePerpsTradeForm() {
       // so generic "invalid signature" / "invalid nonce" errors don't
       // mislabel as SL/TP validation failures.
       const msg = error?.message || error?.toString() || ''
-      const isSlTpInvalid = SL_TP_INVALID_PATTERN.test(msg)
-      if (isSlTpInvalid && slPrice !== null) {
-        perpsToasts.toastStopLossInvalid()
-      }
-      if (isSlTpInvalid && tpPrice !== null) {
-        perpsToasts.toastTakeProfitInvalid()
+      const match = msg.match(SL_TP_INVALID_PATTERN)
+      if (match) {
+        // The capture group is one of stop-loss / take-profit / trigger.
+        // "trigger" doesn't disambiguate, so fall back to firing both toasts
+        // (when both legs are present) to stay safe.
+        const kind = match[1].toLowerCase()
+        const mentionsSl = /stop/.test(kind)
+        const mentionsTp = /take/.test(kind)
+        const ambiguous = !mentionsSl && !mentionsTp
+        if (slPrice !== null && (mentionsSl || ambiguous)) {
+          perpsToasts.toastStopLossInvalid()
+        }
+        if (tpPrice !== null && (mentionsTp || ambiguous)) {
+          perpsToasts.toastTakeProfitInvalid()
+        }
       }
       orderError.value =
         error?.message || error?.toString() || 'Order failed. Please try again.'

--- a/tests/unit/specs/modules/perps/composables/usePerpsToasts.spec.ts
+++ b/tests/unit/specs/modules/perps/composables/usePerpsToasts.spec.ts
@@ -1,0 +1,106 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { useToastStore } from '@/stores/toastStore'
+import { ToastType } from '@/types/notification'
+import { usePerpsToasts } from '@/modules/perps/composables/usePerpsToasts'
+import { describe, it, expect, beforeEach } from 'vitest'
+
+describe('usePerpsToasts', () => {
+  let store: ReturnType<typeof useToastStore>
+  let toasts: ReturnType<typeof usePerpsToasts>
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    store = useToastStore()
+    toasts = usePerpsToasts()
+  })
+
+  it('toastDepositComplete includes size and coin', () => {
+    toasts.toastDepositComplete('100', 'USDC')
+    expect(store.messages).toHaveLength(1)
+    expect(store.messages[0]).toMatchObject({
+      type: ToastType.Success,
+      text: 'Deposit Complete',
+      textSecondary: '100 USDC added to your Trading Account',
+    })
+  })
+
+  it('toastWithdrawalComplete has no secondary text', () => {
+    toasts.toastWithdrawalComplete()
+    expect(store.messages[0]).toMatchObject({
+      type: ToastType.Success,
+      text: 'Withdrawal Complete',
+    })
+    expect(store.messages[0].textSecondary).toBeUndefined()
+  })
+
+  it('toastLiquidationInitiated is warning and infinite', () => {
+    toasts.toastLiquidationInitiated()
+    expect(store.messages[0]).toMatchObject({
+      type: ToastType.Warning,
+      text: 'Liquidation Initiated',
+      isInfinite: true,
+    })
+    expect(store.messages[0].textSecondary).toContain('temporarily locked')
+  })
+
+  it('toastStopLossAdded formats LONG/SHORT upper-case with PERPS line', () => {
+    toasts.toastStopLossAdded({
+      direction: 'long',
+      netQuantity: '0.5',
+      base: 'ETH',
+      quote: 'USD',
+      triggerPrice: '1800',
+    })
+    expect(store.messages[0]).toMatchObject({
+      type: ToastType.Success,
+      text: 'Stop Loss Added',
+    })
+    expect(store.messages[0].textSecondary).toMatch(/^LONG 0\.5 PERPS: ETHUSD at \$1,800\.00$/)
+  })
+
+  it('toastOrderPlaced omits " at {price}" when market order', () => {
+    toasts.toastOrderPlaced({
+      side: 'buy',
+      size: '1',
+      category: 'market',
+      market: 'ETH-USD',
+    })
+    expect(store.messages[0].textSecondary).toBe('Long 1 Market: ETH-USD')
+  })
+
+  it('toastOrderPlaced includes formatted price for limit orders', () => {
+    toasts.toastOrderPlaced({
+      side: 'sell',
+      size: '2',
+      category: 'limit',
+      market: 'BTC-USD',
+      price: '65000',
+    })
+    expect(store.messages[0].textSecondary).toBe('Short 2 Limit: BTC-USD at $65,000.00')
+  })
+
+  it('toastOrderFilled uses Bought for long side', () => {
+    toasts.toastOrderFilled({
+      side: 'buy',
+      filledSize: '1',
+      size: '1',
+      category: 'market',
+      market: 'ETH-USD',
+      fillPrice: '1800',
+    })
+    expect(store.messages[0]).toMatchObject({
+      type: ToastType.Success,
+      text: 'Order Filled',
+      textSecondary: 'Bought 1/1 Market: ETH-USD at $1,800.00',
+    })
+  })
+
+  it('toastCancelFailedInvalidOrderId has the canonical secondary text', () => {
+    toasts.toastCancelFailedInvalidOrderId()
+    expect(store.messages[0]).toMatchObject({
+      type: ToastType.Error,
+      text: 'Cancel Failed',
+      textSecondary: 'Invalid order ID',
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `usePerpsToasts` composable at `src/modules/perps/composables/usePerpsToasts.ts` — central wrapper for all perps toast copy, grouped by domain (deposits/withdrawals, liquidation, stop loss / take profit, orders & trading).
- Unit tests cover representative helpers (Deposit, Withdrawal, Liquidation, SL line format, market vs. limit order lines, fill direction, cancel-failure secondary text).
- Foundation PR in a stacked series of 5. PRs 2-5 consume these helpers.

## Stacked PRs

| PR | Scope | Base |
|---|---|---|
| 1 (this) | Foundation composable | `feat/v7-o-perps` |
| 2 | Deposits & Withdrawals | PR 1 |
| 3 | Liquidation Initiated | PR 2 |
| 4 | Stop Loss & Take Profit | PR 3 |
| 5 | Orders & Trading (non-TWAP) | PR 4 |

## Test plan

- [x] `npx vitest run tests/unit/specs/modules/perps/composables/usePerpsToasts.spec.ts` — 8/8 PASS
- [x] `npm run test:unit` — no regressions
- [x] `npm run lint` + type-check — clean (pre-commit hooks passed)
- [x] `npm run build` — succeeds

Plan: `docs/plans/2026-04-22-perps-toasts.md` (workspace root, not inside the repo).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized perps toast notifications for deposits, withdrawals, liquidations, SL/TP, orders, fills, and cancellation errors with consistent wording; withdrawal success toast added.
* **Bug Fixes**
  * Prevent duplicate deposit toasts when dialogs are closed mid-flight; show cancellation toast when appropriate.
  * Trigger liquidation toast only on real liquidation transitions.
* **Tests**
  * Added unit tests validating toast types and primary/secondary formatting.
* **Changelog**
  * Added changelog entries documenting the perps toast improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->