### PR TITLE
fix: 🐛 rows ui

### DIFF
--- a/src/modules/rewards/RewardsLearnMore.vue
+++ b/src/modules/rewards/RewardsLearnMore.vue
@@ -52,6 +52,7 @@
         <hr class="my-6 border-t border-grey-10" />
 
         <rewards-rows
+          v-if="!isBanned"
           :swap-claimed="swapClaimed"
           :swap-no-rewards="swapNoRewards"
           :swap-remaining-pct="swapRemainingPct"
@@ -87,6 +88,7 @@ import { analytics, RewardsEvent } from '@/analytics'
 import { useWalletMenuStore } from '@/stores/walletMenuStore'
 import { useGlobalStore } from '@/stores/globalStore'
 import { useToastStore } from '@/stores/toastStore'
+import { useRewardsStore } from '@/stores/rewardsStore'
 import { storeToRefs } from 'pinia'
 
 const props = defineProps<{
@@ -120,6 +122,9 @@ const { setWalletPanel } = walletMenu
 const globalStore = useGlobalStore()
 const { selectedNetwork } = storeToRefs(globalStore)
 const toastStore = useToastStore()
+
+const rewardsStore = useRewardsStore()
+const { isBanned } = storeToRefs(rewardsStore)
 
 watch(isOpenModel, val => {
   if (val) {

--- a/src/modules/rewards/RewardsPortfolio.vue
+++ b/src/modules/rewards/RewardsPortfolio.vue
@@ -56,7 +56,8 @@
         :time-until-next-eligible="timeUntilNextEligible"
         @swap="goToSwap"
         @trade="goToTrade"
-        class="max-w-[360px] mt-3 2xl:max-w-none"
+        class="max-w-[360px] 2xl:max-w-none"
+        :class="isOpenSideMenu ? '2xl:-ml-2 2xl:-mr-2' : ''"
         is-rewards-view
       />
       <img

--- a/src/modules/rewards/RewardsPortfolio.vue
+++ b/src/modules/rewards/RewardsPortfolio.vue
@@ -13,7 +13,10 @@
       class="bg-white rounded-16 h-full flex flex-col justify-between px-5 pb-5 relative overflow-hidden xl:max-h-[293px]"
     >
       <!-- Top: Title + Image -->
-      <div class="flex items-start justify-between gap-2 mb-5">
+      <div
+        class="flex items-start justify-between gap-2 mb-5"
+        :class="{ 'opacity-20 pointer-events-none': isBanned }"
+      >
         <div class="flex flex-col pt-5">
           <h3 class="text-s-20 font-bold leading-none">Earn rewards</h3>
           <p class="text-s-16 text-[#575757] leading-[22px] mt-2 max-w-[295px]">
@@ -57,16 +60,34 @@
         @swap="goToSwap"
         @trade="goToTrade"
         class="max-w-[360px] 2xl:max-w-none"
-        :class="isOpenSideMenu ? '2xl:-ml-2 2xl:-mr-2' : ''"
+        :class="[
+          isOpenSideMenu ? '2xl:-ml-2 2xl:-mr-2' : '',
+          { 'opacity-20 pointer-events-none': isBanned },
+        ]"
         is-rewards-view
       />
+      <div
+        v-if="isBanned"
+        class="text-center font-medium text-s-16 p-5 bg-appBackground rounded-20 absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-1 xl:min-w-[300px]"
+      >
+        <p>You are not eligible for rewards at this time</p>
+        <button
+          class="text-s-16 underline text-left w-fit mt-1 hoverOpacity"
+          @click="onLearnMore"
+        >
+          Learn more
+        </button>
+      </div>
       <img
         :src="horizontalUsdc"
         alt=""
         width="650"
         height="292"
         class="shrink-0 object-contain hidden xs:block 3xl:hidden flex-none absolute right-[20px] mx-auto pointer-events-none max-h-[140px] max-w-[140px] sm:max-h-[225px] sm:max-w-[234px] 2xl:hidden"
-        :class="isOpenSideMenu ? '' : 'xl:hidden'"
+        :class="[
+          isOpenSideMenu ? '' : 'xl:hidden',
+          { 'opacity-20 pointer-events-none': isBanned },
+        ]"
       />
 
       <rewards-learn-more
@@ -123,6 +144,7 @@ const {
   tradeRemainingPct,
   tradeRemainingCount,
   nextHourStart,
+  isBanned,
 } = storeToRefs(rewardsStore)
 
 const isLearnMoreOpen = ref(false)

--- a/src/modules/rewards/RewardsRows.vue
+++ b/src/modules/rewards/RewardsRows.vue
@@ -4,7 +4,7 @@
     <div
       class="flex items-center justify-between gap-3"
       :class="{
-        'flex-wrap  items-start xs:items-center': isRewardsView,
+        'flex-wrap  xs:flex-nowrap items-start xs:items-center': isRewardsView,
       }"
     >
       <div class="flex items-center gap-3 min-w-[160px]">
@@ -65,9 +65,9 @@
       </app-base-button>
       <button
         v-else
-        class="flex items-center gap-1 shrink-0 text-s-11 xs:text-s-14 text-[#A5A5A5] font-semibold px-3 py-2 xs:py-[10px] border-[1.5px] border-dashed border-[#A5A5A5] rounded-full"
+        class="flex items-center gap-1 grow text-s-11 xs:text-s-13 text-[#A5A5A5] font-medium px-3 py-[6px] border-[1.5px] border-dashed border-[#A5A5A5] rounded-full max-w-[150px]"
         :class="{
-          '2xl:text-s-11 3xl:text-s-14 2xl:py-2 3xl:py-[10px]': isOpenSideMenu,
+          '2xl:text-s-11 3xl:text-s-13': isOpenSideMenu,
         }"
       >
         Back in {{ swapClaimed ? timeUntilNextEligible : timeUntilHourReset }}
@@ -84,7 +84,7 @@
     <div
       class="flex items-center justify-between gap-3"
       :class="{
-        'flex-wrap  items-start xs:items-center': isRewardsView,
+        'flex-wrap  xs:flex-nowrap items-start xs:items-center': isRewardsView,
       }"
     >
       <div class="flex items-center gap-3 min-w-[160px]">
@@ -140,16 +140,16 @@
         v-if="!tradeClaimed && !tradeNoRewards"
         size="small"
         is-outline
-        class="shrink-0"
+        class="grow max-w-[150px]"
         @click="$emit('trade')"
       >
         Trade $25+
       </app-base-button>
       <button
         v-else
-        class="flex items-center gap-1 shrink-0 text-s-11 xs:text-s-14 text-[#A5A5A5] font-semibold px-3 py-2 xs:py-[10px] border-[1.5px] border-dashed border-[#A5A5A5] rounded-full"
+        class="flex items-center gap-1 grow text-s-11 xs:text-s-13 text-[#A5A5A5] font-medium px-3 py-[6px] border-[1.5px] border-dashed border-[#A5A5A5] rounded-full max-w-[150px]"
         :class="{
-          '2xl:text-s-11 3xl:text-s-14 2xl:py-2 3xl:py-[10px]': isOpenSideMenu,
+          '2xl:text-s-11 3xl:text-s-13': isOpenSideMenu,
         }"
       >
         Back in

--- a/src/modules/rewards/RewardsSmallBanner.vue
+++ b/src/modules/rewards/RewardsSmallBanner.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-if="!isBanned">
     <div
       class="bg-mewBg rounded-2xl flex items-center gap-3 px-3 py-3 cursor-pointer shadow-sm relative mb-3"
       @click="onLearnMore"
@@ -62,6 +62,7 @@ const {
   tradeRemainingPct,
   tradeRemainingCount,
   nextHourStart,
+  isBanned,
 } = storeToRefs(rewardsStore)
 
 const isLearnMoreOpen = ref(false)

--- a/src/stores/rewardsStore.ts
+++ b/src/stores/rewardsStore.ts
@@ -179,8 +179,7 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
 
   const swapNoRewards = computed(
     () =>
-      !swapPool.value?.open ||
-      swapPool.value?.hourlyRemainingRewardCount === 0,
+      !swapPool.value?.open || swapPool.value?.hourlyRemainingRewardCount === 0,
   )
   const tradeNoRewards = computed(
     () =>
@@ -336,6 +335,24 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
     scheduleHourReset()
   }
 
+  const isBanned = computed(() => {
+    if (eligibility.value?.reasons.some(r => r.type === 'ACCOUNT_TOO_NEW'))
+      return true
+
+    const userRecentlyRewarded = eligibility.value?.reasons.some(
+      r => r.type === 'USER_RECENTLY_REWARDED',
+    )
+    if (!userRecentlyRewarded) {
+      return eligibility.value?.reasons.some(
+        r =>
+          r.type === 'REWARDS_DISABLED' ||
+          r.type === 'POOL_LOW_ETH' ||
+          r.type === 'POOL_LOW_USDC',
+      )
+    }
+    return false
+  })
+
   const canClaimReward = computed(() => {
     if (isBitcoinChain.value) return true
     if (!eligibility.value) return false
@@ -395,5 +412,6 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
     isLoading,
     hadInitialLoad,
     isRewardEarnedDuringCampaign,
+    isBanned,
   }
 })


### PR DESCRIPTION
<!-- NOTE: Remove the parts that's not relevant -->

### Devop

* \[ ] Added entry to ./changelog
* \[ ] Add PR label

### Feature

* \[ ] Added entry to ./changelog
* \[ ] Is this a user submitted feature request?
  * \[ ] Link to issue:
* \[ ] Add test cases or procedure
* \[ ] Add PR label

### Fix

* \[ ] Added entry to ./changelog
* \[ ] Is this a user submitted bug?
  * \[ ] Link to issue:
* \[ ] Add PR label

### Release

* \[ ] Merged changelog generation branch
* \[ ] Created a release
  * \[ ] Link to release:
* \[ ] Add PR label
* \[ ] Updated package.json version


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rewards section now respects a ban state: main banner and rewards rows are visually disabled with an overlay message and a “Learn more” action; banned users no longer see rewards content in dialogs or small banners.
* **Style**
  * Adjusted responsive spacing for larger screens based on menu state.
  * Refined sizing, padding and layout of fallback action buttons for improved mobile and xs-breakpoint display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->