### PR TITLE
fix: [MEW-1624] derive market-order price from filledCost / filledSize

### DIFF
--- a/src/modules/perps/ModulePerpInfo.vue
+++ b/src/modules/perps/ModulePerpInfo.vue
@@ -249,7 +249,7 @@
                     {{ order.type }}
                   </td>
                   <td class="py-3 px-4 text-right font-bold">
-                    {{ formatPrice(order.price) }}
+                    {{ formatPrice(getOrderPrice(order)) }}
                   </td>
                   <td class="py-3 px-4 text-right font-bold">
                     {{ order.size }}
@@ -495,6 +495,7 @@ import {
   pnlColor,
   formatPercent,
   formatVolume,
+  getOrderPrice,
 } from './utils/formatters'
 import {
   getLogoUrl,

--- a/src/modules/perps/components/PerpsOrderDialog.vue
+++ b/src/modules/perps/components/PerpsOrderDialog.vue
@@ -75,6 +75,7 @@ import {
   formatPnl,
   pnlColor,
   formatDate,
+  getOrderPrice,
 } from '../utils/formatters'
 import { getBase, getLogoUrl } from '../utils/market'
 
@@ -142,7 +143,7 @@ const rows = computed(() => {
     },
     {
       label: 'Price',
-      value: formatPrice(props.order.price),
+      value: formatPrice(getOrderPrice(props.order)),
     },
     {
       label: 'Size',

--- a/src/modules/perps/components/PerpsPositionsTable.vue
+++ b/src/modules/perps/components/PerpsPositionsTable.vue
@@ -365,7 +365,7 @@
               </td>
               <!-- Price -->
               <td class="px-1 py-3 text-right font-normal text-s-14">
-                <p>{{ formatPrice(order.price) }}</p>
+                <p>{{ formatPrice(getOrderPrice(order)) }}</p>
 
                 <p class="text-s-12 text-info xs:hidden">
                   {{ formatDate(order.createdAt) }}
@@ -736,6 +736,7 @@ import {
   formatRoe,
   pnlColor,
   formatDate,
+  getOrderPrice,
 } from '../utils/formatters'
 import { getBase, getLogoUrl } from '../utils/market'
 import { perpsClient } from '../configs'

--- a/src/modules/perps/utils/formatters.ts
+++ b/src/modules/perps/utils/formatters.ts
@@ -1,7 +1,25 @@
 import { BigNumber } from 'bignumber.js'
+import type { ApiOrder } from '../sdk/types'
 /**
  * Common formatting utilities for the perps module.
  */
+
+// Market orders return an empty price from the API; derive it from
+// filledCost / filledSize once the order has filled.
+export function getOrderPrice(order: ApiOrder): string {
+  if (
+    order.type === 'market' &&
+    parseFloat(order.filledSize) > 0 &&
+    order.filledCost &&
+    !Number.isNaN(Number(order.filledCost)) &&
+    !Number.isNaN(Number(order.filledSize))
+  ) {
+    return new BigNumber(order.filledCost)
+      .dividedBy(order.filledSize)
+      .toString()
+  }
+  return order.price
+}
 export function formatUsd(val: string | number): string {
   const n = typeof val === 'number' ? val : parseFloat(val)
   if (isNaN(n)) return '$0.00'


### PR DESCRIPTION
## Summary

The Orders table was rendering an empty Price cell for **market orders**, because the API returns `price = ""` for that order type. Per [MEW-1624](https://myetherwallet.atlassian.net/browse/MEW-1624), derive the price from `filledCost / filledSize` once the market order has filled.

Added a single helper `getOrderPrice(order)` in `utils/formatters.ts` and wired it into the three places where order price is rendered:

- `ModulePerpInfo.vue` — Orders tab on the per-market info page
- `PerpsPositionsTable.vue` — Orders sub-table on the positions/orders page
- `PerpsOrderDialog.vue` — order detail dialog

Non-market orders (limit, stopMarket, takeProfitMarket) and unfilled market orders fall through to `order.price` unchanged.

## Logic

```ts
if (
  order.type === 'market' &&
  parseFloat(order.filledSize) > 0 &&
  order.filledCost &&
  !Number.isNaN(Number(order.filledCost)) &&
  !Number.isNaN(Number(order.filledSize))
) {
  return new BigNumber(order.filledCost).dividedBy(order.filledSize).toString()
}
return order.price
```

Uses the perps module's existing `bignumber.js` import (matches the codebase rather than introducing `decimal.js`).

## Test plan

- [ ] Place a market order, let it fill → Orders tab in token info page shows the derived price (filledCost / filledSize)
- [ ] Same order in `PerpsPositionsTable` Orders section → price is populated
- [ ] Open the order detail dialog → "Price" row shows the derived value
- [ ] Place a **limit** order → price column still uses the API-supplied `order.price` (no behavior change)
- [ ] Unfilled market order → price renders as the existing `formatPrice` fallback (`—`)
- [ ] `npm run type-check` and lint pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Improved order price accuracy throughout the perps trading interface. Order dialogs, position information displays, and the positions table now correctly calculate and display execution prices for filled market orders based on actual fill amounts, providing clearer insight into true transaction costs and removing pricing inconsistencies across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->