### PR TITLE
MEW-1654: Clarify deposit address refresh button with tooltip

### DIFF
--- a/src/modules/perps/components/PerpsDepositDialog.vue
+++ b/src/modules/perps/components/PerpsDepositDialog.vue
@@ -216,13 +216,15 @@
             </p>
             <app-btn-copy :copy-value="depositAddress || ''" />
             <!-- Refresh -->
-            <app-btn-icon
-              label="refresh"
-              :disabled="loading"
-              @click="fetchDepositAddress"
-            >
-              <arrow-path-icon class="w-[18px] h-[18px]" />
-            </app-btn-icon>
+            <app-tooltip text="Refresh deposit address" position="top-left">
+              <app-btn-icon
+                label="Refresh deposit address"
+                :disabled="loading"
+                @click="fetchDepositAddress"
+              >
+                <arrow-path-icon class="w-[18px] h-[18px]" />
+              </app-btn-icon>
+            </app-tooltip>
           </div>
         </template>
       </div>
@@ -242,6 +244,7 @@ import AppBaseButton from '@/components/AppBaseButton.vue'
 import AppBtnCopy from '@/components/AppBtnCopy.vue'
 import AppBtnIcon from '@/components/AppBtnIcon.vue'
 import AppDialog from '@/components/AppDialog.vue'
+import AppTooltip from '@/components/AppTooltip.vue'
 import AppTokenLogo from '@/components/AppTokenLogo.vue'
 import AppEnterAmount from '@/components/AppEnterAmount.vue'
 import AppBlockie from '@/components/AppBlockie.vue'


### PR DESCRIPTION
## What changed
On the Perps deposit dialog (Ethereum address step), the small refresh icon next to the deposit address looked like a generic decorative button. It was unclear what it did, so users could miss it or be unsure whether clicking it was safe.

This PR adds a tooltip that appears on hover so the action is explicit:

> "Refresh deposit address"

## Why
Per QA ticket MEW-1654, the refresh button needs visible feedback so users understand the action before clicking. The button already performed a real action (re-fetching the deposit address from the API) — only the labelling was missing.

## How to test
1. Connect your wallet and open the Perps module
2. Click **Deposit**, then **Continue** to advance to the Ethereum deposit-address screen
3. Hover the circular refresh icon next to the address — the tooltip "Refresh deposit address" appears
4. Click it — the address re-fetches (button is disabled while loading)

## Notes
- Wraps the existing `AppBtnIcon` in `AppTooltip` (`top-left` position, matching the surrounding controls)
- Also adds an explicit `aria-label` for screen readers
- No behaviour change to the underlying refresh action

Jira: [MEW-1654](https://myetherwallet.atlassian.net/browse/MEW-1654)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tooltip support to the refresh button in the deposit address UI for improved clarity. The button label has been updated to better describe its functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->