### PR TITLE
feat: [MEW-1660] use longName and underlyingName for asset display

### DIFF
--- a/src/modules/perps/ModulePerpInfo.vue
+++ b/src/modules/perps/ModulePerpInfo.vue
@@ -22,7 +22,7 @@
           >
             {{ baseCurrency.toUpperCase() }}
             <span class="text-s-17 xs:text-s-20 mr-1 font-semibold"
-              >({{ displayName }})</span
+              >({{ longName }})</span
             >
           </h1>
           <div>
@@ -426,7 +426,7 @@
           >
             Asset Name
           </p>
-          <p class="text-s-14 font-bold">{{ displayName }}</p>
+          <p class="text-s-14 font-bold">{{ assetName }}</p>
         </div>
         <div>
           <p
@@ -521,6 +521,15 @@ const displayName = computed(() => {
   const pair = markets.value.find(m => m.market === props.market)
   return pair?.displayName ?? baseCurrency.value
 })
+
+const longName = computed(() => {
+  const pair = markets.value.find(m => m.market === props.market)
+  return pair?.longName ?? pair?.displayName ?? baseCurrency.value
+})
+
+const assetName = computed(
+  () => perpInfo.value?.underlyingName ?? longName.value,
+)
 
 const contractData = computed(() =>
   contracts.value.find(c => c.market === props.market),

--- a/src/modules/perps/components/PerpsMarketList.vue
+++ b/src/modules/perps/components/PerpsMarketList.vue
@@ -258,12 +258,12 @@
                     class="rounded-full"
                   />
                   <div class="min-w-0">
-                    <div class="flex items-center gap-2 relative">
-                      <span class="font-bold truncate">{{
+                    <div class="flex items-center gap-2">
+                      <span class="font-bold whitespace-nowrap">{{
                         contract.baseCurrency
                       }}</span>
                       <span
-                        class="absolute -right-5 bg-surface text-info font-bold rounded px-[6px] py-[1px] text-s-9"
+                        class="shrink-0 bg-surface text-info font-bold rounded px-[6px] py-[1px] text-s-9"
                       >
                         {{ contract.defaultLeverage }}x
                       </span>

--- a/src/modules/perps/components/PerpsMarketList.vue
+++ b/src/modules/perps/components/PerpsMarketList.vue
@@ -620,7 +620,8 @@ const filteredContracts = computed(() => {
       c =>
         c.baseCurrency.toLowerCase().includes(q) ||
         c.market.toLowerCase().includes(q) ||
-        c.displayName.toLowerCase().includes(q),
+        c.displayName.toLowerCase().includes(q) ||
+        c.longName.toLowerCase().includes(q),
     )
   }
 

--- a/src/modules/perps/components/PerpsMarketList.vue
+++ b/src/modules/perps/components/PerpsMarketList.vue
@@ -269,7 +269,7 @@
                       </span>
                     </div>
                     <span class="text-info text-s-12 truncate block">{{
-                      contract.displayName
+                      contract.longName
                     }}</span>
                   </div>
                 </div>
@@ -581,6 +581,7 @@ const selectedFilter = ref<FilterOption>(filterOptions[0])
 
 interface EnrichedContract extends Contract {
   displayName: string
+  longName: string
   defaultLeverage: string
 }
 
@@ -589,11 +590,15 @@ const enrichedContracts = computed<EnrichedContract[]>(() => {
   for (const m of markets.value) {
     marketMap.set(m.market, m)
   }
-  return contracts.value.map(c => ({
-    ...c,
-    displayName: marketMap.get(c.market)?.displayName ?? c.baseCurrency,
-    defaultLeverage: marketMap.get(c.market)?.defaultLeverage ?? '',
-  }))
+  return contracts.value.map(c => {
+    const pair = marketMap.get(c.market)
+    return {
+      ...c,
+      displayName: pair?.displayName ?? c.baseCurrency,
+      longName: pair?.longName ?? pair?.displayName ?? c.baseCurrency,
+      defaultLeverage: pair?.defaultLeverage ?? '',
+    }
+  })
 })
 
 const filteredContracts = computed(() => {

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -481,7 +481,7 @@ export function usePerpsTradeForm() {
 
   function getMarketDisplayName(contract: any): string {
     const match = markets.value.find(m => m.market === contract.market)
-    return match?.displayName ?? contract.baseCurrency
+    return match?.longName ?? match?.displayName ?? contract.baseCurrency
   }
 
   function openTokenSelect() {

--- a/src/modules/perps/sdk/types.ts
+++ b/src/modules/perps/sdk/types.ts
@@ -51,6 +51,7 @@ export interface TradingPair {
     quote: string
   }
   displayName: string
+  longName: string
   baseIncrement: string
   quoteIncrement: string
   defaultLeverage: string

--- a/src/modules/perps/sdk/types.ts
+++ b/src/modules/perps/sdk/types.ts
@@ -51,7 +51,7 @@ export interface TradingPair {
     quote: string
   }
   displayName: string
-  longName: string
+  longName?: string
   baseIncrement: string
   quoteIncrement: string
   defaultLeverage: string


### PR DESCRIPTION
## Summary

Replaces the market-symbol display (e.g. `AAPLUSD`) with the human-readable asset name (e.g. `Apple Inc.`) across the three perps surfaces called out in [MEW-1660](https://myetherwallet.atlassian.net/browse/MEW-1660):

- **Market Table** (`PerpsMarketList.vue`) — row subtitle now renders `longName`
- **Select Market Dialog** (`PerpsSelectMarketDialog.vue` via `getMarketDisplayName`) — now returns `longName`
- **Token Info page** (`ModulePerpInfo.vue`):
  - Header parenthetical next to the ticker → `longName`
  - "Asset Name" field → `underlyingName` from `/v1/markets/info/{symbol}`, falling back to `longName`

`longName` is added to the `TradingPair` SDK type. All bindings keep a fallback chain (`longName ?? displayName ?? baseCurrency`) so missing fields don't break rendering.

## Files changed

- `src/modules/perps/sdk/types.ts`
- `src/modules/perps/components/PerpsMarketList.vue`
- `src/modules/perps/composables/usePerpsTradeForm.ts`
- `src/modules/perps/ModulePerpInfo.vue`

## Test plan

- [ ] Open Perps → market table shows long names (e.g. "Apple Inc.") under each ticker
- [ ] Open Select Market dialog → each row shows long name under the ticker
- [ ] Click a market → Token Info header shows `(<longName>)` next to the ticker
- [ ] Token Info → Instrument Information panel "Asset Name" shows `underlyingName` from the info endpoint
- [ ] When a market lacks `longName`/`underlyingName`, fallbacks render the existing display name without errors
- [ ] `npm run type-check` and lint pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Market headers, lists, and instrument details now show more descriptive long names with sensible fallbacks for clearer asset identification.
  * Search/filtering includes these descriptive names for better discoverability.
  * Layout and badge styling adjusted to prevent truncation and improve readability in lists and detail panels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->