### PR TITLE
fix: 🐛 scrolling page issue

### DIFF
--- a/src/components/core_layouts/TheAppLayout.vue
+++ b/src/components/core_layouts/TheAppLayout.vue
@@ -129,6 +129,7 @@ const { isOverflowHidden } = storeToRefs(appLayoutStore)
 const scrollContainer = ref<HTMLElement | null>(null)
 
 const onHeaderWheel = (e: WheelEvent) => {
+  if (isOverflowHidden.value || !scrollContainer.value) return
   scrollContainer.value?.scrollBy({ top: e.deltaY, behavior: 'instant' })
 }
 </script>

--- a/src/components/core_layouts/TheAppLayout.vue
+++ b/src/components/core_layouts/TheAppLayout.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="h-screen relative flex overflow-hidden">
-    <the-header class="basis-full" />
+    <the-header class="basis-full" @wheel="onHeaderWheel" />
 
     <!-- Background -->
     <teleport to="#app">
@@ -22,6 +22,7 @@
       </transition>
     </teleport>
     <div
+      ref="scrollContainer"
       :class="[
         isOpenSideMenu ? 'xl:mr-[455px]' : 'xl:mr-[80px]',
         backgroundClass,
@@ -76,7 +77,7 @@
 import { MewFooter } from '@myetherwallet/vue-common-components'
 import { RouterLink, useRoute } from 'vue-router'
 import { useI18n } from 'vue-i18n'
-import { inject, computed } from 'vue'
+import { inject, computed, ref } from 'vue'
 import type { Analytics } from '@/analytics/amplitude'
 import { Provider } from '@/providers'
 import { useAnalyticsStore } from '@/stores/analyticsStore'
@@ -124,6 +125,12 @@ const backgroundClass = computed(() => {
 
 const appLayoutStore = useAppLayoutStore()
 const { isOverflowHidden } = storeToRefs(appLayoutStore)
+
+const scrollContainer = ref<HTMLElement | null>(null)
+
+const onHeaderWheel = (e: WheelEvent) => {
+  scrollContainer.value?.scrollBy({ top: e.deltaY, behavior: 'instant' })
+}
 </script>
 
 <style scoped>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scrolling with the mouse wheel over the header now correctly scrolls the main content area.
  * Wheel interactions are routed to the content container to prevent inconsistent scroll behavior.
  * When overflow is hidden, wheel events are ignored so content doesn't jump unexpectedly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->