### PR TITLE
feat: [MEW-1670] block letters in withdraw amount + reuse perps amount input

### DIFF
--- a/src/modules/perps/components/PerpsAmount.vue
+++ b/src/modules/perps/components/PerpsAmount.vue
@@ -7,7 +7,7 @@
     }"
     @click="setInFocusInput"
   >
-    <p class="font-semibold text-s-12 text-info">Price</p>
+    <p class="font-semibold text-s-12 text-info">{{ title }}</p>
     <div class="flex justify-start items-center w-full gap-1">
       <span
         class="font-medium text-s-28 tracking-tight shrink-0"
@@ -40,6 +40,10 @@ import { onClickOutside } from '@vueuse/core'
 import { useInFocusInput } from '@/composables/useInFocusInput'
 
 const props = defineProps({
+  title: {
+    type: String,
+    default: 'Price',
+  },
   validateInput: {
     type: Function as PropType<() => void>,
     default: () => {},

--- a/src/modules/perps/components/PerpsTakeProfitStopLossDialog.vue
+++ b/src/modules/perps/components/PerpsTakeProfitStopLossDialog.vue
@@ -48,7 +48,7 @@
                 Remove
               </app-btn-text>
             </div>
-            <perps-enter-profit-loss-amount
+            <perps-amount
               v-model:amount="takeProfitPrice"
               :error="takeProfitError ? precisionMessage : ''"
               :validate-input="() => {}"
@@ -68,7 +68,7 @@
                   </button>
                 </div>
               </template>
-            </perps-enter-profit-loss-amount>
+            </perps-amount>
             <transition name="fade" mode="out-in">
               <div
                 v-if="takeProfitError"
@@ -118,7 +118,7 @@
                 Remove
               </app-btn-text>
             </div>
-            <perps-enter-profit-loss-amount
+            <perps-amount
               v-model:amount="stopLossPrice"
               :error="stopLossError ? precisionMessage : ''"
               :validate-input="() => {}"
@@ -138,7 +138,7 @@
                   </button>
                 </div>
               </template>
-            </perps-enter-profit-loss-amount>
+            </perps-amount>
             <transition name="fade" mode="out-in">
               <div v-if="stopLossError" class="text-error text-s-12 mt-1 pl-3">
                 {{ precisionMessage }}
@@ -182,7 +182,7 @@ import AppDialog from '@/components/AppDialog.vue'
 import AppTokenLogo from '@/components/AppTokenLogo.vue'
 import AppBaseButton from '@/components/AppBaseButton.vue'
 import AppBtnText from '@/components/AppBtnText.vue'
-import PerpsEnterProfitLossAmount from './PerpsEnterProfitLossAmount.vue'
+import PerpsAmount from './PerpsAmount.vue'
 import { formatUsd } from '../utils/formatters'
 import { getLogoUrl } from '../utils/market'
 import { PlusCircleIcon } from '@heroicons/vue/24/solid'

--- a/src/modules/perps/components/PerpsWithdrawDialog.vue
+++ b/src/modules/perps/components/PerpsWithdrawDialog.vue
@@ -27,29 +27,32 @@
 
         <!-- Amount -->
         <div class="mb-4">
-          <label
-            class="text-info text-s-11 uppercase tracking-wider font-medium mb-1.5 block"
+          <perps-amount
+            v-model:amount="amount"
+            v-model:error="amountError"
+            title="Amount"
+            :validate-input="validateAmount"
           >
-            Amount
-          </label>
-          <div class="flex items-center gap-2">
-            <input
-              v-model="amount"
-              type="text"
-              placeholder="0.00"
-              class="flex-1 bg-surface rounded-12 px-4 py-3 text-s-14 outline-none focus:ring-2 focus:ring-primary"
-            />
-            <button
-              class="text-primary text-s-13 font-medium"
-              @click="amount = withdrawableMargin"
-            >
-              MAX
-            </button>
-          </div>
+            <template #footer>
+              <div class="flex justify-start mt-1">
+                <button
+                  class="px-3 sm:px-4 py-1 text-s-9 sm:text-s-11 leading-p-120 font-semibold bg-white hoverBGWhite rounded-full transition-all duration-150 shadow-button shadow-button-elevated"
+                  @click="setMax"
+                >
+                  MAX
+                </button>
+              </div>
+            </template>
+          </perps-amount>
         </div>
 
         <!-- Error -->
-        <p v-if="error" class="text-error text-s-12 mb-4">{{ error }}</p>
+        <p
+          v-if="amountError || error"
+          class="text-error text-s-12 mb-4"
+        >
+          {{ amountError || error }}
+        </p>
 
         <!-- Success -->
         <div
@@ -84,11 +87,14 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
 import AppDialog from '@/components/AppDialog.vue'
-import { perpsClient } from '../configs'
+import PerpsAmount from './PerpsAmount.vue'
+import { perpsClient, USDC_DECIMALS } from '../configs'
+import { mainnet } from 'viem/chains'
 import { usePerpsAuth, usePerpsBalance } from '../composables/usePerpsAuth'
 import { useWalletStore } from '@/stores/walletStore'
 import { storeToRefs } from 'pinia'
 import { usePerpsToasts } from '@/modules/perps/composables/usePerpsToasts'
+import { hasInvalidPrecision } from '../utils/formatters'
 
 const props = defineProps<{
   visible: boolean
@@ -109,7 +115,8 @@ const store = useWalletStore()
 const { wallet } = storeToRefs(store)
 const perpsToasts = usePerpsToasts()
 
-const amount = ref('')
+const amount = ref<number | null>(null)
+const amountError = ref('')
 const sending = ref(false)
 const error = ref<string | null>(null)
 const withdrawalSuccess = ref(false)
@@ -120,16 +127,39 @@ const withdrawableMargin = computed(
 )
 
 const isValidAmount = computed(() => {
-  if (!amount.value) return false
-  const n = parseFloat(amount.value)
-  return !isNaN(n) && n > 0 && n <= parseFloat(withdrawableMargin.value)
+  if (amount.value === null || amount.value <= 0) return false
+  if (amountError.value) return false
+  return amount.value <= parseFloat(withdrawableMargin.value)
 })
+
+const validateAmount = () => {
+  if (amount.value === null) {
+    amountError.value = ''
+    return
+  }
+  if (hasInvalidPrecision(amount.value, USDC_DECIMALS[mainnet.id])) {
+    amountError.value = `Amount supports up to ${USDC_DECIMALS[mainnet.id]} decimal places`
+    return
+  }
+  if (amount.value > parseFloat(withdrawableMargin.value)) {
+    amountError.value = 'Amount exceeds available balance'
+    return
+  }
+  amountError.value = ''
+}
+
+const setMax = () => {
+  const max = parseFloat(withdrawableMargin.value)
+  amount.value = isNaN(max) ? null : max
+  validateAmount()
+}
 
 watch(
   () => props.visible,
   async visible => {
     if (!visible) return
-    amount.value = ''
+    amount.value = null
+    amountError.value = ''
     error.value = null
     withdrawalSuccess.value = false
     if (wallet.value) {
@@ -171,7 +201,7 @@ async function submitWithdraw() {
       customer_withdrawal_id: `withdraw-${Date.now()}`,
       symbol: 'USDC',
       network: 'ethereum',
-      amount: amount.value,
+      amount: String(amount.value),
       address: walletAddress.value,
       from: { id: accountId.value, wallet: 'margin' },
     })


### PR DESCRIPTION
## What was wrong

In the **Withdraw USDC** dialog, the *Amount* field was a plain text input. You could type letters into it (e.g., `abc`, `1.5x`), and there was no limit on how many decimal places you could enter. The TP/SL dialog already had a nice numeric-only input that blocks letters at the keystroke — that component was just hardcoded to a "Price" label, so it couldn't be reused elsewhere.

## What's new

- The TP/SL price input has been generalized into a reusable **PerpsAmount** component with a configurable title (default still `"Price"`, so TP/SL renders identically).
- The **Withdraw USDC** dialog now uses this component for the *Amount* field, so:
  - Letters and other non-numeric characters are blocked at the keystroke — they can no longer be typed.
  - Only one decimal point is allowed.
  - Entering more than **6** decimal places (USDC's max precision on mainnet) shows an inline error.
  - Entering an amount above the available balance shows an inline error and keeps the Withdraw button disabled.
- The **MAX** button now lives directly under the amount input, styled to match the percentage pills used elsewhere in the perps module.

## How to test

1. Open the perps Portfolio → click **Withdraw**.
2. In the *Amount* field:
   - Try typing letters (`abc`, `xyz`) → nothing should appear.
   - Try typing two decimal points (`1..5`) → the second `.` should be blocked.
   - Type `1.1234567` (7 decimals) → an error message appears: "Amount supports up to 6 decimal places".
   - Type a value larger than your available balance → "Amount exceeds available balance" appears, Withdraw button stays disabled.
   - Click **MAX** → field fills with your full available balance.
3. Open the **Auto Close (TP/SL)** dialog on a position and confirm the price inputs render and behave exactly as before — the percentage pills (+10%, +20%, etc. and -1% through -5%) should still set the price.

## Jira

https://myetherwallet.atlassian.net/browse/MEW-1670

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable input labels for perps amount fields
  * Unified amount input component used across Take Profit, Stop Loss and Withdraw dialogs
  * MAX control moved into the amount input footer for quick selection

* **Bug Fixes**
  * Stronger amount validation with precise decimal checks and clearer error messages
  * Resetting and consistent handling of amount state when dialogs open/submit
<!-- end of auto-generated comment: release notes by coderabbit.ai -->