### PR TITLE
MEW-1623: Refresh Perps balance every 1s instead of 5s

### DIFF
--- a/src/modules/perps/composables/usePerpsAuth.ts
+++ b/src/modules/perps/composables/usePerpsAuth.ts
@@ -135,7 +135,7 @@ export function usePerpsBalance() {
     }
 
     poll()
-    setInterval(poll, 5_000)
+    setInterval(poll, 1_000)
 
     let lastRefreshKey = refreshKey.value
     setInterval(() => {


### PR DESCRIPTION
## What changed
The Perps balance now updates **once per second** instead of every five seconds. Users selecting a token or watching their balance after a fill will see the new value much sooner — closer to Ondo's broker-style "live" feel.

## Why
Per QA ticket MEW-1623, our balance refresh felt slow next to Ondo (which updates roughly twice a second). Switching to a true streaming connection is the long-term goal but it's a larger lift; this PR is the agreed quick fix to close most of the perceived gap with a one-line change.

## How to test
1. Connect your wallet and open Perps
2. Open the **Trading Account** balance widget (or any view that shows the balance)
3. Place / close a position, or simply observe — balance should now refresh roughly once per second instead of every five seconds

## Notes
- Single-line change in `usePerpsAuth.ts` — bumps the balance polling interval from `5_000` ms to `1_000` ms
- Endpoint hit: `GET /v1/perps/balance` (authenticated; goes through the Perps SDK `getPerpsBalance()` method)
- Other polls left as-is for this ticket: positions (5s), mark prices (5s), open orders / fills (10s), portfolio summary (5min). The team can decide if those should follow in a separate ticket
- Vitest: 8/8 passing. ESLint: clean

## Trade-offs (already discussed on the ticket)
- Roughly 5× more requests per user against `/v1/perps/balance`. Each request is small and authenticated — should be well within normal rate limits, but worth keeping an eye on once it's deployed
- This does not match Ondo's true streaming behaviour; ticket comments outline the SSE/streaming option for a follow-up

Jira: [MEW-1623](https://myetherwallet.atlassian.net/browse/MEW-1623)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Balance information now refreshes more frequently, ensuring users see updated balance data in near real-time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->