### PR TITLE
feat: [MEW-1662] select market sort by price/volume + pin selected

### DIFF
--- a/src/modules/perps/ModulePerpsTrade.vue
+++ b/src/modules/perps/ModulePerpsTrade.vue
@@ -740,10 +740,14 @@
       v-model:is-open="showMarketModal"
       v-model:search="marketSearch"
       v-model:active-filter="marketFilter"
-      v-model:sort-asc="marketSortAsc"
+      :sort-value="marketSortValue"
+      :sort-direction="marketSortDirection"
+      :sort-options="marketSortOptions"
+      :selected-market-name="fullMarketName"
       :contracts="filteredMarketList"
       :filter-tabs="marketFilterTabs"
       :get-market-display-name="getMarketDisplayName"
+      @set-sort="setMarketSort"
       @select="selectMarket"
     />
 
@@ -918,9 +922,13 @@ const {
   showMarketModal,
   marketSearch,
   marketFilter,
-  marketSortAsc,
+  marketSortValue,
+  marketSortDirection,
+  marketSortOptions,
+  setMarketSort,
   marketFilterTabs,
   filteredMarketList,
+  fullMarketName,
   getMarketDisplayName,
   openTokenSelect,
   selectMarket,

--- a/src/modules/perps/components/PerpsSelectMarketDialog.vue
+++ b/src/modules/perps/components/PerpsSelectMarketDialog.vue
@@ -90,6 +90,8 @@
                 ? '!bg-mewBg'
                 : 'bg-transparent hoverBGWhite'
             "
+            :aria-pressed="contract.market === selectedMarketName"
+            :aria-label="`${getMarketDisplayName(contract)}${contract.market === selectedMarketName ? ' (selected)' : ''}`"
             @click="$emit('select', contract)"
           >
             <div class="flex justify-between items-center w-full">

--- a/src/modules/perps/components/PerpsSelectMarketDialog.vue
+++ b/src/modules/perps/components/PerpsSelectMarketDialog.vue
@@ -8,7 +8,7 @@
   >
     <template #content>
       <div class="flex flex-col">
-        <!-- Search -->
+        <!-- Search + Sort -->
         <div
           class="flex gap-2 justify-between items-center mb-2 mx-4 bg-surface rounded-full p-1"
         >
@@ -25,37 +25,36 @@
                 class="flex items-center px-4 py-2 text-s-15 font-medium hoverNoBG rounded-full bg-white h-10 shadow-sm whitespace-nowrap justify-center gap-1"
                 @click="toggleMenu"
               >
-                <span>Name</span>
-                <arrow-long-up-icon v-if="sortAsc" class="w-4 h-4 shrink-0" />
+                <span>{{ activeSortLabel }}</span>
+                <arrow-long-up-icon
+                  v-if="sortDirection === 'asc'"
+                  class="w-4 h-4 shrink-0"
+                />
                 <arrow-long-down-icon v-else class="w-4 h-4 shrink-0" />
               </button>
             </template>
             <template #menu-content="{ toggleMenu }">
-              <div class="py-4 flex flex-col w-[160px] gap-1">
+              <div class="py-4 flex flex-col w-[200px] gap-1">
                 <div class="flex items-center justify-between mb-1 mx-3">
                   <p class="text-s-17 font-medium ml-3">Sort</p>
                   <app-btn-icon-close @close="toggleMenu" />
                 </div>
                 <hr class="h-px bg-grey-outline border-0 w-full mt-1 mb-2" />
                 <button
+                  v-for="option in sortOptions"
+                  :key="option.value"
                   class="flex items-center px-4 py-2.5 mx-3 hoverNoBG rounded-16 text-s-15 font-medium"
-                  :class="{ 'bg-grey-5': sortAsc }"
-                  @click="[$emit('update:sortAsc', true), toggleMenu()]"
+                  :class="{ 'bg-grey-5': sortValue === option.value }"
+                  @click="[$emit('setSort', option.value), toggleMenu()]"
                 >
-                  Name
-                  <arrow-long-up-icon
-                    v-if="sortAsc"
-                    class="ml-auto w-5 h-5 text-primary"
-                  />
-                </button>
-                <button
-                  class="flex items-center px-4 py-2.5 mx-3 hoverNoBG rounded-16 text-s-15 font-medium"
-                  :class="{ 'bg-grey-5': !sortAsc }"
-                  @click="[$emit('update:sortAsc', false), toggleMenu()]"
-                >
-                  Name
-                  <arrow-long-down-icon
-                    v-if="!sortAsc"
+                  {{ option.label }}
+                  <component
+                    :is="
+                      sortValue === option.value && sortDirection === 'asc'
+                        ? ArrowLongUpIcon
+                        : ArrowLongDownIcon
+                    "
+                    v-if="sortValue === option.value"
                     class="ml-auto w-5 h-5 text-primary"
                   />
                 </button>
@@ -85,7 +84,12 @@
           <button
             v-for="contract in contracts"
             :key="contract.market"
-            class="flex items-center justify-between w-full px-2 py-3 cursor-pointer hoverNoBG rounded-20 transition-colors animate-fade-in bg-transparent hoverBGWhite"
+            class="flex items-center justify-between w-full px-2 py-3 cursor-pointer hoverNoBG rounded-20 transition-colors animate-fade-in"
+            :class="
+              contract.market === selectedMarketName
+                ? '!bg-mewBg'
+                : 'bg-transparent hoverBGWhite'
+            "
             @click="$emit('select', contract)"
           >
             <div class="flex justify-between items-center w-full">
@@ -140,7 +144,7 @@
 </template>
 
 <script setup lang="ts">
-import type { PropType } from 'vue'
+import { computed, type PropType } from 'vue'
 import { ArrowLongUpIcon, ArrowLongDownIcon } from '@heroicons/vue/24/solid'
 import AppDialog from '@/components/AppDialog.vue'
 import AppTokenLogo from '@/components/AppTokenLogo.vue'
@@ -151,8 +155,13 @@ import AppBtnIconClose from '@/components/AppBtnIconClose.vue'
 import { getLogoUrl } from '../utils/market'
 import { formatContractPrice, formatPriceChange } from '../utils/formatters'
 import type { Contract } from '../sdk/types'
+import type {
+  MarketSortValue,
+  SortDirection,
+  MarketSortOption,
+} from '../composables/usePerpsTradeForm'
 
-defineProps({
+const props = defineProps({
   contracts: {
     type: Array as PropType<Contract[]>,
     required: true,
@@ -169,9 +178,21 @@ defineProps({
     type: String,
     required: true,
   },
-  sortAsc: {
-    type: Boolean,
+  sortValue: {
+    type: String as PropType<MarketSortValue>,
     required: true,
+  },
+  sortDirection: {
+    type: String as PropType<SortDirection>,
+    required: true,
+  },
+  sortOptions: {
+    type: Array as PropType<MarketSortOption[]>,
+    required: true,
+  },
+  selectedMarketName: {
+    type: String,
+    default: '',
   },
   getMarketDisplayName: {
     type: Function as PropType<(contract: Contract) => string>,
@@ -187,7 +208,12 @@ const isOpen = defineModel('isOpen', {
 defineEmits<{
   'update:activeFilter': [value: string]
   'update:search': [value: string]
-  'update:sortAsc': [value: boolean]
+  setSort: [value: MarketSortValue]
   select: [contract: Contract]
 }>()
+
+const activeSortLabel = computed(
+  () =>
+    props.sortOptions.find(o => o.value === props.sortValue)?.label ?? 'Sort',
+)
 </script>

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -509,19 +509,20 @@ export function usePerpsTradeForm() {
       )
     }
     const dir = marketSortDirection.value === 'asc' ? 1 : -1
+    const toSafeNumber = (value?: string | number) => {
+      const n = typeof value === 'number' ? value : Number(value)
+      return Number.isFinite(n) ? n : 0
+    }
     list.sort((a, b) => {
       switch (marketSortValue.value) {
         case 'volume':
-          return (
-            (parseFloat(a.usdVolume ?? '0') - parseFloat(b.usdVolume ?? '0')) *
-            dir
-          )
+          return (toSafeNumber(a.usdVolume) - toSafeNumber(b.usdVolume)) * dir
         case 'price':
-          return (midPrice(a) - midPrice(b)) * dir
+          return (toSafeNumber(midPrice(a)) - toSafeNumber(midPrice(b))) * dir
         case 'priceChange':
           return (
-            (parseFloat(a.priceChangePercent ?? '0') -
-              parseFloat(b.priceChangePercent ?? '0')) *
+            (toSafeNumber(a.priceChangePercent) -
+              toSafeNumber(b.priceChangePercent)) *
             dir
           )
         case 'name':

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -13,6 +13,13 @@ import { getCategory, midPrice } from '../utils/market'
 
 type OrderSide = 'buy' | 'sell'
 type OrderType = 'market' | 'limit'
+export type MarketSortValue = 'name' | 'volume' | 'price' | 'priceChange'
+export type SortDirection = 'asc' | 'desc'
+export interface MarketSortOption {
+  value: MarketSortValue
+  label: string
+  numeric: boolean
+}
 interface OrderSideButton {
   label: string
   value: OrderSide
@@ -70,7 +77,13 @@ export function usePerpsTradeForm() {
   const showMarketModal = ref(false)
   const marketSearch = ref('')
   const marketFilter = ref('all')
-  const marketSortAsc = ref(true)
+  const marketSortValue = ref<MarketSortValue>('name')
+  const marketSortDirection = ref<SortDirection>('asc')
+  // Tracks whether the user has explicitly chosen a sort. While false, the
+  // currently-selected market is pinned to the top of filteredMarketList so
+  // the user lands on it when reopening the dialog. The first explicit sort
+  // pick releases the pin.
+  const marketSortIsUserSet = ref(false)
   const manageMode = ref<'add' | 'close'>('add')
   const closeAmount = ref('')
   const closeSliderValue = ref(0)
@@ -460,6 +473,28 @@ export function usePerpsTradeForm() {
     { key: 'ETFs', label: 'ETFs' },
   ]
 
+  const marketSortOptions: MarketSortOption[] = [
+    { value: 'name', label: 'Name', numeric: false },
+    { value: 'volume', label: 'Volume', numeric: true },
+    { value: 'price', label: 'Price', numeric: true },
+    { value: 'priceChange', label: 'Price change', numeric: true },
+  ]
+
+  // Re-clicking the active sort flips its direction; a different sort jumps
+  // to the option's natural default (numeric → DESC, string → ASC). Mirrors
+  // the AppSwapSelectedToken sort popup so behavior is consistent app-wide.
+  function setMarketSort(value: MarketSortValue) {
+    marketSortIsUserSet.value = true
+    if (marketSortValue.value === value) {
+      marketSortDirection.value =
+        marketSortDirection.value === 'asc' ? 'desc' : 'asc'
+      return
+    }
+    const option = marketSortOptions.find(o => o.value === value)
+    marketSortValue.value = value
+    marketSortDirection.value = option?.numeric ? 'desc' : 'asc'
+  }
+
   const filteredMarketList = computed(() => {
     let list = [...contracts.value]
     if (marketFilter.value !== 'all') {
@@ -473,10 +508,36 @@ export function usePerpsTradeForm() {
           c.market.toLowerCase().includes(q),
       )
     }
+    const dir = marketSortDirection.value === 'asc' ? 1 : -1
     list.sort((a, b) => {
-      const cmp = a.baseCurrency.localeCompare(b.baseCurrency)
-      return marketSortAsc.value ? cmp : -cmp
+      switch (marketSortValue.value) {
+        case 'volume':
+          return (
+            (parseFloat(a.usdVolume ?? '0') - parseFloat(b.usdVolume ?? '0')) *
+            dir
+          )
+        case 'price':
+          return (midPrice(a) - midPrice(b)) * dir
+        case 'priceChange':
+          return (
+            (parseFloat(a.priceChangePercent ?? '0') -
+              parseFloat(b.priceChangePercent ?? '0')) *
+            dir
+          )
+        case 'name':
+        default:
+          return a.baseCurrency.localeCompare(b.baseCurrency) * dir
+      }
     })
+    // Pin the active market on top until the user explicitly picks a sort,
+    // so the dialog opens on the row they just left.
+    if (!marketSortIsUserSet.value && fullMarketName.value) {
+      const idx = list.findIndex(c => c.market === fullMarketName.value)
+      if (idx > 0) {
+        const [selected] = list.splice(idx, 1)
+        list.unshift(selected)
+      }
+    }
     return list
   })
 
@@ -488,6 +549,9 @@ export function usePerpsTradeForm() {
   function openTokenSelect() {
     marketSearch.value = ''
     marketFilter.value = 'all'
+    marketSortValue.value = 'volume'
+    marketSortDirection.value = 'desc'
+    marketSortIsUserSet.value = false
     showMarketModal.value = true
   }
 
@@ -955,9 +1019,13 @@ export function usePerpsTradeForm() {
     showMarketModal,
     marketSearch,
     marketFilter,
-    marketSortAsc,
+    marketSortValue,
+    marketSortDirection,
+    marketSortOptions,
+    setMarketSort,
     marketFilterTabs,
     filteredMarketList,
+    fullMarketName,
     getMarketDisplayName,
     openTokenSelect,
     selectMarket,


### PR DESCRIPTION
## What's new

The **Select Perps Market** dialog now lets you sort by more than just name, and lands you back on the market you were just trading.

### Sorting

The sort menu (top-right of the search bar) now offers four options:

- **Name** — alphabetical (A→Z by default)
- **Volume** — 24h USD volume (high → low by default)
- **Price** — current mid price (high → low by default)
- **Price change** — 24h % change (high → low by default)

Re-clicking the active sort flips the direction (ascending ↔ descending). The button next to search shows the current sort name and an up/down arrow.

### Pin & highlight selected market

When you open the dialog:

- The market you're currently viewing is **pinned to the top** so it's the first row you see
- That row is **highlighted** so it's easy to spot at a glance
- The default sort underneath the pin is **Volume (high → low)**

As soon as you pick any sort option, the pin releases — your selected market then appears in its natural sorted position (still highlighted).

## How to test

1. Navigate to **Perps → Trade**.
2. Click the market name (top of the trade form) to open the Select Market dialog.
3. Confirm the currently-selected market appears at the top, highlighted.
4. Open the sort menu — confirm the four options (Name / Volume / Price / Price change) are present.
5. Pick **Price** — list reorders by price descending; click again, it flips to ascending.
6. Pick **Price change** — list reorders by 24h % change.
7. Filter by Equities / Commodities / ETFs and confirm sort + search still work.
8. Pick a different market, reopen the dialog — the new selection should now be the pinned/highlighted row.

## Jira

https://myetherwallet.atlassian.net/browse/MEW-1662

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Market selector now supports multiple sort keys (name, volume, price, price change) with ascending/descending control.
  * Active market is pinned to the top until the user explicitly changes sorting; modal reopen resets to sensible defaults.

* **Accessibility / UI Improvements**
  * Market list shows clear selection state with improved labels and pressed-state indication for assistive technologies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->