### PR TITLE
feat: paginate perps Markets, Positions and Fills tables

### DIFF
--- a/src/modules/perps/components/PerpsMarketList.vue
+++ b/src/modules/perps/components/PerpsMarketList.vue
@@ -73,7 +73,7 @@
 
       <!-- Markets table -->
       <div v-else>
-        <table class="w-full text-sm table-fixed">
+        <table ref="marketsTable" class="w-full text-sm table-fixed">
           <thead class="bg-white">
             <tr
               class="text-left text-s-11 uppercase text-info tracking-sp-06 font-bold"
@@ -456,6 +456,7 @@
           <perps-pagination
             :current-page="currentPage"
             :total-pages="totalPages"
+            :scroll-target="marketsTable"
             @prev="prevPage"
             @next="nextPage"
           />
@@ -523,6 +524,8 @@ import PerpsPagination from './PerpsPagination.vue'
 defineEmits<{
   openPosition: [market: string, side?: 'buy' | 'sell']
 }>()
+
+const marketsTable = ref<HTMLElement | null>(null)
 
 const { markets } = usePerpsMarkets()
 const {

--- a/src/modules/perps/components/PerpsMarketList.vue
+++ b/src/modules/perps/components/PerpsMarketList.vue
@@ -226,7 +226,7 @@
           </thead>
           <tbody>
             <tr
-              v-for="contract in filteredContracts"
+              v-for="contract in paginatedContracts"
               :key="contract.market"
               class="h-14 hoverBGWhite cursor-pointer"
               @click="$emit('openPosition', contract.market)"
@@ -450,6 +450,17 @@
           </tbody>
         </table>
         <div
+          v-if="filteredContracts.length > 0 && totalPages > 1"
+          class="flex justify-end mt-4 px-2"
+        >
+          <perps-pagination
+            :current-page="currentPage"
+            :total-pages="totalPages"
+            @prev="prevPage"
+            @next="nextPage"
+          />
+        </div>
+        <div
           v-if="filteredContracts.length === 0"
           class="w-full flex flex-col items-center justify-center mx-auto text-info py-10 text-s-14"
         >
@@ -505,6 +516,9 @@ import type { Contract, TradingPair } from '../sdk/types'
 import { formatPrice, formatPercent, formatVolume } from '../utils/formatters'
 import { getLogoUrl, midPrice, hasTag } from '../utils/market'
 import { usePerpsPositions } from '../composables/usePerpsPositions'
+import { usePaginate } from '@/composables/usePaginate'
+import { PERPS_PAGE_SIZE } from '../configs'
+import PerpsPagination from './PerpsPagination.vue'
 
 defineEmits<{
   openPosition: [market: string, side?: 'buy' | 'sell']
@@ -653,4 +667,12 @@ function formatChange(pct?: string): string {
   if (!pct) return '—'
   return formatPercent(parseFloat(pct))
 }
+
+const {
+  currentPage,
+  paginatedArray: paginatedContracts,
+  totalPages,
+  nextPage,
+  prevPage,
+} = usePaginate<EnrichedContract>(filteredContracts, PERPS_PAGE_SIZE)
 </script>

--- a/src/modules/perps/components/PerpsPagination.vue
+++ b/src/modules/perps/components/PerpsPagination.vue
@@ -1,0 +1,64 @@
+<template>
+  <div class="flex items-center justify-center gap-1">
+    <app-btn-icon
+      :disabled="disabled || !canPrev"
+      label="previous page"
+      height="h-8"
+      width="w-8"
+      @click="$emit('prev')"
+    >
+      <ChevronLeftIcon class="w-4 h-4" />
+    </app-btn-icon>
+    <span class="px-2 text-s-12 text-info font-medium">
+      <template v-if="totalPages !== undefined"
+        >{{ currentPage + 1 }} of {{ totalPages }}</template
+      >
+      <template v-else>Page {{ currentPage + 1 }}</template>
+    </span>
+    <app-btn-icon
+      :disabled="disabled || !canNext"
+      label="next page"
+      height="h-8"
+      width="w-8"
+      @click="$emit('next')"
+    >
+      <ChevronRightIcon class="w-4 h-4" />
+    </app-btn-icon>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import AppBtnIcon from '@/components/AppBtnIcon.vue'
+import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/vue/24/solid'
+
+const props = withDefaults(
+  defineProps<{
+    currentPage: number
+    totalPages?: number
+    disabled?: boolean
+    hasPrev?: boolean
+    hasNext?: boolean
+  }>(),
+  {
+    totalPages: undefined,
+    disabled: false,
+    hasPrev: undefined,
+    hasNext: undefined,
+  },
+)
+
+defineEmits<{
+  prev: []
+  next: []
+}>()
+
+const canPrev = computed(() =>
+  props.hasPrev !== undefined ? props.hasPrev : props.currentPage > 0,
+)
+const canNext = computed(() =>
+  props.hasNext !== undefined
+    ? props.hasNext
+    : props.totalPages !== undefined && props.currentPage + 1 < props.totalPages,
+)
+</script>

--- a/src/modules/perps/components/PerpsPagination.vue
+++ b/src/modules/perps/components/PerpsPagination.vue
@@ -5,7 +5,7 @@
       label="previous page"
       height="h-8"
       width="w-8"
-      @click="$emit('prev')"
+      @click="onPrev"
     >
       <ChevronLeftIcon class="w-4 h-4" />
     </app-btn-icon>
@@ -20,7 +20,7 @@
       label="next page"
       height="h-8"
       width="w-8"
-      @click="$emit('next')"
+      @click="onNext"
     >
       <ChevronRightIcon class="w-4 h-4" />
     </app-btn-icon>
@@ -39,16 +39,18 @@ const props = withDefaults(
     disabled?: boolean
     hasPrev?: boolean
     hasNext?: boolean
+    scrollTarget?: HTMLElement | null
   }>(),
   {
     totalPages: undefined,
     disabled: false,
     hasPrev: undefined,
     hasNext: undefined,
+    scrollTarget: null,
   },
 )
 
-defineEmits<{
+const emit = defineEmits<{
   prev: []
   next: []
 }>()
@@ -61,4 +63,26 @@ const canNext = computed(() =>
     ? props.hasNext
     : props.totalPages !== undefined && props.currentPage + 1 < props.totalPages,
 )
+
+function scrollToTarget() {
+  const target = props.scrollTarget
+  if (!target) return
+  // Offset for the fixed app header (TheHeader.vue: h-[68px] sm:h-[76px]).
+  // Setting scroll-margin-top lets scrollIntoView honor the offset inside
+  // whichever ancestor is the actual scroll container (the app layout uses
+  // an inner overflow-y-auto wrapper, not the window).
+  const headerHeight = window.innerWidth >= 640 ? 76 : 68
+  target.style.scrollMarginTop = `${headerHeight + 12}px`
+  target.scrollIntoView({ behavior: 'smooth', block: 'start' })
+}
+
+function onPrev() {
+  emit('prev')
+  scrollToTarget()
+}
+
+function onNext() {
+  emit('next')
+  scrollToTarget()
+}
 </script>

--- a/src/modules/perps/components/PerpsPositionsTable.vue
+++ b/src/modules/perps/components/PerpsPositionsTable.vue
@@ -67,7 +67,11 @@
         >
           No open positions
         </div>
-        <table v-else class="w-full text-s-14 table-fixed">
+        <table
+          v-else
+          ref="positionsTable"
+          class="w-full text-s-14 table-fixed"
+        >
           <thead>
             <tr
               class="text-left text-s-11 uppercase text-info tracking-sp-06 font-bold"
@@ -243,6 +247,7 @@
           <perps-pagination
             :current-page="positionsCurrentPage"
             :total-pages="positionsTotalPages"
+            :scroll-target="positionsTable"
             @prev="positionsPrevPage"
             @next="positionsNextPage"
           />
@@ -465,7 +470,7 @@
           No fills
         </div>
         <div v-else class="overflow-x-auto">
-          <table class="w-full text-s-14 table-fixed">
+          <table ref="fillsTable" class="w-full text-s-14 table-fixed">
             <thead>
               <tr
                 class="text-left text-s-11 uppercase text-info tracking-sp-06 font-bold"
@@ -583,6 +588,7 @@
               :has-prev="fillsHasPrev"
               :has-next="fillsHasNext"
               :disabled="fillsLoading"
+              :scroll-target="fillsTable"
               @prev="fillsPrevPage"
               @next="fillsNextPage"
             />
@@ -772,6 +778,9 @@ const USDC_LOGO =
 defineEmits<{
   openPosition: [market: string]
 }>()
+
+const positionsTable = ref<HTMLElement | null>(null)
+const fillsTable = ref<HTMLElement | null>(null)
 
 const positionsSkeletonColumns: SkeletonColumn[] = [
   { header: 'Market' },

--- a/src/modules/perps/components/PerpsPositionsTable.vue
+++ b/src/modules/perps/components/PerpsPositionsTable.vue
@@ -103,7 +103,7 @@
           </thead>
           <tbody>
             <tr
-              v-for="pos in positions"
+              v-for="pos in paginatedPositions"
               :key="pos.market"
               class="cursor-pointer hoverBGWhite"
               @click="openPositionDialog(pos)"
@@ -236,6 +236,17 @@
             </tr>
           </tbody>
         </table>
+        <div
+          v-if="positions.length > 0 && positionsTotalPages > 1"
+          class="flex justify-end mt-4 px-2"
+        >
+          <perps-pagination
+            :current-page="positionsCurrentPage"
+            :total-pages="positionsTotalPages"
+            @prev="positionsPrevPage"
+            @next="positionsNextPage"
+          />
+        </div>
       </template>
 
       <!-- Orders tab -->
@@ -448,7 +459,7 @@
           :columns="fillsSkeletonColumns"
         />
         <div
-          v-else-if="fills.length === 0"
+          v-else-if="fills.length === 0 && fillsCurrentPage === 0"
           class="text-center py-8 text-info text-s-14"
         >
           No fills
@@ -563,6 +574,19 @@
               </tr>
             </tbody>
           </table>
+          <div
+            v-if="fillsHasPrev || fillsHasNext"
+            class="flex justify-end mt-4 px-2"
+          >
+            <perps-pagination
+              :current-page="fillsCurrentPage"
+              :has-prev="fillsHasPrev"
+              :has-next="fillsHasNext"
+              :disabled="fillsLoading"
+              @prev="fillsPrevPage"
+              @next="fillsNextPage"
+            />
+          </div>
         </div>
       </template>
 
@@ -722,6 +746,7 @@ import AppTableSkeleton, {
 import PerpsPositionDialog from './PerpsPositionDialog.vue'
 import PerpsFillDetailsDialog from './PerpsFillDetailsDialog.vue'
 import PerpsOrderDialog from './PerpsOrderDialog.vue'
+import PerpsPagination from './PerpsPagination.vue'
 import { usePerpsPositions } from '../composables/usePerpsPositions'
 import {
   usePerpsOrders,
@@ -738,7 +763,8 @@ import {
   formatDate,
 } from '../utils/formatters'
 import { getBase, getLogoUrl } from '../utils/market'
-import { perpsClient } from '../configs'
+import { perpsClient, PERPS_PAGE_SIZE } from '../configs'
+import { usePaginate } from '@/composables/usePaginate'
 import type { Position, ApiOrder, ApiFill } from '../sdk/types'
 
 const USDC_LOGO =
@@ -789,6 +815,14 @@ const dwSkeletonColumns: SkeletonColumn[] = [
 ]
 
 const { positions, loading } = usePerpsPositions()
+
+const {
+  currentPage: positionsCurrentPage,
+  paginatedArray: paginatedPositions,
+  totalPages: positionsTotalPages,
+  nextPage: positionsNextPage,
+  prevPage: positionsPrevPage,
+} = usePaginate<Position>(positions, PERPS_PAGE_SIZE)
 
 const showPositionDialog = ref(false)
 const selectedPosition = ref<Position | null>(null)
@@ -854,7 +888,15 @@ const showCancelButton = (order: ApiOrder) => {
   )
 }
 
-const { fills, loading: fillsLoading } = usePerpsFills()
+const {
+  fills,
+  loading: fillsLoading,
+  currentPage: fillsCurrentPage,
+  hasPrev: fillsHasPrev,
+  hasNext: fillsHasNext,
+  nextPage: fillsNextPage,
+  prevPage: fillsPrevPage,
+} = usePerpsFills()
 const {
   deposits,
   withdrawals,

--- a/src/modules/perps/composables/useCursorPaginate.ts
+++ b/src/modules/perps/composables/useCursorPaginate.ts
@@ -13,18 +13,23 @@ export function useCursorPaginate<T>(
   const currentPage = ref(0)
   const cursorStack = ref<(string | undefined)[]>([undefined])
   const nextCursor = ref<string | undefined>(undefined)
+  // Bumped on reset() so any in-flight request started under a previous
+  // auth/wallet context is dropped instead of overwriting the new state.
+  let requestEpoch = 0
 
   async function fetchPage(cursor: string | undefined): Promise<boolean> {
+    const epoch = requestEpoch
     loading.value = true
     try {
       const res = await fetcher({ limit: pageSize, cursor })
+      if (epoch !== requestEpoch) return false
       items.value = res.result ?? []
       nextCursor.value = res.pageInfo?.nextCursor
       return true
     } catch {
       return false
     } finally {
-      loading.value = false
+      if (epoch === requestEpoch) loading.value = false
     }
   }
 
@@ -58,10 +63,12 @@ export function useCursorPaginate<T>(
   }
 
   function reset() {
+    requestEpoch += 1
     items.value = []
     cursorStack.value = [undefined]
     currentPage.value = 0
     nextCursor.value = undefined
+    loading.value = false
   }
 
   const hasNext = computed(() => !!nextCursor.value)

--- a/src/modules/perps/composables/useCursorPaginate.ts
+++ b/src/modules/perps/composables/useCursorPaginate.ts
@@ -14,39 +14,47 @@ export function useCursorPaginate<T>(
   const cursorStack = ref<(string | undefined)[]>([undefined])
   const nextCursor = ref<string | undefined>(undefined)
 
-  async function fetchPage(cursor: string | undefined) {
+  async function fetchPage(cursor: string | undefined): Promise<boolean> {
     loading.value = true
     try {
       const res = await fetcher({ limit: pageSize, cursor })
       items.value = res.result ?? []
       nextCursor.value = res.pageInfo?.nextCursor
+      return true
     } catch {
-      items.value = []
-      nextCursor.value = undefined
+      return false
     } finally {
       loading.value = false
     }
   }
 
   async function refetch() {
-    cursorStack.value = [undefined]
-    currentPage.value = 0
-    await fetchPage(undefined)
+    const ok = await fetchPage(undefined)
+    if (ok) {
+      cursorStack.value = [undefined]
+      currentPage.value = 0
+    }
   }
 
   async function nextPage() {
     if (!nextCursor.value) return
-    cursorStack.value.push(nextCursor.value)
-    currentPage.value += 1
-    await fetchPage(nextCursor.value)
+    const targetCursor = nextCursor.value
+    const ok = await fetchPage(targetCursor)
+    if (ok) {
+      cursorStack.value.push(targetCursor)
+      currentPage.value += 1
+    }
   }
 
   async function prevPage() {
     if (currentPage.value === 0) return
-    cursorStack.value.pop()
-    currentPage.value -= 1
-    const cursor = cursorStack.value[cursorStack.value.length - 1]
-    await fetchPage(cursor)
+    const candidateStack = cursorStack.value.slice(0, -1)
+    const cursor = candidateStack[candidateStack.length - 1]
+    const ok = await fetchPage(cursor)
+    if (ok) {
+      cursorStack.value = candidateStack
+      currentPage.value -= 1
+    }
   }
 
   function reset() {

--- a/src/modules/perps/composables/useCursorPaginate.ts
+++ b/src/modules/perps/composables/useCursorPaginate.ts
@@ -1,0 +1,73 @@
+import { ref, computed, type Ref } from 'vue'
+import type { PaginatedResponse } from '../sdk/types'
+
+export function useCursorPaginate<T>(
+  fetcher: (opts: {
+    limit: number
+    cursor?: string
+  }) => Promise<PaginatedResponse<T>>,
+  pageSize: number,
+) {
+  const items = ref<T[]>([]) as Ref<T[]>
+  const loading = ref(false)
+  const currentPage = ref(0)
+  const cursorStack = ref<(string | undefined)[]>([undefined])
+  const nextCursor = ref<string | undefined>(undefined)
+
+  async function fetchPage(cursor: string | undefined) {
+    loading.value = true
+    try {
+      const res = await fetcher({ limit: pageSize, cursor })
+      items.value = res.result ?? []
+      nextCursor.value = res.pageInfo?.nextCursor
+    } catch {
+      items.value = []
+      nextCursor.value = undefined
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function refetch() {
+    cursorStack.value = [undefined]
+    currentPage.value = 0
+    await fetchPage(undefined)
+  }
+
+  async function nextPage() {
+    if (!nextCursor.value) return
+    cursorStack.value.push(nextCursor.value)
+    currentPage.value += 1
+    await fetchPage(nextCursor.value)
+  }
+
+  async function prevPage() {
+    if (currentPage.value === 0) return
+    cursorStack.value.pop()
+    currentPage.value -= 1
+    const cursor = cursorStack.value[cursorStack.value.length - 1]
+    await fetchPage(cursor)
+  }
+
+  function reset() {
+    items.value = []
+    cursorStack.value = [undefined]
+    currentPage.value = 0
+    nextCursor.value = undefined
+  }
+
+  const hasNext = computed(() => !!nextCursor.value)
+  const hasPrev = computed(() => currentPage.value > 0)
+
+  return {
+    items,
+    loading,
+    currentPage,
+    hasNext,
+    hasPrev,
+    nextPage,
+    prevPage,
+    refetch,
+    reset,
+  }
+}

--- a/src/modules/perps/composables/usePerpsHistory.ts
+++ b/src/modules/perps/composables/usePerpsHistory.ts
@@ -73,11 +73,14 @@ export function usePerpsFills() {
   watchEffect(() => {
     void refreshKey.value
     if (pollTimer) clearInterval(pollTimer)
+    // Reset before fetching so any in-flight request from the previous auth
+    // context is invalidated and prior fills don't briefly remain visible
+    // after a wallet switch / logout.
+    pagination.reset()
     if (token.value) {
       pagination.refetch()
       pollTimer = setInterval(refreshFirstPageIfActive, 10_000)
     } else {
-      pagination.reset()
       pollTimer = null
     }
   })

--- a/src/modules/perps/composables/usePerpsHistory.ts
+++ b/src/modules/perps/composables/usePerpsHistory.ts
@@ -1,6 +1,7 @@
 import { ref, watchEffect, onUnmounted } from 'vue'
-import { perpsClient } from '../configs'
+import { perpsClient, PERPS_PAGE_SIZE } from '../configs'
 import { usePerpsAuth } from './usePerpsAuth'
+import { useCursorPaginate } from './useCursorPaginate'
 import type {
   ApiOrder,
   ApiFill,
@@ -51,23 +52,15 @@ export function usePerpsOrders() {
 
 export function usePerpsFills() {
   const { token, refreshKey } = usePerpsAuth()
-  const fills = ref<ApiFill[]>([])
-  const loading = ref(false)
+  const pagination = useCursorPaginate<ApiFill>(
+    opts => perpsClient.getFills(opts),
+    PERPS_PAGE_SIZE,
+  )
   let pollTimer: ReturnType<typeof setInterval> | null = null
 
-  async function fetchFills() {
-    if (!token.value) {
-      fills.value = []
-      return
-    }
-    loading.value = true
-    try {
-      const res = await perpsClient.getFills({ limit: 100 })
-      fills.value = res.result ?? []
-    } catch {
-      fills.value = []
-    } finally {
-      loading.value = false
+  async function refreshFirstPageIfActive() {
+    if (pagination.currentPage.value === 0) {
+      await pagination.refetch()
     }
   }
 
@@ -75,10 +68,10 @@ export function usePerpsFills() {
     void refreshKey.value
     if (pollTimer) clearInterval(pollTimer)
     if (token.value) {
-      fetchFills()
-      pollTimer = setInterval(fetchFills, 10_000)
+      pagination.refetch()
+      pollTimer = setInterval(refreshFirstPageIfActive, 10_000)
     } else {
-      fills.value = []
+      pagination.reset()
       pollTimer = null
     }
   })
@@ -87,7 +80,16 @@ export function usePerpsFills() {
     if (pollTimer) clearInterval(pollTimer)
   })
 
-  return { fills, loading, refetch: fetchFills }
+  return {
+    fills: pagination.items,
+    loading: pagination.loading,
+    refetch: pagination.refetch,
+    currentPage: pagination.currentPage,
+    hasNext: pagination.hasNext,
+    hasPrev: pagination.hasPrev,
+    nextPage: pagination.nextPage,
+    prevPage: pagination.prevPage,
+  }
 }
 
 export function usePerpsDepositsWithdrawals() {

--- a/src/modules/perps/composables/usePerpsHistory.ts
+++ b/src/modules/perps/composables/usePerpsHistory.ts
@@ -57,10 +57,16 @@ export function usePerpsFills() {
     PERPS_PAGE_SIZE,
   )
   let pollTimer: ReturnType<typeof setInterval> | null = null
+  let isRefreshing = false
 
   async function refreshFirstPageIfActive() {
-    if (pagination.currentPage.value === 0) {
+    if (isRefreshing) return
+    if (pagination.currentPage.value !== 0) return
+    isRefreshing = true
+    try {
       await pagination.refetch()
+    } finally {
+      isRefreshing = false
     }
   }
 

--- a/src/modules/perps/composables/usePerpsHistory.ts
+++ b/src/modules/perps/composables/usePerpsHistory.ts
@@ -61,6 +61,7 @@ export function usePerpsFills() {
 
   async function refreshFirstPageIfActive() {
     if (isRefreshing) return
+    if (pagination.loading.value) return
     if (pagination.currentPage.value !== 0) return
     isRefreshing = true
     try {

--- a/src/modules/perps/configs.ts
+++ b/src/modules/perps/configs.ts
@@ -24,6 +24,8 @@ const USDC_DECIMALS = {
 const BUILDER_CODE = 'myetherwallet'
 const MAINNET_ENABLED = false
 
+const PERPS_PAGE_SIZE = 10
+
 export {
   IS_PERPS_LIVE,
   PERPS_BASE_URL,
@@ -33,4 +35,5 @@ export {
   USDC_DECIMALS,
   MAINNET_ENABLED,
   BUILDER_CODE,
+  PERPS_PAGE_SIZE,
 }


### PR DESCRIPTION
## What

Adds pagination to the long perps tables so users can browse them comfortably instead of scrolling through every row at once.

Tables included:
- **Markets** (Perpetuals Markets list)
- **Positions** tab (My Positions)
- **Fills** tab (My Fills)

Tables intentionally **left as-is** (out of scope for this ticket):
- Orders
- Deposits & Withdrawals

## How it looks

Each paginated table now shows a small footer at the bottom-right with chevron arrows and a page indicator (`1 of 5` for client-side, `Page 1` for the cursor-based Fills table). Page size is **10 rows per page**.

## Behavior notes

- Markets and Positions paginate locally over the already-loaded list, so navigating pages is instant. Filtering or searching resets to page 1 automatically when the new result set is shorter.
- Fills uses the API's cursor-based pagination so we only load 10 rows at a time. Auto-refresh still runs every 10 seconds, but only refreshes page 1 — if you've navigated to page 3, your view stays put.

## Scope

All new shared pieces (the pagination component and the cursor-pagination helper) live inside `src/modules/perps/`. We did **not** touch the existing pagination in non-perps tables (e.g. Portfolio Gains/Losses) — that migration is a follow-up.

## Ticket

[MEW-1615](https://myetherwallet.atlassian.net/browse/MEW-1615)

## Test checklist

- [ ] Markets table: navigate pages, change filter (All / Stocks / Watchlist / etc.), verify page resets correctly
- [ ] Markets table: search for a token; pagination updates to match results
- [ ] Positions tab: open ≥11 positions in sandbox, verify pagination appears and works
- [ ] Fills tab: navigate forward/back through pages; verify auto-refresh doesn't yank you off page 2+
- [ ] Orders and Deposits & Withdrawals tabs: verify they look unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pagination added to markets, positions, and fills lists with prev/next controls and page status; defaults to 10 items per page.
  * New pagination control offers smooth scroll back to the table when changing pages.

* **Improvements**
  * Fills switched to cursor-based pagination; polling limited to the first page and refresh/reset behavior improved on auth changes. Navigation disables while loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->