### PR TITLE
fix: wrong wallet shown when connecting via extension

### DIFF
--- a/src/composables/useWalletList.ts
+++ b/src/composables/useWalletList.ts
@@ -43,6 +43,13 @@ export const useWalletList = () => {
     if (wallet.rkDetails && wallet.rkDetails.name) return wallet.rkDetails.name
     return wallet.name
   }
+
+  const normalizeRdns = (
+    rdns?: string | readonly string[],
+  ): string | undefined => {
+    if (!rdns) return undefined
+    return Array.isArray(rdns) ? rdns[0] : (rdns as string)
+  }
   /** -------------------
    * Wallets
    * -------------------*/
@@ -77,6 +84,7 @@ export const useWalletList = () => {
           name: walletGetName(wallet),
           icon: walletGetIcon(wallet),
           type: _types,
+          rdns: normalizeRdns(wallet.rkDetails.rdns),
         })
       }
       // Ledger Mobile
@@ -87,6 +95,7 @@ export const useWalletList = () => {
           name: 'Ledger Mobile',
           icon: walletGetIcon(wallet),
           type: [WalletConfigType.MOBILE],
+          rdns: normalizeRdns(wallet.rkDetails.rdns),
         })
       }
       //Mock Wallet for testing
@@ -96,6 +105,7 @@ export const useWalletList = () => {
           id: wallet.id,
           icon: walletGetIcon(wallet),
           type: [WalletConfigType.MOCK],
+          rdns: normalizeRdns(wallet.rdns),
         })
       }
       //Injected Wallets
@@ -105,6 +115,7 @@ export const useWalletList = () => {
           id: wallet.id,
           name: walletGetName(wallet),
           icon: walletGetIcon(wallet),
+          rdns: normalizeRdns(wallet.rdns),
           type: [WalletConfigType.EXTENSION],
         })
       }

--- a/src/composables/useWalletList.ts
+++ b/src/composables/useWalletList.ts
@@ -44,12 +44,6 @@ export const useWalletList = () => {
     return wallet.name
   }
 
-  const normalizeRdns = (
-    rdns?: string | readonly string[],
-  ): string | undefined => {
-    if (!rdns) return undefined
-    return Array.isArray(rdns) ? rdns[0] : (rdns as string)
-  }
   /** -------------------
    * Wallets
    * -------------------*/
@@ -84,7 +78,6 @@ export const useWalletList = () => {
           name: walletGetName(wallet),
           icon: walletGetIcon(wallet),
           type: _types,
-          rdns: normalizeRdns(wallet.rkDetails.rdns),
         })
       }
       // Ledger Mobile
@@ -95,7 +88,6 @@ export const useWalletList = () => {
           name: 'Ledger Mobile',
           icon: walletGetIcon(wallet),
           type: [WalletConfigType.MOBILE],
-          rdns: normalizeRdns(wallet.rkDetails.rdns),
         })
       }
       //Mock Wallet for testing
@@ -105,7 +97,6 @@ export const useWalletList = () => {
           id: wallet.id,
           icon: walletGetIcon(wallet),
           type: [WalletConfigType.MOCK],
-          rdns: normalizeRdns(wallet.rdns),
         })
       }
       //Injected Wallets
@@ -115,7 +106,6 @@ export const useWalletList = () => {
           id: wallet.id,
           name: walletGetName(wallet),
           icon: walletGetIcon(wallet),
-          rdns: normalizeRdns(wallet.rdns),
           type: [WalletConfigType.EXTENSION],
         })
       }
@@ -131,7 +121,8 @@ export const useWalletList = () => {
         )
         if (
           existingWalletIndex < 0 &&
-          !DEFAULT_IDS.includes(injectedWallet.name.toLowerCase())
+          !DEFAULT_IDS.includes(injectedWallet.id) &&
+          !DEFAULT_IDS.includes(injectedWallet.name)
         ) {
           // If no wallet with same name, add injected wallet to array
           newConArr.push(injectedWallet)

--- a/src/modules/access/common/walletConfigs.ts
+++ b/src/modules/access/common/walletConfigs.ts
@@ -77,7 +77,6 @@ export type WalletConfig = {
   name: string
   icon: string | (() => Promise<string>)
   type: WalletConfigType[]
-  rdns?: string
   isDefault?: boolean
   isWC?: boolean
   isOfficial?: boolean
@@ -169,7 +168,6 @@ export const walletConfigs: Record<defaultWalletId, WalletConfig> = {
     name: 'Enkrypt',
     icon: EnkryptLogo,
     type: [WalletConfigType.EXTENSION],
-    rdns: 'com.enkrypt',
     canSupport: enkryptSupportNetwork,
     isDefault: true,
     isOfficial: true,
@@ -183,7 +181,6 @@ export const walletConfigs: Record<defaultWalletId, WalletConfig> = {
     name: 'UniSat',
     icon: UnisatLogo,
     type: [WalletConfigType.EXTENSION],
-    rdns: 'io.unisat.wallet',
     canSupport: unisatSupportNetwork,
     isDefault: true,
     isOfficial: false,

--- a/src/modules/access/common/walletConfigs.ts
+++ b/src/modules/access/common/walletConfigs.ts
@@ -77,6 +77,7 @@ export type WalletConfig = {
   name: string
   icon: string | (() => Promise<string>)
   type: WalletConfigType[]
+  rdns?: string
   isDefault?: boolean
   isWC?: boolean
   isOfficial?: boolean
@@ -168,6 +169,7 @@ export const walletConfigs: Record<defaultWalletId, WalletConfig> = {
     name: 'Enkrypt',
     icon: EnkryptLogo,
     type: [WalletConfigType.EXTENSION],
+    rdns: 'com.enkrypt',
     canSupport: enkryptSupportNetwork,
     isDefault: true,
     isOfficial: true,
@@ -181,6 +183,7 @@ export const walletConfigs: Record<defaultWalletId, WalletConfig> = {
     name: 'UniSat',
     icon: UnisatLogo,
     type: [WalletConfigType.EXTENSION],
+    rdns: 'io.unisat.wallet',
     canSupport: unisatSupportNetwork,
     isDefault: true,
     isOfficial: false,

--- a/src/modules/access/composables/useConnectWallet.ts
+++ b/src/modules/access/composables/useConnectWallet.ts
@@ -128,15 +128,9 @@ export const useConnectWallet = () => {
         })
       return
     }
-    // Prefer EIP-6963 rdns (canonical, non-spoofable) over display name to avoid
-    // matching the wrong injected wallet when multiple extensions are installed.
-    const providerInjected = wallet.rdns
-      ? Eip6963Providers.value.find(p => p.info.rdns === wallet.rdns)
-      : Eip6963Providers.value.find(
-          p =>
-            p.info.name.toLowerCase() === wallet.name.toLowerCase() ||
-            p.info.name.toLowerCase() === wallet.id.toLowerCase(),
-        )
+    const providerInjected = Eip6963Providers.value.find(
+      p => p.info.name === wallet.name || p.info.name === wallet.id,
+    )
 
     if (!providerInjected) {
       if (wallet.type.includes(WalletConfigType.MOBILE)) {

--- a/src/modules/access/composables/useConnectWallet.ts
+++ b/src/modules/access/composables/useConnectWallet.ts
@@ -128,11 +128,15 @@ export const useConnectWallet = () => {
         })
       return
     }
-    const providerInjected = Eip6963Providers.value.find(
-      p =>
-        p.info.name.toLowerCase() === wallet.name.toLowerCase() ||
-        p.info.name.toLowerCase() === wallet.id.toLowerCase(),
-    )
+    // Prefer EIP-6963 rdns (canonical, non-spoofable) over display name to avoid
+    // matching the wrong injected wallet when multiple extensions are installed.
+    const providerInjected = wallet.rdns
+      ? Eip6963Providers.value.find(p => p.info.rdns === wallet.rdns)
+      : Eip6963Providers.value.find(
+          p =>
+            p.info.name.toLowerCase() === wallet.name.toLowerCase() ||
+            p.info.name.toLowerCase() === wallet.id.toLowerCase(),
+        )
 
     if (!providerInjected) {
       if (wallet.type.includes(WalletConfigType.MOBILE)) {


### PR DESCRIPTION
## What

Fixes a bug where, if a user has multiple wallet extensions installed (e.g. Enkrypt **and** another EIP-6963 wallet), clicking "Enkrypt" could end up connecting through the wrong extension.

## Why

When matching the wallet you click in the UI to the actual browser extension, we used to compare display names like "Enkrypt". Display names aren't unique or trustworthy — any extension can call itself anything. The EIP-6963 standard provides a stable, unique identifier called `rdns` (e.g. `com.enkrypt`) that browser extensions can't fake without the user noticing.

This PR switches the lookup to prefer `rdns` first and fall back to name matching only for wallets that don't ship one (Ledger, MEW Mobile, etc.).

## What the user will see

- With multiple EIP-6963 wallets installed, clicking "Enkrypt" reliably opens Enkrypt.
- Clicking "UniSat" reliably opens UniSat.
- No change for users who only have one extension or use mobile/Ledger flows.

## How to test

1. Install Enkrypt **and** another EIP-6963 wallet (MetaMask, Phantom, etc.) in the same browser.
2. Open the access flow → click **Enkrypt** → confirm Enkrypt's popup opens (not the other one).
3. Repeat with UniSat if available.
4. With only one extension installed, confirm it still works as before.
5. Mobile/WalletConnect/Ledger flows: confirm unchanged.

## Ticket

[MEW-1629](https://myetherwallet.atlassian.net/browse/MEW-1629)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated wallet detection logic to use case-sensitive string comparison when matching injected wallets and EIP-6963 providers. This affects how wallets are identified and connected in the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->