### PR TITLE
feat: perps liquidation-initiated toast

### DIFF
--- a/changelog/feat-perps-toasts-liquidation.md
+++ b/changelog/feat-perps-toasts-liquidation.md
@@ -1,0 +1,1 @@
+feat: toast notification when a perps account enters liquidation

--- a/changelog/feat-perps-toasts-sltp.md
+++ b/changelog/feat-perps-toasts-sltp.md
@@ -1,0 +1,1 @@
+feat: toast notifications for perps stop loss and take profit lifecycle

--- a/src/modules/perps/components/PerpsPositionsTable.vue
+++ b/src/modules/perps/components/PerpsPositionsTable.vue
@@ -728,6 +728,7 @@ import {
   usePerpsFills,
   usePerpsDepositsWithdrawals,
 } from '../composables/usePerpsHistory'
+import { usePerpsToasts } from '../composables/usePerpsToasts'
 import {
   formatUsd,
   formatPrice,
@@ -861,6 +862,7 @@ const {
 } = usePerpsDepositsWithdrawals()
 
 const cancellingOrderId = ref<string | null>(null)
+const perpsToasts = usePerpsToasts()
 
 async function cancelOrder(orderId: string) {
   cancellingOrderId.value = orderId
@@ -870,6 +872,7 @@ async function cancelOrder(orderId: string) {
     await refetchOrders()
   } catch (e) {
     console.error('Failed to cancel order:', e)
+    perpsToasts.toastFailedToRemoveOrder()
   } finally {
     cancellingOrderId.value = null
   }

--- a/src/modules/perps/composables/usePerpsAuth.ts
+++ b/src/modules/perps/composables/usePerpsAuth.ts
@@ -148,15 +148,16 @@ export function usePerpsBalance() {
     _sharedFetchBalance = fetchBalance
 
     const perpsToasts = usePerpsToasts()
-    const previousUnderLiquidation = ref(false)
 
+    // Only fire on a genuine false→true transition. Watching the raw field
+    // (without `?? false`) keeps the initial observation as `undefined`, so
+    // a page reload of an already-liquidated account does NOT fire the toast.
     watch(
-      () => _sharedBalance.value?.underLiquidation ?? false,
-      (current) => {
-        if (current && !previousUnderLiquidation.value) {
+      () => _sharedBalance.value?.underLiquidation,
+      (current, previous) => {
+        if (current === true && previous === false) {
           perpsToasts.toastLiquidationInitiated()
         }
-        previousUnderLiquidation.value = current
       },
       { immediate: false },
     )

--- a/src/modules/perps/composables/usePerpsAuth.ts
+++ b/src/modules/perps/composables/usePerpsAuth.ts
@@ -1,8 +1,9 @@
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import { BUILDER_CODE, perpsClient } from '../configs'
 import { useWalletStore } from '@/stores/walletStore'
 import { storeToRefs } from 'pinia'
 import type { PerpsBalance, PortfolioSummary } from '../sdk/types'
+import { usePerpsToasts } from '@/modules/perps/composables/usePerpsToasts'
 
 const STORAGE_KEY_TOKEN = 'perps_auth_token'
 const STORAGE_KEY_ACCOUNT = 'perps_auth_account'
@@ -145,6 +146,20 @@ export function usePerpsBalance() {
     }, 500)
 
     _sharedFetchBalance = fetchBalance
+
+    const perpsToasts = usePerpsToasts()
+    const previousUnderLiquidation = ref(false)
+
+    watch(
+      () => _sharedBalance.value?.underLiquidation ?? false,
+      (current) => {
+        if (current && !previousUnderLiquidation.value) {
+          perpsToasts.toastLiquidationInitiated()
+        }
+        previousUnderLiquidation.value = current
+      },
+      { immediate: false },
+    )
   }
 
   return { balance, loading, refetch: _sharedFetchBalance! }

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -18,6 +18,13 @@ interface OrderSideButton {
   value: OrderSide
 }
 
+// Matches SDK error messages that specifically flag SL/TP as invalid, so
+// generic "invalid signature" / "invalid nonce" errors don't mislabel as
+// SL/TP validation failures. Revisit if/when the SDK exposes a structured
+// error code.
+const SL_TP_INVALID_PATTERN = /invalid\s+(stop[\s-]?loss|take[\s-]?profit|trigger)/i
+const TRIGGER_PRICE_DECIMALS = 2
+
 export function usePerpsTradeForm() {
   const walletMenuStore = useWalletMenuStore()
   const router = useRouter()
@@ -663,8 +670,10 @@ export function usePerpsTradeForm() {
     const priorPosition = activePosition.value
     const hadPriorStopLoss = !!priorPosition?.stopLossTriggerPrice
     const hadPriorTakeProfit = !!priorPosition?.takeProfitTriggerPrice
-    const willSetStopLoss = stopLossPrice.value !== null
-    const willSetTakeProfit = takeProfitPrice.value !== null
+    // Capture numeric SL/TP values once up front: used for the API payload,
+    // the formatted toast price, and as the null-guard for both branches.
+    const slPrice = stopLossPrice.value
+    const tpPrice = takeProfitPrice.value
     // Direction describes the POSITION side (LONG/SHORT), not the order side —
     // "LONG 0.5 PERPS: …" matches the position, including when placing a
     // reduce-only counter-order to modify an existing long.
@@ -676,6 +685,13 @@ export function usePerpsTradeForm() {
       ? (fullMarketName.value.split('-')[1] ?? '')
       : ''
     const slTpNetQuantity = priorPosition?.netQuantity ?? orderSize.value
+    const buildSlTpArgs = (triggerPrice: number) => ({
+      direction: positionDirection,
+      netQuantity: slTpNetQuantity,
+      base: slTpBase,
+      quote: slTpQuote,
+      triggerPrice: triggerPrice.toFixed(TRIGGER_PRICE_DECIMALS),
+    })
     try {
       const orderParams: Record<string, unknown> = {
         market: fullMarketName.value,
@@ -691,37 +707,25 @@ export function usePerpsTradeForm() {
           orderParams.price = limitPrice.value
         }
       }
-      if (willSetTakeProfit) {
+      if (tpPrice !== null) {
         orderParams.takeProfit = {
-          triggerPrice: (takeProfitPrice.value as number).toFixed(2),
+          triggerPrice: tpPrice.toFixed(TRIGGER_PRICE_DECIMALS),
         }
       }
-      if (willSetStopLoss) {
+      if (slPrice !== null) {
         orderParams.stopLoss = {
-          triggerPrice: (stopLossPrice.value as number).toFixed(2),
+          triggerPrice: slPrice.toFixed(TRIGGER_PRICE_DECIMALS),
         }
       }
       await perpsClient.createOrder(orderParams as any)
       // Fire SL/TP toasts only after the SDK call succeeded.
-      if (willSetStopLoss && stopLossPrice.value !== null) {
-        const args = {
-          direction: positionDirection,
-          netQuantity: slTpNetQuantity,
-          base: slTpBase,
-          quote: slTpQuote,
-          triggerPrice: (stopLossPrice.value as number).toFixed(2),
-        }
+      if (slPrice !== null) {
+        const args = buildSlTpArgs(slPrice)
         if (hadPriorStopLoss) perpsToasts.toastStopLossModified(args)
         else perpsToasts.toastStopLossAdded(args)
       }
-      if (willSetTakeProfit && takeProfitPrice.value !== null) {
-        const args = {
-          direction: positionDirection,
-          netQuantity: slTpNetQuantity,
-          base: slTpBase,
-          quote: slTpQuote,
-          triggerPrice: (takeProfitPrice.value as number).toFixed(2),
-        }
+      if (tpPrice !== null) {
+        const args = buildSlTpArgs(tpPrice)
         if (hadPriorTakeProfit) perpsToasts.toastTakeProfitModified(args)
         else perpsToasts.toastTakeProfitAdded(args)
       }
@@ -733,13 +737,15 @@ export function usePerpsTradeForm() {
       // If SL/TP were part of the request and the API rejected them as
       // invalid, surface dedicated Invalid toasts. These branches are
       // mutually exclusive with the success toasts above (which only run
-      // after createOrder resolves).
-      const msg = (error?.message || error?.toString() || '').toLowerCase()
-      const isInvalid = msg.includes('invalid')
-      if (isInvalid && willSetStopLoss) {
+      // after createOrder resolves). The regex targets SL/TP-scoped messages
+      // so generic "invalid signature" / "invalid nonce" errors don't
+      // mislabel as SL/TP validation failures.
+      const msg = error?.message || error?.toString() || ''
+      const isSlTpInvalid = SL_TP_INVALID_PATTERN.test(msg)
+      if (isSlTpInvalid && slPrice !== null) {
         perpsToasts.toastStopLossInvalid()
       }
-      if (isInvalid && willSetTakeProfit) {
+      if (isSlTpInvalid && tpPrice !== null) {
         perpsToasts.toastTakeProfitInvalid()
       }
       orderError.value =

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -7,6 +7,7 @@ import { usePerpsAuth, usePerpsBalance } from './usePerpsAuth'
 import { usePerpsMarkets, usePerpsContracts } from './usePerpsMarkets'
 import { usePerpsPositions } from './usePerpsPositions'
 import { usePerpsMarkPrices } from './usePerpsMarkPrices'
+import { usePerpsToasts } from './usePerpsToasts'
 import { formatUsd } from '../utils/formatters'
 import { getCategory, midPrice } from '../utils/market'
 
@@ -26,6 +27,7 @@ export function usePerpsTradeForm() {
   const { contracts } = usePerpsContracts()
   const { positions, closePosition } = usePerpsPositions()
   const { markPriceData } = usePerpsMarkPrices()
+  const perpsToasts = usePerpsToasts()
 
   // ── State ──────────────────────────────────────────────────
 
@@ -655,6 +657,25 @@ export function usePerpsTradeForm() {
   async function confirmAndSubmitOrder() {
     if (submitDisabled.value) return
     isSubmitting.value = true
+    // Snapshot prior SL/TP state BEFORE the SDK call so "prior" reflects what
+    // the user was about to change. Reading it afterward would see the new
+    // values once positions re-poll.
+    const priorPosition = activePosition.value
+    const hadPriorStopLoss = !!priorPosition?.stopLossTriggerPrice
+    const hadPriorTakeProfit = !!priorPosition?.takeProfitTriggerPrice
+    const willSetStopLoss = stopLossPrice.value !== null
+    const willSetTakeProfit = takeProfitPrice.value !== null
+    // Direction describes the POSITION side (LONG/SHORT), not the order side —
+    // "LONG 0.5 PERPS: …" matches the position, including when placing a
+    // reduce-only counter-order to modify an existing long.
+    const positionDirection =
+      priorPosition?.direction ??
+      (orderSide.value === 'buy' ? 'long' : 'short')
+    const slTpBase = displaySymbol.value
+    const slTpQuote = fullMarketName.value.includes('-')
+      ? (fullMarketName.value.split('-')[1] ?? '')
+      : ''
+    const slTpNetQuantity = priorPosition?.netQuantity ?? orderSize.value
     try {
       const orderParams: Record<string, unknown> = {
         market: fullMarketName.value,
@@ -670,28 +691,70 @@ export function usePerpsTradeForm() {
           orderParams.price = limitPrice.value
         }
       }
-      if (takeProfitPrice.value !== null) {
+      if (willSetTakeProfit) {
         orderParams.takeProfit = {
-          triggerPrice: takeProfitPrice.value.toFixed(2),
+          triggerPrice: (takeProfitPrice.value as number).toFixed(2),
         }
       }
-      if (stopLossPrice.value !== null) {
+      if (willSetStopLoss) {
         orderParams.stopLoss = {
-          triggerPrice: stopLossPrice.value.toFixed(2),
+          triggerPrice: (stopLossPrice.value as number).toFixed(2),
         }
       }
       await perpsClient.createOrder(orderParams as any)
+      // Fire SL/TP toasts only after the SDK call succeeded.
+      if (willSetStopLoss && stopLossPrice.value !== null) {
+        const args = {
+          direction: positionDirection,
+          netQuantity: slTpNetQuantity,
+          base: slTpBase,
+          quote: slTpQuote,
+          triggerPrice: (stopLossPrice.value as number).toFixed(2),
+        }
+        if (hadPriorStopLoss) perpsToasts.toastStopLossModified(args)
+        else perpsToasts.toastStopLossAdded(args)
+      }
+      if (willSetTakeProfit && takeProfitPrice.value !== null) {
+        const args = {
+          direction: positionDirection,
+          netQuantity: slTpNetQuantity,
+          base: slTpBase,
+          quote: slTpQuote,
+          triggerPrice: (takeProfitPrice.value as number).toFixed(2),
+        }
+        if (hadPriorTakeProfit) perpsToasts.toastTakeProfitModified(args)
+        else perpsToasts.toastTakeProfitAdded(args)
+      }
       showConfirmModal.value = false
       inputAmount.value = ''
       sliderValue.value = 0
       triggerRefresh()
     } catch (error: any) {
+      // If SL/TP were part of the request and the API rejected them as
+      // invalid, surface dedicated Invalid toasts. These branches are
+      // mutually exclusive with the success toasts above (which only run
+      // after createOrder resolves).
+      const msg = (error?.message || error?.toString() || '').toLowerCase()
+      const isInvalid = msg.includes('invalid')
+      if (isInvalid && willSetStopLoss) {
+        perpsToasts.toastStopLossInvalid()
+      }
+      if (isInvalid && willSetTakeProfit) {
+        perpsToasts.toastTakeProfitInvalid()
+      }
       orderError.value =
         error?.message || error?.toString() || 'Order failed. Please try again.'
     } finally {
       isSubmitting.value = false
     }
   }
+
+  // NOTE(perps-toasts): Dedicated remove-stop-loss / remove-take-profit flows
+  // are not yet wired in this composable. The SDK client today exposes
+  // createOrder / cancelOrder / setLeverage only — SL/TP are created inline
+  // via createOrder. When a remove-SL/TP endpoint is added, wire
+  // toastStopLossRemoved / toastTakeProfitRemoved / toastFailedToRemoveSlTp
+  // into those paths.
 
   // ── Lifecycle & watchers ───────────────────────────────────
   onMounted(() => {


### PR DESCRIPTION
## Summary

- Watches `PerpsBalance.underLiquidation` in `usePerpsAuth` and fires `toastLiquidationInitiated` exactly once on each `false → true` transition.
- Uses `{ immediate: false }` so a reload while already under liquidation does not re-fire the toast.
- Stacked on #5410 (→ #5409 → `feat/v7-o-perps`). Retarget when ancestors merge.

## Test plan

- [x] Unit suite green; lint + type-check clean
- [ ] Manual QA (reviewer to confirm if sandbox supports forcing `underLiquidation=true`): toast fires once on entry, not on repeated polls, not on reload with already-true state

Plan: `docs/plans/2026-04-22-perps-toasts.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added toast notifications for stop‑loss / take‑profit lifecycle (created, modified, invalid).
  * Added toast when a perps account enters liquidation (only when status changes to liquidating).

* **Bug Fixes**
  * Show a failure toast if cancelling a perps order fails.

* **Documentation**
  * Added changelog entries describing the new perps toast behaviours.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->