### PR TITLE
feat: [MEW-1658] validate decimal precision on trade-form numeric inputs

### DIFF
--- a/src/modules/perps/ModulePerpsTrade.vue
+++ b/src/modules/perps/ModulePerpsTrade.vue
@@ -242,7 +242,10 @@
           <div class="flex items-center py-1">
             <span
               class="font-bold text-s-20 tracking-tight"
-              :class="!limitPrice || limitPrice === '' ? 'opacity-50' : ''"
+              :class="[
+                !limitPrice || limitPrice === '' ? 'opacity-50' : '',
+                limitPriceHasError ? 'text-error' : '',
+              ]"
               >$</span
             >
             <input
@@ -251,6 +254,7 @@
               inputmode="decimal"
               placeholder="0.00"
               class="w-full font-bold text-s-20 tracking-tight outline-none bg-transparent"
+              :class="{ 'text-error': limitPriceHasError }"
               @keydown="
                 e => {
                   if (['-', '+', 'e', 'E'].includes(e.key)) e.preventDefault()
@@ -275,6 +279,16 @@
               class="text-error text-s-12 mb-1"
             >
               Price must be less than $10,000,000
+            </div>
+            <div
+              v-else-if="limitPricePrecisionError"
+              class="text-error text-s-12 mb-1"
+            >
+              {{
+                quoteDecimals === 0
+                  ? 'Price must be a whole number'
+                  : `Price supports up to ${quoteDecimals} decimal place${quoteDecimals === 1 ? '' : 's'}`
+              }}
             </div>
           </transition>
 
@@ -306,11 +320,12 @@
               <div class="">
                 <div
                   class="flex items-center before:content-['$'] before:font-bold before:text-s-28 before:tracking-tight before:mr-1"
-                  :class="
+                  :class="[
                     !inputAmount || inputAmount === ''
                       ? 'before:opacity-50'
-                      : ''
-                  "
+                      : '',
+                    marginPrecisionError ? 'before:text-error' : '',
+                  ]"
                 >
                   <input
                     v-model="inputAmount"
@@ -319,6 +334,7 @@
                     step="any"
                     placeholder="0.00"
                     class="font-bold text-s-28 bg-transparent outline-none w-full"
+                    :class="{ 'text-error': marginPrecisionError }"
                     @keydown="
                       e => {
                         if (['e', 'E', '+', '-'].includes(e.key))
@@ -347,7 +363,13 @@
             <!-- Error State -->
             <transition name="fade" mode="out-in">
               <div
-                v-if="
+                v-if="marginPrecisionError"
+                class="text-error text-s-12 mb-1"
+              >
+                Margin supports up to 2 decimal places
+              </div>
+              <div
+                v-else-if="
                   Number(inputAmount || '0') > availableMargin ||
                   isNaN(Number(inputAmount))
                 "
@@ -489,9 +511,10 @@
             <!-- input -->
             <div
               class="flex items-center before:content-['$'] before:font-bold before:text-[28px] before:tracking-tight before:mr-1"
-              :class="
-                !closeAmount || closeAmount === '' ? 'before:opacity-50' : ''
-              "
+              :class="[
+                !closeAmount || closeAmount === '' ? 'before:opacity-50' : '',
+                closeAmountPrecisionError ? 'before:text-error' : '',
+              ]"
             >
               <input
                 v-model="closeAmount"
@@ -500,6 +523,7 @@
                 step="any"
                 placeholder="0.00"
                 class="font-bold text-s-28 bg-transparent outline-none w-full"
+                :class="{ 'text-error': closeAmountPrecisionError }"
                 @keydown="
                   e => {
                     if (['e', 'E', '+', '-'].includes(e.key)) e.preventDefault()
@@ -519,6 +543,14 @@
                 )
               }}
             </p>
+            <transition name="fade" mode="out-in">
+              <div
+                v-if="closeAmountPrecisionError"
+                class="text-error text-s-12 mb-1"
+              >
+                Amount supports up to 2 decimal places
+              </div>
+            </transition>
             <!--slider -->
             <input
               v-model="closeSliderValue"
@@ -768,6 +800,9 @@
       :temp-projected-loss="tempProjectedLoss"
       :active-tp-pill="activeTpPill"
       :active-sl-pill="activeSlPill"
+      :take-profit-error="takeProfitPrecisionError"
+      :stop-loss-error="stopLossPrecisionError"
+      :quote-decimals="quoteDecimals"
       @clear-take-profit="clearTempTakeProfit"
       @clear-stop-loss="clearTempStopLoss"
       @set-take-profit-pct="setTakeProfitPct"
@@ -902,6 +937,13 @@ const {
   isSubmitting,
   submitDisabled,
   submitButtonLabel,
+  limitPriceHasError,
+  limitPricePrecisionError,
+  marginPrecisionError,
+  closeAmountPrecisionError,
+  takeProfitPrecisionError,
+  stopLossPrecisionError,
+  quoteDecimals,
   orderError,
   showConfirmModal,
   showConfirmation,

--- a/src/modules/perps/components/PerpsTakeProfitStopLossDialog.vue
+++ b/src/modules/perps/components/PerpsTakeProfitStopLossDialog.vue
@@ -50,7 +50,7 @@
             </div>
             <perps-enter-profit-loss-amount
               v-model:amount="takeProfitPrice"
-              error=""
+              :error="takeProfitError ? precisionMessage : ''"
               :validate-input="() => {}"
             >
               <template #footer>
@@ -69,6 +69,14 @@
                 </div>
               </template>
             </perps-enter-profit-loss-amount>
+            <transition name="fade" mode="out-in">
+              <div
+                v-if="takeProfitError"
+                class="text-error text-s-12 mt-1 pl-3"
+              >
+                {{ precisionMessage }}
+              </div>
+            </transition>
             <div class="text-right text-s-12 sm:text-s-13 mt-2 mr-2">
               <span class="text-info">Projected profit</span>
               <span
@@ -112,7 +120,7 @@
             </div>
             <perps-enter-profit-loss-amount
               v-model:amount="stopLossPrice"
-              error=""
+              :error="stopLossError ? precisionMessage : ''"
               :validate-input="() => {}"
             >
               <template #footer>
@@ -131,6 +139,14 @@
                 </div>
               </template>
             </perps-enter-profit-loss-amount>
+            <transition name="fade" mode="out-in">
+              <div
+                v-if="stopLossError"
+                class="text-error text-s-12 mt-1 pl-3"
+              >
+                {{ precisionMessage }}
+              </div>
+            </transition>
             <div class="text-right text-s-12 sm:text-s-13 mt-2 mr-2">
               <span class="text-info">Projected loss</span>
               <span
@@ -164,7 +180,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch, type PropType } from 'vue'
+import { ref, watch, computed, type PropType } from 'vue'
 import AppDialog from '@/components/AppDialog.vue'
 import AppTokenLogo from '@/components/AppTokenLogo.vue'
 import AppBaseButton from '@/components/AppBaseButton.vue'
@@ -176,14 +192,23 @@ import { PlusCircleIcon } from '@heroicons/vue/24/solid'
 
 const isOpen = defineModel<boolean>('isOpen', { default: false })
 
-defineProps<{
+const props = defineProps<{
   displaySymbol: string
   currentPrice: number
   tempProjectedProfit: number | null
   tempProjectedLoss: number | null
   activeTpPill: number | null
   activeSlPill: number | null
+  takeProfitError?: boolean
+  stopLossError?: boolean
+  quoteDecimals?: number
 }>()
+
+const precisionMessage = computed(() => {
+  const dec = props.quoteDecimals ?? 2
+  if (dec === 0) return 'Price must be a whole number'
+  return `Price supports up to ${dec} decimal place${dec === 1 ? '' : 's'}`
+})
 
 const emit = defineEmits<{
   clearTakeProfit: []

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -8,7 +8,7 @@ import { usePerpsMarkets, usePerpsContracts } from './usePerpsMarkets'
 import { usePerpsPositions } from './usePerpsPositions'
 import { usePerpsMarkPrices } from './usePerpsMarkPrices'
 import { usePerpsToasts } from './usePerpsToasts'
-import { formatUsd } from '../utils/formatters'
+import { formatUsd, hasInvalidPrecision, decimalPlaces } from '../utils/formatters'
 import { getCategory, midPrice } from '../utils/market'
 
 type OrderSide = 'buy' | 'sell'
@@ -182,6 +182,17 @@ export function usePerpsTradeForm() {
     return parseFloat(market?.quoteIncrement || '0.01')
   })
 
+  // Decimal-place caps derived from market increments. Used by input-precision
+  // validators so values match what the API will accept.
+  const quoteDecimals = computed(() => {
+    const market = markets.value.find(m => m.market === fullMarketName.value)
+    return decimalPlaces(market?.quoteIncrement || '0.01')
+  })
+
+  // USDC collateral is stored to 2 decimals across the perps surface (margin
+  // and amount-to-close inputs).
+  const COLLATERAL_DECIMALS = 2
+
   // API requires limit/trigger prices to align with quoteIncrement
   // (/v1/markets). Using a hardcoded 2-decimal rounding rejects on markets
   // with finer precision (e.g. quoteIncrement "0.0001").
@@ -240,6 +251,8 @@ export function usePerpsTradeForm() {
     if (amt > 0 && amt < minOrderAmount.value) return true
     if (maxCloseSizeUsd.value !== null && amt > maxCloseSizeUsd.value)
       return true
+    if (closeAmountPrecisionError.value) return true
+    if (limitPriceHasError.value) return true
     return false
   })
 
@@ -339,11 +352,47 @@ export function usePerpsTradeForm() {
     return (usedMargin + additionalMargin) / marginBal
   })
 
+  // ── Precision validation ───────────────────────────────────
+  // Each input on the trade form must respect the precision the API enforces.
+  // Quote-priced fields (limit price, take-profit, stop-loss) use the market's
+  // quoteIncrement; collateral-denominated fields (margin, amount-to-close)
+  // use the USDC convention of 2 decimals.
+  const limitPricePrecisionError = computed(() => {
+    if (orderType.value !== 'limit') return false
+    return hasInvalidPrecision(limitPrice.value, quoteDecimals.value)
+  })
+
+  const marginPrecisionError = computed(() =>
+    hasInvalidPrecision(inputAmount.value, COLLATERAL_DECIMALS),
+  )
+
+  const closeAmountPrecisionError = computed(() =>
+    hasInvalidPrecision(closeAmount.value, COLLATERAL_DECIMALS),
+  )
+
+  const takeProfitPrecisionError = computed(() => {
+    if (tempTakeProfitPrice.value == null) return false
+    return hasInvalidPrecision(
+      String(tempTakeProfitPrice.value),
+      quoteDecimals.value,
+    )
+  })
+
+  const stopLossPrecisionError = computed(() => {
+    if (tempStopLossPrice.value == null) return false
+    return hasInvalidPrecision(
+      String(tempStopLossPrice.value),
+      quoteDecimals.value,
+    )
+  })
+
   // ── Limit price validation ─────────────────────────────────
   const limitPriceHasError = computed(() => {
     if (orderType.value !== 'limit' || !limitPrice.value) return false
     const price = parseFloat(limitPrice.value)
-    return isNaN(price) || price <= 0 || price >= 10_000_000
+    if (isNaN(price) || price <= 0 || price >= 10_000_000) return true
+    if (limitPricePrecisionError.value) return true
+    return false
   })
 
   // ── Submit validation ──────────────────────────────────────
@@ -351,6 +400,9 @@ export function usePerpsTradeForm() {
     const amt = parseFloat(inputAmount.value)
     if (!amt || amt <= 0 || isSubmitting.value) return true
     if (limitPriceHasError.value) return true
+    if (marginPrecisionError.value) return true
+    if (takeProfitPrecisionError.value || stopLossPrecisionError.value)
+      return true
     if (availableMargin.value * leverage.value < minOrderAmount.value)
       return true
     if (amt > availableMargin.value) return true
@@ -938,6 +990,12 @@ export function usePerpsTradeForm() {
     submitDisabled,
     submitButtonLabel,
     limitPriceHasError,
+    limitPricePrecisionError,
+    marginPrecisionError,
+    closeAmountPrecisionError,
+    takeProfitPrecisionError,
+    stopLossPrecisionError,
+    quoteDecimals,
     newMarginRatio,
     orderError,
     showConfirmModal,

--- a/src/modules/perps/utils/formatters.ts
+++ b/src/modules/perps/utils/formatters.ts
@@ -103,3 +103,30 @@ export function formatPriceChange(pct?: string): string {
   const num = parseFloat(pct)
   return `${num >= 0 ? '+' : ''}${num.toFixed(2)}%`
 }
+
+// Count decimal places from a numeric string. Used to validate user input
+// against per-market increments (quoteIncrement / baseIncrement) where the
+// API rejects values with more precision than the increment allows.
+export function decimalPlaces(value: string | number): number {
+  const s = String(value)
+  const dot = s.indexOf('.')
+  return dot < 0 ? 0 : s.length - dot - 1
+}
+
+// Returns true when `value` is non-numeric or carries more decimal places
+// than `maxDecimals` permits. Empty input is treated as not-yet-invalid so
+// the error doesn't flash on a fresh field.
+//
+// Accepts string or number because Vue 3's v-model on `<input type="number">`
+// auto-coerces to number (overriding string refs), while limit-price uses a
+// `type="text"` input that stays a string.
+export function hasInvalidPrecision(
+  value: string | number,
+  maxDecimals: number,
+): boolean {
+  if (value === '' || value === null || value === undefined) return false
+  const s = String(value)
+  if (!/^-?\d*\.?\d*$/.test(s)) return true
+  if (Number.isNaN(Number(s))) return true
+  return decimalPlaces(s) > maxDecimals
+}


### PR DESCRIPTION
## Summary

Inline-validate the five numeric inputs in the perps trade form so users get feedback when a value carries more decimals than the API will accept. No auto-snap — typed/pasted input is preserved so the user can correct it.

**Per-field precision rules**

| Input | Cap | Source |
|---|---|---|
| Limit price | dynamic | `markets[active].quoteIncrement` |
| Take profit | dynamic | `markets[active].quoteIncrement` |
| Stop loss | dynamic | `markets[active].quoteIncrement` |
| Margin | 2 | USDC convention (`COLLATERAL_DECIMALS`) |
| Amount to close | 2 | USDC convention (`COLLATERAL_DECIMALS`) |

**Behaviour**
- Inline error appears under each input using the existing `<transition name="fade">` + `text-error text-s-12 mb-1` pattern (matches "Insufficient margin available").
- Input text and the `$` prefix turn red on error (mirrors the TP/SL input styling).
- Submit / Close buttons are disabled while any precision error is active.
- Paste validates the same as typing.

## Changes

- `utils/formatters.ts` — adds `decimalPlaces(value)` and `hasInvalidPrecision(value, maxDecimals)` (accepts `string | number` because Vue 3's `v-model` on `<input type="number">` auto-coerces to number).
- `composables/usePerpsTradeForm.ts` — adds `quoteDecimals` (derived from `quoteIncrement`), `COLLATERAL_DECIMALS`, and the five precision-error computeds; extends `limitPriceHasError`, `submitDisabled`, and `closeDisabled`.
- `ModulePerpsTrade.vue` — renders precision errors and red-tints inputs/`$` for limit price, margin, amount-to-close.
- `components/PerpsTakeProfitStopLossDialog.vue` — accepts `takeProfitError` / `stopLossError` / `quoteDecimals` props and renders matching inline error.

## Test plan

- [ ] Limit price: type/paste a value with more decimals than market's `quoteIncrement` → red `$`, red text, inline error, submit disabled.
- [ ] Margin: type `1.234` → "Margin supports up to 2 decimal places", submit disabled.
- [ ] Amount to close: same as margin under Manage → Close.
- [ ] Take profit / Stop loss: open Auto Close, type a value exceeding `quoteIncrement` precision → input goes red and error renders below.
- [ ] Switching markets (different `quoteIncrement`) updates the cap and message.
- [ ] Clearing the input clears the error (no flash on empty fields).
- [ ] Submit succeeds for values that respect the cap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added decimal precision validation for perpetuals trade inputs (limit price, margin, close amount) with tailored error messages.
  * Enhanced take-profit and stop-loss inputs with precision-aware error messaging based on market specifications.

* **Bug Fixes**
  * Improved validation error handling to prevent invalid decimal entries and provide clearer feedback to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->