### PR TITLE
feat: [MEW-1669] add reusable warning + show liquidation risk on withdraw

### DIFF
--- a/src/components/AppWarning.vue
+++ b/src/components/AppWarning.vue
@@ -1,0 +1,28 @@
+<template>
+  <div
+    class="p-4 sm:p-6 bg-warning-10 border-1 border-warning rounded-16 w-full"
+  >
+    <div class="flex items-center">
+      <exclamation-triangle-icon class="w-6 h-6 mr-2 text-warning shrink-0" />
+      <h3 class="font-bold">{{ title }}</h3>
+    </div>
+    <p class="pt-2 text-s-14 leading-p-150">
+      {{ text }}
+    </p>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ExclamationTriangleIcon } from '@heroicons/vue/24/outline'
+
+defineProps({
+  title: {
+    type: String,
+    required: true,
+  },
+  text: {
+    type: String,
+    required: true,
+  },
+})
+</script>

--- a/src/components/AppWarning.vue
+++ b/src/components/AppWarning.vue
@@ -1,5 +1,6 @@
 <template>
   <div
+    role="alert"
     class="p-4 sm:p-6 bg-warning-10 border-1 border-warning rounded-16 w-full"
   >
     <div class="flex items-center">

--- a/src/modules/perps/components/PerpsWithdrawDialog.vue
+++ b/src/modules/perps/components/PerpsWithdrawDialog.vue
@@ -2,6 +2,7 @@
   <app-dialog
     v-model:is-open="isOpen"
     title="Withdraw USDC"
+    class="sm:max-w-[460px] sm:mx-auto"
     has-content-gutter
     @close-dialog="$emit('close')"
   >
@@ -61,6 +62,13 @@
           </p>
         </div>
 
+        <app-warning
+          v-if="!withdrawalSuccess && hasOpenPositions"
+          title="Liquidation Risk"
+          text="You have open positions. Withdrawing funds will reduce your account equity and increase your effective leverage, which may increase your liquidation risk."
+          class="mb-4"
+        />
+
         <button
           v-if="!withdrawalSuccess"
           :disabled="sending || !isValidAmount"
@@ -84,8 +92,10 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
 import AppDialog from '@/components/AppDialog.vue'
+import AppWarning from '@/components/AppWarning.vue'
 import { perpsClient } from '../configs'
 import { usePerpsAuth, usePerpsBalance } from '../composables/usePerpsAuth'
+import { usePerpsPositions } from '../composables/usePerpsPositions'
 import { useWalletStore } from '@/stores/walletStore'
 import { storeToRefs } from 'pinia'
 import { usePerpsToasts } from '@/modules/perps/composables/usePerpsToasts'
@@ -105,9 +115,12 @@ const isOpen = computed({
 
 const { accountId, triggerRefresh } = usePerpsAuth()
 const { balance } = usePerpsBalance()
+const { positions } = usePerpsPositions()
 const store = useWalletStore()
 const { wallet } = storeToRefs(store)
 const perpsToasts = usePerpsToasts()
+
+const hasOpenPositions = computed(() => positions.value.length > 0)
 
 const amount = ref('')
 const sending = ref(false)


### PR DESCRIPTION
## What

When a user opens the **Withdraw USDC** modal in Perps, we now show a warning if they have any open positions:

> **Liquidation Risk**
> You have open positions. Withdrawing funds will reduce your account equity and increase your effective leverage, which may increase your liquidation risk.

The warning has the same overall layout as the existing "Not Recommended" banner used elsewhere in the app, but it uses the **warning** color palette (orange/amber) instead of red.

To make this reusable for future surfaces, the warning is implemented as a new global component (`AppWarning`) that takes `title` and `text` props.

The withdraw modal width is also capped to match the deposit modal — without that, the long warning copy was making the dialog grow wider than its sibling dialogs.

## Why

Users could withdraw funds while holding open positions without any heads-up that doing so increases liquidation risk. The legacy Perps page surfaces this warning in the same flow — we were just missing it here.

## How to test

1. Log into Perps with a wallet that **has at least one open position**.
2. Click **Withdraw**.
3. Verify the orange "Liquidation Risk" warning appears between the amount field and the **Withdraw** button.
4. Close, then with a wallet that has **no open positions**, open the withdraw modal again — the warning should NOT appear.
5. Confirm the modal width looks consistent with the Deposit modal (capped, doesn't stretch wide).

## Jira

https://myetherwallet.atlassian.net/browse/MEW-1669

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable warning notification component for prominent alert messages.
  * Integrated the warning into the withdrawal dialog to inform users when open positions may affect withdrawal success.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->