### PR TITLE
feat: [MEW-1701] color funding rate by sign in PerpsInfo page

### DIFF
--- a/src/modules/perps/ModulePerpInfo.vue
+++ b/src/modules/perps/ModulePerpInfo.vue
@@ -162,11 +162,13 @@
               Funding Countdown
             </p>
             <p class="text-s-14 font-bold">
-              {{
-                contractData?.fundingRate
-                  ? `${(parseFloat(contractData.fundingRate) * 100).toFixed(4)}%`
-                  : '—'
-              }}
+              <span :class="pnlColor(contractData?.fundingRate || '0')">
+                {{
+                  contractData?.fundingRate
+                    ? `${(parseFloat(contractData.fundingRate) * 100).toFixed(4)}%`
+                    : '—'
+                }}
+              </span>
               <span v-if="fundingCountdown" class="text-info text-s-12">
                 in {{ fundingCountdown }}
               </span>


### PR DESCRIPTION
## What's new

On the Perpetuals Market page, the **Funding Countdown** value now shows the funding rate in green when it's positive and red when it's negative — matching how PnL and ROE are already coloured throughout the app. Zero / unavailable values stay neutral grey, and the trailing "in Xm" countdown text is still grey so it doesn't compete visually.

## How to test

1. Open the Perpetuals page and pick any market.
2. In the top stats row, look at **Funding Countdown**.
3. Confirm:
   - Positive funding rate → percentage rendered in **green** (success).
   - Negative funding rate → percentage rendered in **red** (error).
   - The "in Xm" countdown beside it stays grey.
4. Switch between several markets to see the colour flip with the sign.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Funding rate values in the Perpetuals module now display with dynamic color-based styling for enhanced visual distinction. Existing formatting calculations and countdown timing information remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->