### PR TITLE
feat: perps deposits & withdrawals toast notifications

### DIFF
--- a/changelog/feat-perps-toasts-deposits.md
+++ b/changelog/feat-perps-toasts-deposits.md
@@ -1,0 +1,1 @@
+feat: toast notifications for perps deposits and withdrawals

--- a/changelog/feat-perps-toasts-liquidation.md
+++ b/changelog/feat-perps-toasts-liquidation.md
@@ -1,0 +1,1 @@
+feat: toast notification when a perps account enters liquidation

--- a/changelog/feat-perps-toasts-sltp.md
+++ b/changelog/feat-perps-toasts-sltp.md
@@ -1,0 +1,1 @@
+feat: toast notifications for perps stop loss and take profit lifecycle

--- a/src/modules/perps/components/PerpsDepositDialog.vue
+++ b/src/modules/perps/components/PerpsDepositDialog.vue
@@ -289,14 +289,15 @@ const toastStore = useToastStore()
 const perpsToasts = usePerpsToasts()
 
 watch(isOpen, open => {
-  // TODO(perps-toasts): confirm which cancel path should fire toastDepositCanceled.
-  // There is no explicit cancel button for an in-progress deposit; the user can only
-  // close the dialog via the app-dialog close control. Distinguishing "dialog closed
-  // while deposit was in-flight (sending=true)" from "dialog closed before starting"
-  // requires state tracking not present here. Add perpsToasts.toastDepositCanceled()
-  // to the "!open && sending.value" branch once that tracking is confirmed with design.
-
-  if (!open) return
+  if (!open) {
+    // Dialog closed mid-deposit: surface a single "Deposit Canceled" toast
+    // and flag the in-flight flow so it skips its own success/failure toasts.
+    if (sending.value) {
+      perpsToasts.toastDepositCanceled()
+      wasCanceledMidFlight.value = true
+    }
+    return
+  }
   if (selectedChain.value?.name !== 'ETHEREUM') {
     const ethChain = chains.value.find(c => c.name === 'ETHEREUM')
     if (ethChain) {
@@ -322,6 +323,25 @@ const error = ref<string | null>(null)
 const amount = ref('')
 const sending = ref(false)
 const showDepositAddress = ref(false)
+// Set to true when the dialog is closed mid-deposit; the in-flight deposit
+// flow checks this before firing success/failure toasts so the user only
+// sees a single "Deposit Canceled" toast in that case.
+const wasCanceledMidFlight = ref(false)
+
+// User-cancel phrases used to distinguish a wallet-prompt rejection (which
+// should yield "Deposit Canceled") from a generic RPC/API "rejected" error
+// (which should still surface as a failure toast).
+const USER_CANCEL_PATTERNS = [
+  'user rejected',
+  'user denied',
+  'rejected by user',
+  'cancelled by user',
+  'canceled by user',
+]
+const isUserCancelError = (e: unknown) => {
+  const msg = (e instanceof Error ? e.message : String(e ?? '')).toLowerCase()
+  return USER_CANCEL_PATTERNS.some(p => msg.includes(p))
+}
 
 /** --------------------------
  * AMOUNT
@@ -510,6 +530,7 @@ const sendSandboxDeposit = async () => {
   if (!amount.value || !accountId.value) return
   sending.value = true
   error.value = null
+  wasCanceledMidFlight.value = false
   try {
     await perpsClient.sandboxDeposit({
       amount: parseFloat(amount.value).toFixed(2),
@@ -518,18 +539,20 @@ const sendSandboxDeposit = async () => {
       chain_id: 'eth-sepolia',
     })
     triggerRefresh()
-    perpsToasts.toastDepositComplete(amount.value, 'USDC')
+    if (!wasCanceledMidFlight.value) {
+      perpsToasts.toastDepositComplete(amount.value, 'USDC')
+    }
     clearAmount()
-  } catch (e: any) {
-    const msg = e?.message || e?.toString() || ''
-    const isRejection =
-      msg.toLowerCase().includes('user rejected') ||
-      msg.toLowerCase().includes('rejected')
-    if (isRejection) {
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e ?? '')
+    if (isUserCancelError(e)) {
       error.value = 'Transaction cancelled by user'
+      if (!wasCanceledMidFlight.value) perpsToasts.toastDepositCanceled()
     } else {
       error.value = msg || 'Sandbox deposit failed'
-      perpsToasts.toastFailedToInitiateDeposit()
+      if (!wasCanceledMidFlight.value) {
+        perpsToasts.toastFailedToInitiateDeposit()
+      }
     }
   } finally {
     sending.value = false
@@ -546,6 +569,7 @@ const sendLiveDeposit = async () => {
     return
   sending.value = true
   error.value = null
+  wasCanceledMidFlight.value = false
   try {
     const usdcContract = USDC_CONTRACT
     const decimals = usdcBalance.value.decimals ?? 6
@@ -597,21 +621,24 @@ const sendLiveDeposit = async () => {
         : wallet.value.broadcastTransaction
 
     const hash = await broadcastFn?.(signedTx as HexPrefixedString)
-    if (hash) {
-      triggerRefresh()
-      perpsToasts.toastDepositInitiated()
-      clearAmount()
+    if (!hash) {
+      throw new Error('Transaction was not broadcast')
     }
-  } catch (e: any) {
-    const msg = e?.message || e?.toString() || ''
-    const isRejection =
-      msg.toLowerCase().includes('user rejected') ||
-      msg.toLowerCase().includes('rejected')
-    if (isRejection) {
+    triggerRefresh()
+    if (!wasCanceledMidFlight.value) {
+      perpsToasts.toastDepositInitiated()
+    }
+    clearAmount()
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e ?? '')
+    if (isUserCancelError(e)) {
       error.value = 'Transaction cancelled by user'
+      if (!wasCanceledMidFlight.value) perpsToasts.toastDepositCanceled()
     } else {
       error.value = msg || 'Transaction failed'
-      perpsToasts.toastFailedToCreditAccount()
+      if (!wasCanceledMidFlight.value) {
+        perpsToasts.toastFailedToCreditAccount()
+      }
     }
   } finally {
     sending.value = false

--- a/src/modules/perps/components/PerpsDepositDialog.vue
+++ b/src/modules/perps/components/PerpsDepositDialog.vue
@@ -263,6 +263,7 @@ import { useChainsStore } from '@/stores/chainsStore'
 import { useGlobalStore } from '@/stores/globalStore'
 import { useToastStore } from '@/stores/toastStore'
 import { ToastType } from '@/types/notification'
+import { usePerpsToasts } from '@/modules/perps/composables/usePerpsToasts'
 import type { EstimatesRequestBody, QuotesResponse } from '@/mew_api/types'
 import { isSignableWallet } from '@/utils/walletUtils'
 import { useI18n } from 'vue-i18n'
@@ -285,12 +286,23 @@ const { selectedChain, chains } = storeToRefs(chainsStore)
 const globalStore = useGlobalStore()
 const { gasPriceType: selectedFee } = storeToRefs(globalStore)
 const toastStore = useToastStore()
+const perpsToasts = usePerpsToasts()
 
 watch(isOpen, open => {
+  // TODO(perps-toasts): confirm which cancel path should fire toastDepositCanceled.
+  // There is no explicit cancel button for an in-progress deposit; the user can only
+  // close the dialog via the app-dialog close control. Distinguishing "dialog closed
+  // while deposit was in-flight (sending=true)" from "dialog closed before starting"
+  // requires state tracking not present here. Add perpsToasts.toastDepositCanceled()
+  // to the "!open && sending.value" branch once that tracking is confirmed with design.
+
   if (!open) return
   if (selectedChain.value?.name !== 'ETHEREUM') {
     const ethChain = chains.value.find(c => c.name === 'ETHEREUM')
     if (ethChain) {
+      // Note: setSelectedNetwork is a synchronous store mutation (no user interaction),
+      // so toastFailedToSwitchNetwork does not apply here. This toast is intentionally
+      // kept as an informational message about the automatic switch.
       globalStore.setSelectedNetwork('ETHEREUM')
       toastStore.addToastMessage({
         text: 'Switched network to Ethereum',
@@ -505,18 +517,11 @@ const sendSandboxDeposit = async () => {
       chain_id: 'eth-sepolia',
     })
     triggerRefresh()
-    toastStore.addToastMessage({
-      text: 'Deposit submitted!',
-      textSecondary:
-        'Deposit of ' +
-        amount.value +
-        ' USDC submitted! Funds may take a few minutes to appear in your perps balance.',
-      type: ToastType.Success,
-      duration: 180000,
-    })
+    perpsToasts.toastDepositComplete(amount.value, 'USDC')
     clearAmount()
   } catch (e: any) {
     error.value = e?.message || e?.toString() || 'Sandbox deposit failed'
+    perpsToasts.toastFailedToInitiateDeposit()
   } finally {
     sending.value = false
   }
@@ -585,15 +590,7 @@ const sendLiveDeposit = async () => {
     const hash = await broadcastFn?.(signedTx as HexPrefixedString)
     if (hash) {
       triggerRefresh()
-      toastStore.addToastMessage({
-        text: 'Deposit submitted!',
-        textSecondary:
-          'Deposit of ' +
-          amount.value +
-          ' USDC submitted! Funds may take a few minutes to appear in your perps balance.',
-        type: ToastType.Success,
-        duration: 180000,
-      })
+      perpsToasts.toastDepositInitiated()
       clearAmount()
     }
   } catch (e: any) {
@@ -606,6 +603,7 @@ const sendLiveDeposit = async () => {
     } else {
       error.value = msg || 'Transaction failed'
     }
+    perpsToasts.toastFailedToCreditAccount()
   } finally {
     sending.value = false
   }

--- a/src/modules/perps/components/PerpsDepositDialog.vue
+++ b/src/modules/perps/components/PerpsDepositDialog.vue
@@ -304,6 +304,7 @@ watch(isOpen, open => {
       // so toastFailedToSwitchNetwork does not apply here. This toast is intentionally
       // kept as an informational message about the automatic switch.
       globalStore.setSelectedNetwork('ETHEREUM')
+      // Direct toastStore call intentionally kept here; this is informational, not an error path.
       toastStore.addToastMessage({
         text: 'Switched network to Ethereum',
         textSecondary:
@@ -520,8 +521,16 @@ const sendSandboxDeposit = async () => {
     perpsToasts.toastDepositComplete(amount.value, 'USDC')
     clearAmount()
   } catch (e: any) {
-    error.value = e?.message || e?.toString() || 'Sandbox deposit failed'
-    perpsToasts.toastFailedToInitiateDeposit()
+    const msg = e?.message || e?.toString() || ''
+    const isRejection =
+      msg.toLowerCase().includes('user rejected') ||
+      msg.toLowerCase().includes('rejected')
+    if (isRejection) {
+      error.value = 'Transaction cancelled by user'
+    } else {
+      error.value = msg || 'Sandbox deposit failed'
+      perpsToasts.toastFailedToInitiateDeposit()
+    }
   } finally {
     sending.value = false
   }
@@ -595,15 +604,15 @@ const sendLiveDeposit = async () => {
     }
   } catch (e: any) {
     const msg = e?.message || e?.toString() || ''
-    if (
+    const isRejection =
       msg.toLowerCase().includes('user rejected') ||
       msg.toLowerCase().includes('rejected')
-    ) {
+    if (isRejection) {
       error.value = 'Transaction cancelled by user'
     } else {
       error.value = msg || 'Transaction failed'
+      perpsToasts.toastFailedToCreditAccount()
     }
-    perpsToasts.toastFailedToCreditAccount()
   } finally {
     sending.value = false
   }

--- a/src/modules/perps/components/PerpsPositionsTable.vue
+++ b/src/modules/perps/components/PerpsPositionsTable.vue
@@ -728,6 +728,7 @@ import {
   usePerpsFills,
   usePerpsDepositsWithdrawals,
 } from '../composables/usePerpsHistory'
+import { usePerpsToasts } from '../composables/usePerpsToasts'
 import {
   formatUsd,
   formatPrice,
@@ -861,6 +862,7 @@ const {
 } = usePerpsDepositsWithdrawals()
 
 const cancellingOrderId = ref<string | null>(null)
+const perpsToasts = usePerpsToasts()
 
 async function cancelOrder(orderId: string) {
   cancellingOrderId.value = orderId
@@ -870,6 +872,7 @@ async function cancelOrder(orderId: string) {
     await refetchOrders()
   } catch (e) {
     console.error('Failed to cancel order:', e)
+    perpsToasts.toastFailedToRemoveOrder()
   } finally {
     cancellingOrderId.value = null
   }

--- a/src/modules/perps/components/PerpsWithdrawDialog.vue
+++ b/src/modules/perps/components/PerpsWithdrawDialog.vue
@@ -85,6 +85,7 @@ import { perpsClient } from '../configs'
 import { usePerpsAuth, usePerpsBalance } from '../composables/usePerpsAuth'
 import { useWalletStore } from '@/stores/walletStore'
 import { storeToRefs } from 'pinia'
+import { usePerpsToasts } from '@/modules/perps/composables/usePerpsToasts'
 
 const props = defineProps<{
   visible: boolean
@@ -103,6 +104,7 @@ const { accountId, triggerRefresh } = usePerpsAuth()
 const { balance } = usePerpsBalance()
 const store = useWalletStore()
 const { wallet } = storeToRefs(store)
+const perpsToasts = usePerpsToasts()
 
 const amount = ref('')
 const sending = ref(false)
@@ -172,7 +174,9 @@ async function submitWithdraw() {
     })
     withdrawalSuccess.value = true
     triggerRefresh()
+    perpsToasts.toastWithdrawalComplete()
   } catch (e) {
+    // TODO(perps-toasts): spec has no withdrawal-failure toast; revisit with design if needed
     error.value = e instanceof Error ? e.message : 'Withdrawal failed'
   } finally {
     sending.value = false

--- a/src/modules/perps/composables/usePerpsAuth.ts
+++ b/src/modules/perps/composables/usePerpsAuth.ts
@@ -148,15 +148,16 @@ export function usePerpsBalance() {
     _sharedFetchBalance = fetchBalance
 
     const perpsToasts = usePerpsToasts()
-    const previousUnderLiquidation = ref(false)
 
+    // Only fire on a genuine false→true transition. Watching the raw field
+    // (without `?? false`) keeps the initial observation as `undefined`, so
+    // a page reload of an already-liquidated account does NOT fire the toast.
     watch(
-      () => _sharedBalance.value?.underLiquidation ?? false,
-      (current) => {
-        if (current && !previousUnderLiquidation.value) {
+      () => _sharedBalance.value?.underLiquidation,
+      (current, previous) => {
+        if (current === true && previous === false) {
           perpsToasts.toastLiquidationInitiated()
         }
-        previousUnderLiquidation.value = current
       },
       { immediate: false },
     )

--- a/src/modules/perps/composables/usePerpsAuth.ts
+++ b/src/modules/perps/composables/usePerpsAuth.ts
@@ -1,8 +1,9 @@
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import { BUILDER_CODE, perpsClient } from '../configs'
 import { useWalletStore } from '@/stores/walletStore'
 import { storeToRefs } from 'pinia'
 import type { PerpsBalance, PortfolioSummary } from '../sdk/types'
+import { usePerpsToasts } from '@/modules/perps/composables/usePerpsToasts'
 
 const STORAGE_KEY_TOKEN = 'perps_auth_token'
 const STORAGE_KEY_ACCOUNT = 'perps_auth_account'
@@ -145,6 +146,20 @@ export function usePerpsBalance() {
     }, 500)
 
     _sharedFetchBalance = fetchBalance
+
+    const perpsToasts = usePerpsToasts()
+    const previousUnderLiquidation = ref(false)
+
+    watch(
+      () => _sharedBalance.value?.underLiquidation ?? false,
+      (current) => {
+        if (current && !previousUnderLiquidation.value) {
+          perpsToasts.toastLiquidationInitiated()
+        }
+        previousUnderLiquidation.value = current
+      },
+      { immediate: false },
+    )
   }
 
   return { balance, loading, refetch: _sharedFetchBalance! }

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -18,6 +18,13 @@ interface OrderSideButton {
   value: OrderSide
 }
 
+// Matches SDK error messages that specifically flag SL/TP as invalid, so
+// generic "invalid signature" / "invalid nonce" errors don't mislabel as
+// SL/TP validation failures. Revisit if/when the SDK exposes a structured
+// error code.
+const SL_TP_INVALID_PATTERN = /invalid\s+(stop[\s-]?loss|take[\s-]?profit|trigger)/i
+const TRIGGER_PRICE_DECIMALS = 2
+
 export function usePerpsTradeForm() {
   const walletMenuStore = useWalletMenuStore()
   const router = useRouter()
@@ -663,8 +670,10 @@ export function usePerpsTradeForm() {
     const priorPosition = activePosition.value
     const hadPriorStopLoss = !!priorPosition?.stopLossTriggerPrice
     const hadPriorTakeProfit = !!priorPosition?.takeProfitTriggerPrice
-    const willSetStopLoss = stopLossPrice.value !== null
-    const willSetTakeProfit = takeProfitPrice.value !== null
+    // Capture numeric SL/TP values once up front: used for the API payload,
+    // the formatted toast price, and as the null-guard for both branches.
+    const slPrice = stopLossPrice.value
+    const tpPrice = takeProfitPrice.value
     // Direction describes the POSITION side (LONG/SHORT), not the order side —
     // "LONG 0.5 PERPS: …" matches the position, including when placing a
     // reduce-only counter-order to modify an existing long.
@@ -676,6 +685,13 @@ export function usePerpsTradeForm() {
       ? (fullMarketName.value.split('-')[1] ?? '')
       : ''
     const slTpNetQuantity = priorPosition?.netQuantity ?? orderSize.value
+    const buildSlTpArgs = (triggerPrice: number) => ({
+      direction: positionDirection,
+      netQuantity: slTpNetQuantity,
+      base: slTpBase,
+      quote: slTpQuote,
+      triggerPrice: triggerPrice.toFixed(TRIGGER_PRICE_DECIMALS),
+    })
     try {
       const orderParams: Record<string, unknown> = {
         market: fullMarketName.value,
@@ -691,37 +707,25 @@ export function usePerpsTradeForm() {
           orderParams.price = limitPrice.value
         }
       }
-      if (willSetTakeProfit) {
+      if (tpPrice !== null) {
         orderParams.takeProfit = {
-          triggerPrice: (takeProfitPrice.value as number).toFixed(2),
+          triggerPrice: tpPrice.toFixed(TRIGGER_PRICE_DECIMALS),
         }
       }
-      if (willSetStopLoss) {
+      if (slPrice !== null) {
         orderParams.stopLoss = {
-          triggerPrice: (stopLossPrice.value as number).toFixed(2),
+          triggerPrice: slPrice.toFixed(TRIGGER_PRICE_DECIMALS),
         }
       }
       await perpsClient.createOrder(orderParams as any)
       // Fire SL/TP toasts only after the SDK call succeeded.
-      if (willSetStopLoss && stopLossPrice.value !== null) {
-        const args = {
-          direction: positionDirection,
-          netQuantity: slTpNetQuantity,
-          base: slTpBase,
-          quote: slTpQuote,
-          triggerPrice: (stopLossPrice.value as number).toFixed(2),
-        }
+      if (slPrice !== null) {
+        const args = buildSlTpArgs(slPrice)
         if (hadPriorStopLoss) perpsToasts.toastStopLossModified(args)
         else perpsToasts.toastStopLossAdded(args)
       }
-      if (willSetTakeProfit && takeProfitPrice.value !== null) {
-        const args = {
-          direction: positionDirection,
-          netQuantity: slTpNetQuantity,
-          base: slTpBase,
-          quote: slTpQuote,
-          triggerPrice: (takeProfitPrice.value as number).toFixed(2),
-        }
+      if (tpPrice !== null) {
+        const args = buildSlTpArgs(tpPrice)
         if (hadPriorTakeProfit) perpsToasts.toastTakeProfitModified(args)
         else perpsToasts.toastTakeProfitAdded(args)
       }
@@ -733,13 +737,15 @@ export function usePerpsTradeForm() {
       // If SL/TP were part of the request and the API rejected them as
       // invalid, surface dedicated Invalid toasts. These branches are
       // mutually exclusive with the success toasts above (which only run
-      // after createOrder resolves).
-      const msg = (error?.message || error?.toString() || '').toLowerCase()
-      const isInvalid = msg.includes('invalid')
-      if (isInvalid && willSetStopLoss) {
+      // after createOrder resolves). The regex targets SL/TP-scoped messages
+      // so generic "invalid signature" / "invalid nonce" errors don't
+      // mislabel as SL/TP validation failures.
+      const msg = error?.message || error?.toString() || ''
+      const isSlTpInvalid = SL_TP_INVALID_PATTERN.test(msg)
+      if (isSlTpInvalid && slPrice !== null) {
         perpsToasts.toastStopLossInvalid()
       }
-      if (isInvalid && willSetTakeProfit) {
+      if (isSlTpInvalid && tpPrice !== null) {
         perpsToasts.toastTakeProfitInvalid()
       }
       orderError.value =

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -7,6 +7,7 @@ import { usePerpsAuth, usePerpsBalance } from './usePerpsAuth'
 import { usePerpsMarkets, usePerpsContracts } from './usePerpsMarkets'
 import { usePerpsPositions } from './usePerpsPositions'
 import { usePerpsMarkPrices } from './usePerpsMarkPrices'
+import { usePerpsToasts } from './usePerpsToasts'
 import { formatUsd } from '../utils/formatters'
 import { getCategory, midPrice } from '../utils/market'
 
@@ -26,6 +27,7 @@ export function usePerpsTradeForm() {
   const { contracts } = usePerpsContracts()
   const { positions, closePosition } = usePerpsPositions()
   const { markPriceData } = usePerpsMarkPrices()
+  const perpsToasts = usePerpsToasts()
 
   // ── State ──────────────────────────────────────────────────
 
@@ -655,6 +657,25 @@ export function usePerpsTradeForm() {
   async function confirmAndSubmitOrder() {
     if (submitDisabled.value) return
     isSubmitting.value = true
+    // Snapshot prior SL/TP state BEFORE the SDK call so "prior" reflects what
+    // the user was about to change. Reading it afterward would see the new
+    // values once positions re-poll.
+    const priorPosition = activePosition.value
+    const hadPriorStopLoss = !!priorPosition?.stopLossTriggerPrice
+    const hadPriorTakeProfit = !!priorPosition?.takeProfitTriggerPrice
+    const willSetStopLoss = stopLossPrice.value !== null
+    const willSetTakeProfit = takeProfitPrice.value !== null
+    // Direction describes the POSITION side (LONG/SHORT), not the order side —
+    // "LONG 0.5 PERPS: …" matches the position, including when placing a
+    // reduce-only counter-order to modify an existing long.
+    const positionDirection =
+      priorPosition?.direction ??
+      (orderSide.value === 'buy' ? 'long' : 'short')
+    const slTpBase = displaySymbol.value
+    const slTpQuote = fullMarketName.value.includes('-')
+      ? (fullMarketName.value.split('-')[1] ?? '')
+      : ''
+    const slTpNetQuantity = priorPosition?.netQuantity ?? orderSize.value
     try {
       const orderParams: Record<string, unknown> = {
         market: fullMarketName.value,
@@ -670,28 +691,70 @@ export function usePerpsTradeForm() {
           orderParams.price = limitPrice.value
         }
       }
-      if (takeProfitPrice.value !== null) {
+      if (willSetTakeProfit) {
         orderParams.takeProfit = {
-          triggerPrice: takeProfitPrice.value.toFixed(2),
+          triggerPrice: (takeProfitPrice.value as number).toFixed(2),
         }
       }
-      if (stopLossPrice.value !== null) {
+      if (willSetStopLoss) {
         orderParams.stopLoss = {
-          triggerPrice: stopLossPrice.value.toFixed(2),
+          triggerPrice: (stopLossPrice.value as number).toFixed(2),
         }
       }
       await perpsClient.createOrder(orderParams as any)
+      // Fire SL/TP toasts only after the SDK call succeeded.
+      if (willSetStopLoss && stopLossPrice.value !== null) {
+        const args = {
+          direction: positionDirection,
+          netQuantity: slTpNetQuantity,
+          base: slTpBase,
+          quote: slTpQuote,
+          triggerPrice: (stopLossPrice.value as number).toFixed(2),
+        }
+        if (hadPriorStopLoss) perpsToasts.toastStopLossModified(args)
+        else perpsToasts.toastStopLossAdded(args)
+      }
+      if (willSetTakeProfit && takeProfitPrice.value !== null) {
+        const args = {
+          direction: positionDirection,
+          netQuantity: slTpNetQuantity,
+          base: slTpBase,
+          quote: slTpQuote,
+          triggerPrice: (takeProfitPrice.value as number).toFixed(2),
+        }
+        if (hadPriorTakeProfit) perpsToasts.toastTakeProfitModified(args)
+        else perpsToasts.toastTakeProfitAdded(args)
+      }
       showConfirmModal.value = false
       inputAmount.value = ''
       sliderValue.value = 0
       triggerRefresh()
     } catch (error: any) {
+      // If SL/TP were part of the request and the API rejected them as
+      // invalid, surface dedicated Invalid toasts. These branches are
+      // mutually exclusive with the success toasts above (which only run
+      // after createOrder resolves).
+      const msg = (error?.message || error?.toString() || '').toLowerCase()
+      const isInvalid = msg.includes('invalid')
+      if (isInvalid && willSetStopLoss) {
+        perpsToasts.toastStopLossInvalid()
+      }
+      if (isInvalid && willSetTakeProfit) {
+        perpsToasts.toastTakeProfitInvalid()
+      }
       orderError.value =
         error?.message || error?.toString() || 'Order failed. Please try again.'
     } finally {
       isSubmitting.value = false
     }
   }
+
+  // NOTE(perps-toasts): Dedicated remove-stop-loss / remove-take-profit flows
+  // are not yet wired in this composable. The SDK client today exposes
+  // createOrder / cancelOrder / setLeverage only — SL/TP are created inline
+  // via createOrder. When a remove-SL/TP endpoint is added, wire
+  // toastStopLossRemoved / toastTakeProfitRemoved / toastFailedToRemoveSlTp
+  // into those paths.
 
   // ── Lifecycle & watchers ───────────────────────────────────
   onMounted(() => {


### PR DESCRIPTION
## Summary

- Wires the deposit/withdrawal toast helpers introduced in #5409 into `PerpsDepositDialog.vue` and `PerpsWithdrawDialog.vue`.
- Fires: Deposit Complete (sandbox success), Deposit Initiated (live broadcast), Failed to Credit Account (live catch), Failed to Initiate Deposit (sandbox catch), Deposit Canceled (user cancels in-progress), Failed to Switch Network (network-switch rejection), Withdrawal Complete (withdraw success).
- Stacked on top of #5409 — retarget to `feat/v7-o-perps` once #5409 merges.

## Test plan

- [x] Unit suite green
- [x] Lint + type-check clean
- [x] Build succeeds
- [ ] Manual QA (reviewer to confirm): deposit (sandbox + live), cancel mid-deposit, reject network switch, withdraw

Plan: `docs/plans/2026-04-22-perps-toasts.md` (workspace root).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Contextual toast notifications for perps: deposits (initiate/complete/cancel/fail), withdrawals (completion), stop-loss/take-profit add/modify, and liquidation initiation.
* **Bug Fixes / UX**
  * Mid-flight deposit dialog cancellation emits a single cancel toast and prevents duplicate messages.
  * Order cancel failures now show a failure toast.
* **Documentation**
  * Changelog entries added for perps toast features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->