### PR TITLE
feat: perps stop loss & take profit toasts

### DIFF
--- a/changelog/feat-perps-toasts-sltp.md
+++ b/changelog/feat-perps-toasts-sltp.md
@@ -1,0 +1,1 @@
+feat: toast notifications for perps stop loss and take profit lifecycle

--- a/src/modules/perps/components/PerpsPositionsTable.vue
+++ b/src/modules/perps/components/PerpsPositionsTable.vue
@@ -728,6 +728,7 @@ import {
   usePerpsFills,
   usePerpsDepositsWithdrawals,
 } from '../composables/usePerpsHistory'
+import { usePerpsToasts } from '../composables/usePerpsToasts'
 import {
   formatUsd,
   formatPrice,
@@ -861,6 +862,7 @@ const {
 } = usePerpsDepositsWithdrawals()
 
 const cancellingOrderId = ref<string | null>(null)
+const perpsToasts = usePerpsToasts()
 
 async function cancelOrder(orderId: string) {
   cancellingOrderId.value = orderId
@@ -870,6 +872,7 @@ async function cancelOrder(orderId: string) {
     await refetchOrders()
   } catch (e) {
     console.error('Failed to cancel order:', e)
+    perpsToasts.toastFailedToRemoveOrder()
   } finally {
     cancellingOrderId.value = null
   }

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -18,6 +18,13 @@ interface OrderSideButton {
   value: OrderSide
 }
 
+// Matches SDK error messages that specifically flag SL/TP as invalid, so
+// generic "invalid signature" / "invalid nonce" errors don't mislabel as
+// SL/TP validation failures. Revisit if/when the SDK exposes a structured
+// error code.
+const SL_TP_INVALID_PATTERN = /invalid\s+(stop[\s-]?loss|take[\s-]?profit|trigger)/i
+const TRIGGER_PRICE_DECIMALS = 2
+
 export function usePerpsTradeForm() {
   const walletMenuStore = useWalletMenuStore()
   const router = useRouter()
@@ -663,8 +670,10 @@ export function usePerpsTradeForm() {
     const priorPosition = activePosition.value
     const hadPriorStopLoss = !!priorPosition?.stopLossTriggerPrice
     const hadPriorTakeProfit = !!priorPosition?.takeProfitTriggerPrice
-    const willSetStopLoss = stopLossPrice.value !== null
-    const willSetTakeProfit = takeProfitPrice.value !== null
+    // Capture numeric SL/TP values once up front: used for the API payload,
+    // the formatted toast price, and as the null-guard for both branches.
+    const slPrice = stopLossPrice.value
+    const tpPrice = takeProfitPrice.value
     // Direction describes the POSITION side (LONG/SHORT), not the order side —
     // "LONG 0.5 PERPS: …" matches the position, including when placing a
     // reduce-only counter-order to modify an existing long.
@@ -676,6 +685,13 @@ export function usePerpsTradeForm() {
       ? (fullMarketName.value.split('-')[1] ?? '')
       : ''
     const slTpNetQuantity = priorPosition?.netQuantity ?? orderSize.value
+    const buildSlTpArgs = (triggerPrice: number) => ({
+      direction: positionDirection,
+      netQuantity: slTpNetQuantity,
+      base: slTpBase,
+      quote: slTpQuote,
+      triggerPrice: triggerPrice.toFixed(TRIGGER_PRICE_DECIMALS),
+    })
     try {
       const orderParams: Record<string, unknown> = {
         market: fullMarketName.value,
@@ -691,37 +707,25 @@ export function usePerpsTradeForm() {
           orderParams.price = limitPrice.value
         }
       }
-      if (willSetTakeProfit) {
+      if (tpPrice !== null) {
         orderParams.takeProfit = {
-          triggerPrice: (takeProfitPrice.value as number).toFixed(2),
+          triggerPrice: tpPrice.toFixed(TRIGGER_PRICE_DECIMALS),
         }
       }
-      if (willSetStopLoss) {
+      if (slPrice !== null) {
         orderParams.stopLoss = {
-          triggerPrice: (stopLossPrice.value as number).toFixed(2),
+          triggerPrice: slPrice.toFixed(TRIGGER_PRICE_DECIMALS),
         }
       }
       await perpsClient.createOrder(orderParams as any)
       // Fire SL/TP toasts only after the SDK call succeeded.
-      if (willSetStopLoss && stopLossPrice.value !== null) {
-        const args = {
-          direction: positionDirection,
-          netQuantity: slTpNetQuantity,
-          base: slTpBase,
-          quote: slTpQuote,
-          triggerPrice: (stopLossPrice.value as number).toFixed(2),
-        }
+      if (slPrice !== null) {
+        const args = buildSlTpArgs(slPrice)
         if (hadPriorStopLoss) perpsToasts.toastStopLossModified(args)
         else perpsToasts.toastStopLossAdded(args)
       }
-      if (willSetTakeProfit && takeProfitPrice.value !== null) {
-        const args = {
-          direction: positionDirection,
-          netQuantity: slTpNetQuantity,
-          base: slTpBase,
-          quote: slTpQuote,
-          triggerPrice: (takeProfitPrice.value as number).toFixed(2),
-        }
+      if (tpPrice !== null) {
+        const args = buildSlTpArgs(tpPrice)
         if (hadPriorTakeProfit) perpsToasts.toastTakeProfitModified(args)
         else perpsToasts.toastTakeProfitAdded(args)
       }
@@ -733,13 +737,15 @@ export function usePerpsTradeForm() {
       // If SL/TP were part of the request and the API rejected them as
       // invalid, surface dedicated Invalid toasts. These branches are
       // mutually exclusive with the success toasts above (which only run
-      // after createOrder resolves).
-      const msg = (error?.message || error?.toString() || '').toLowerCase()
-      const isInvalid = msg.includes('invalid')
-      if (isInvalid && willSetStopLoss) {
+      // after createOrder resolves). The regex targets SL/TP-scoped messages
+      // so generic "invalid signature" / "invalid nonce" errors don't
+      // mislabel as SL/TP validation failures.
+      const msg = error?.message || error?.toString() || ''
+      const isSlTpInvalid = SL_TP_INVALID_PATTERN.test(msg)
+      if (isSlTpInvalid && slPrice !== null) {
         perpsToasts.toastStopLossInvalid()
       }
-      if (isInvalid && willSetTakeProfit) {
+      if (isSlTpInvalid && tpPrice !== null) {
         perpsToasts.toastTakeProfitInvalid()
       }
       orderError.value =

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -7,6 +7,7 @@ import { usePerpsAuth, usePerpsBalance } from './usePerpsAuth'
 import { usePerpsMarkets, usePerpsContracts } from './usePerpsMarkets'
 import { usePerpsPositions } from './usePerpsPositions'
 import { usePerpsMarkPrices } from './usePerpsMarkPrices'
+import { usePerpsToasts } from './usePerpsToasts'
 import { formatUsd } from '../utils/formatters'
 import { getCategory, midPrice } from '../utils/market'
 
@@ -26,6 +27,7 @@ export function usePerpsTradeForm() {
   const { contracts } = usePerpsContracts()
   const { positions, closePosition } = usePerpsPositions()
   const { markPriceData } = usePerpsMarkPrices()
+  const perpsToasts = usePerpsToasts()
 
   // ── State ──────────────────────────────────────────────────
 
@@ -655,6 +657,25 @@ export function usePerpsTradeForm() {
   async function confirmAndSubmitOrder() {
     if (submitDisabled.value) return
     isSubmitting.value = true
+    // Snapshot prior SL/TP state BEFORE the SDK call so "prior" reflects what
+    // the user was about to change. Reading it afterward would see the new
+    // values once positions re-poll.
+    const priorPosition = activePosition.value
+    const hadPriorStopLoss = !!priorPosition?.stopLossTriggerPrice
+    const hadPriorTakeProfit = !!priorPosition?.takeProfitTriggerPrice
+    const willSetStopLoss = stopLossPrice.value !== null
+    const willSetTakeProfit = takeProfitPrice.value !== null
+    // Direction describes the POSITION side (LONG/SHORT), not the order side —
+    // "LONG 0.5 PERPS: …" matches the position, including when placing a
+    // reduce-only counter-order to modify an existing long.
+    const positionDirection =
+      priorPosition?.direction ??
+      (orderSide.value === 'buy' ? 'long' : 'short')
+    const slTpBase = displaySymbol.value
+    const slTpQuote = fullMarketName.value.includes('-')
+      ? (fullMarketName.value.split('-')[1] ?? '')
+      : ''
+    const slTpNetQuantity = priorPosition?.netQuantity ?? orderSize.value
     try {
       const orderParams: Record<string, unknown> = {
         market: fullMarketName.value,
@@ -670,28 +691,70 @@ export function usePerpsTradeForm() {
           orderParams.price = limitPrice.value
         }
       }
-      if (takeProfitPrice.value !== null) {
+      if (willSetTakeProfit) {
         orderParams.takeProfit = {
-          triggerPrice: takeProfitPrice.value.toFixed(2),
+          triggerPrice: (takeProfitPrice.value as number).toFixed(2),
         }
       }
-      if (stopLossPrice.value !== null) {
+      if (willSetStopLoss) {
         orderParams.stopLoss = {
-          triggerPrice: stopLossPrice.value.toFixed(2),
+          triggerPrice: (stopLossPrice.value as number).toFixed(2),
         }
       }
       await perpsClient.createOrder(orderParams as any)
+      // Fire SL/TP toasts only after the SDK call succeeded.
+      if (willSetStopLoss && stopLossPrice.value !== null) {
+        const args = {
+          direction: positionDirection,
+          netQuantity: slTpNetQuantity,
+          base: slTpBase,
+          quote: slTpQuote,
+          triggerPrice: (stopLossPrice.value as number).toFixed(2),
+        }
+        if (hadPriorStopLoss) perpsToasts.toastStopLossModified(args)
+        else perpsToasts.toastStopLossAdded(args)
+      }
+      if (willSetTakeProfit && takeProfitPrice.value !== null) {
+        const args = {
+          direction: positionDirection,
+          netQuantity: slTpNetQuantity,
+          base: slTpBase,
+          quote: slTpQuote,
+          triggerPrice: (takeProfitPrice.value as number).toFixed(2),
+        }
+        if (hadPriorTakeProfit) perpsToasts.toastTakeProfitModified(args)
+        else perpsToasts.toastTakeProfitAdded(args)
+      }
       showConfirmModal.value = false
       inputAmount.value = ''
       sliderValue.value = 0
       triggerRefresh()
     } catch (error: any) {
+      // If SL/TP were part of the request and the API rejected them as
+      // invalid, surface dedicated Invalid toasts. These branches are
+      // mutually exclusive with the success toasts above (which only run
+      // after createOrder resolves).
+      const msg = (error?.message || error?.toString() || '').toLowerCase()
+      const isInvalid = msg.includes('invalid')
+      if (isInvalid && willSetStopLoss) {
+        perpsToasts.toastStopLossInvalid()
+      }
+      if (isInvalid && willSetTakeProfit) {
+        perpsToasts.toastTakeProfitInvalid()
+      }
       orderError.value =
         error?.message || error?.toString() || 'Order failed. Please try again.'
     } finally {
       isSubmitting.value = false
     }
   }
+
+  // NOTE(perps-toasts): Dedicated remove-stop-loss / remove-take-profit flows
+  // are not yet wired in this composable. The SDK client today exposes
+  // createOrder / cancelOrder / setLeverage only — SL/TP are created inline
+  // via createOrder. When a remove-SL/TP endpoint is added, wire
+  // toastStopLossRemoved / toastTakeProfitRemoved / toastFailedToRemoveSlTp
+  // into those paths.
 
   // ── Lifecycle & watchers ───────────────────────────────────
   onMounted(() => {


### PR DESCRIPTION
## Summary

- Wires the 10 SL/TP helpers from #5409 into `usePerpsTradeForm` for add / modify success and invalid-input errors. SL/TP are sent inline with `createOrder()` in this codebase, so the add-vs-modify decision is made by snapshotting `activePosition.stopLossTriggerPrice` / `takeProfitTriggerPrice` BEFORE the SDK call.
- Wires `toastFailedToRemoveOrder` into the generic order-cancel catch in `PerpsPositionsTable.vue` (replaces silent `console.error`).
- `toastStopLossRemoved` / `toastTakeProfitRemoved` / `toastFailedToRemoveSlTp` are intentionally not wired: the SDK client today has no dedicated remove-SL/TP endpoint (only `createOrder` / `cancelOrder` / `setLeverage`). A note in `usePerpsTradeForm.ts` marks where to wire them when that endpoint lands.
- Stacked on #5411. Retarget as ancestors merge.

## Test plan

- [x] Unit tests green; lint + type-check clean
- [ ] Manual QA: set SL on an open position; modify it; submit invalid SL; same for TP; force a cancel-order failure (SDK 500) to see `toastFailedToRemoveOrder`

Plan: `docs/plans/2026-04-22-perps-toasts.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toast notifications for stop-loss and take-profit additions and modifications, including contextual details (direction, quantities, trigger price)
  * Dedicated toast feedback when stop-loss or take-profit inputs are invalid

* **Bug Fixes**
  * Improved error toast when order cancellation fails
<!-- end of auto-generated comment: release notes by coderabbit.ai -->