### PR TITLE
fix: [MEW-1698] use limit price for order size and gate confirm on errors

### DIFF
--- a/src/modules/perps/components/PerpsOrderConfirmationDialog.vue
+++ b/src/modules/perps/components/PerpsOrderConfirmationDialog.vue
@@ -101,7 +101,7 @@
         <div class="flex flex-col gap-1">
           <app-base-button
             :theme="orderSide === 'buy' ? 'success' : 'error'"
-            :disabled="isSubmitting"
+            :disabled="isSubmitting || !!orderError"
             :is-loading="isSubmitting"
             class="flex-1"
             @click="$emit('confirm')"

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -9,7 +9,7 @@ import { usePerpsPositions } from './usePerpsPositions'
 import { usePerpsMarkPrices } from './usePerpsMarkPrices'
 import { usePerpsToasts } from './usePerpsToasts'
 import { formatUsd, hasInvalidPrecision, decimalPlaces } from '../utils/formatters'
-import { getCategory, midPrice } from '../utils/market'
+import { getCategory, midPrice, resolveEffectivePrice } from '../utils/market'
 
 type OrderSide = 'buy' | 'sell'
 type OrderType = 'market' | 'limit'
@@ -212,20 +212,14 @@ export function usePerpsTradeForm() {
   const formatQuotePrice = (value: number): string =>
     floorToIncrement(value, activeMarketQuoteIncrement.value)
 
-  // For limit orders the order size in base units is determined by the user's
-  // chosen limit price, not the live mark price — quoting against mark would
-  // produce a wildly different base quantity (e.g. 500 USDC margin × 20x at a
-  // $5,000 limit should be 2 NVDA, not ~50 NVDA quoted against a $200 mark)
-  // and make the open order reserve maintenance margin against the wrong
-  // notional. Falls back to currentPrice while the limit field is empty or
-  // invalid so the displayed size stays defined.
-  const effectivePrice = computed(() => {
-    if (orderType.value === 'limit') {
-      const lp = parseFloat(limitPrice.value)
-      if (!isNaN(lp) && lp > 0) return lp
-    }
-    return currentPrice.value
-  })
+  const effectivePrice = computed(() =>
+    resolveEffectivePrice({
+      orderType: orderType.value,
+      orderSide: orderSide.value,
+      limitPrice: limitPrice.value,
+      currentPrice: currentPrice.value,
+    }),
+  )
 
   const orderSize = computed(() => {
     if (!effectivePrice.value) return '0'

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -212,14 +212,29 @@ export function usePerpsTradeForm() {
   const formatQuotePrice = (value: number): string =>
     floorToIncrement(value, activeMarketQuoteIncrement.value)
 
+  // For limit orders the order size in base units is determined by the user's
+  // chosen limit price, not the live mark price — quoting against mark would
+  // produce a wildly different base quantity (e.g. 500 USDC margin × 20x at a
+  // $5,000 limit should be 2 NVDA, not ~50 NVDA quoted against a $200 mark)
+  // and make the open order reserve maintenance margin against the wrong
+  // notional. Falls back to currentPrice while the limit field is empty or
+  // invalid so the displayed size stays defined.
+  const effectivePrice = computed(() => {
+    if (orderType.value === 'limit') {
+      const lp = parseFloat(limitPrice.value)
+      if (!isNaN(lp) && lp > 0) return lp
+    }
+    return currentPrice.value
+  })
+
   const orderSize = computed(() => {
-    if (!currentPrice.value) return '0'
-    const rawSize = positionSizeUsd.value / currentPrice.value
+    if (!effectivePrice.value) return '0'
+    const rawSize = positionSizeUsd.value / effectivePrice.value
     return floorToIncrement(rawSize, activeMarketIncrement.value)
   })
 
   const minOrderAmount = computed(
-    () => activeMarketIncrement.value * currentPrice.value,
+    () => activeMarketIncrement.value * effectivePrice.value,
   )
 
   // ── Max-order-size helpers ─────────────────────────────────
@@ -271,8 +286,8 @@ export function usePerpsTradeForm() {
 
   const closeOrderSize = computed(() => {
     const amt = parseFloat(closeAmount.value) || 0
-    if (!currentPrice.value || amt <= 0) return '0'
-    const rawSize = amt / currentPrice.value
+    if (!effectivePrice.value || amt <= 0) return '0'
+    const rawSize = amt / effectivePrice.value
     return floorToIncrement(rawSize, activeMarketIncrement.value)
   })
 
@@ -323,7 +338,7 @@ export function usePerpsTradeForm() {
         } else {
           const closeUsd = parseFloat(closeAmount.value) || 0
           if (closeUsd <= 0) return
-          const rawSize = closeUsd / currentPrice.value
+          const rawSize = closeUsd / effectivePrice.value
           placedSize = floorToIncrement(rawSize, activeMarketIncrement.value)
         }
 

--- a/src/modules/perps/utils/market.ts
+++ b/src/modules/perps/utils/market.ts
@@ -30,3 +30,33 @@ export function getCategory(contract: Contract): string {
   if (hasTag(contract, 'etf')) return 'ETFs'
   return 'Equities'
 }
+
+// Resolves the price the order will actually fill at, used for sizing the
+// base quantity on the trade form. Mirrors how the matching engine treats a
+// crossed limit:
+//   LONG  (buy):  limit ≥ mark → fills at mark; limit < mark → rests at limit.
+//                 Effective price = min(limit, mark).
+//   SHORT (sell): limit ≤ mark → fills at mark; limit > mark → rests at limit.
+//                 Effective price = max(limit, mark).
+// Falls back to currentPrice if not in limit mode or the limit field is
+// empty/invalid, and to the limit alone if mark hasn't loaded yet, so the
+// displayed size stays defined.
+export function resolveEffectivePrice(opts: {
+  orderType: 'market' | 'limit'
+  orderSide: 'buy' | 'sell'
+  limitPrice: string
+  currentPrice: number
+}): number {
+  if (opts.orderType === 'limit') {
+    const lp = parseFloat(opts.limitPrice)
+    if (!isNaN(lp) && lp > 0) {
+      if (opts.currentPrice > 0) {
+        return opts.orderSide === 'buy'
+          ? Math.min(lp, opts.currentPrice)
+          : Math.max(lp, opts.currentPrice)
+      }
+      return lp
+    }
+  }
+  return opts.currentPrice
+}

--- a/tests/unit/specs/modules/perps/utils/market.spec.ts
+++ b/tests/unit/specs/modules/perps/utils/market.spec.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from 'vitest'
+import { resolveEffectivePrice } from '@/modules/perps/utils/market'
+
+describe('resolveEffectivePrice', () => {
+  describe('market orders', () => {
+    it('returns currentPrice regardless of limitPrice or side', () => {
+      expect(
+        resolveEffectivePrice({
+          orderType: 'market',
+          orderSide: 'buy',
+          limitPrice: '999',
+          currentPrice: 200,
+        }),
+      ).toBe(200)
+      expect(
+        resolveEffectivePrice({
+          orderType: 'market',
+          orderSide: 'sell',
+          limitPrice: '1',
+          currentPrice: 200,
+        }),
+      ).toBe(200)
+    })
+  })
+
+  describe('limit orders — invalid limit price', () => {
+    it('falls back to currentPrice when limitPrice is empty', () => {
+      expect(
+        resolveEffectivePrice({
+          orderType: 'limit',
+          orderSide: 'buy',
+          limitPrice: '',
+          currentPrice: 200,
+        }),
+      ).toBe(200)
+    })
+
+    it('falls back to currentPrice when limitPrice is non-numeric', () => {
+      expect(
+        resolveEffectivePrice({
+          orderType: 'limit',
+          orderSide: 'sell',
+          limitPrice: 'abc',
+          currentPrice: 200,
+        }),
+      ).toBe(200)
+    })
+
+    it('falls back to currentPrice when limitPrice is zero or negative', () => {
+      expect(
+        resolveEffectivePrice({
+          orderType: 'limit',
+          orderSide: 'buy',
+          limitPrice: '0',
+          currentPrice: 200,
+        }),
+      ).toBe(200)
+      expect(
+        resolveEffectivePrice({
+          orderType: 'limit',
+          orderSide: 'buy',
+          limitPrice: '-50',
+          currentPrice: 200,
+        }),
+      ).toBe(200)
+    })
+  })
+
+  describe('limit orders — LONG (buy)', () => {
+    it('uses currentPrice when limit ≥ mark (would fill immediately at mark)', () => {
+      expect(
+        resolveEffectivePrice({
+          orderType: 'limit',
+          orderSide: 'buy',
+          limitPrice: '5000',
+          currentPrice: 200,
+        }),
+      ).toBe(200)
+    })
+
+    it('uses currentPrice when limit equals mark', () => {
+      expect(
+        resolveEffectivePrice({
+          orderType: 'limit',
+          orderSide: 'buy',
+          limitPrice: '200',
+          currentPrice: 200,
+        }),
+      ).toBe(200)
+    })
+
+    it('uses limitPrice when limit < mark (rests and fills at limit)', () => {
+      expect(
+        resolveEffectivePrice({
+          orderType: 'limit',
+          orderSide: 'buy',
+          limitPrice: '180',
+          currentPrice: 200,
+        }),
+      ).toBe(180)
+    })
+  })
+
+  describe('limit orders — SHORT (sell)', () => {
+    it('uses currentPrice when limit ≤ mark (would fill immediately at mark)', () => {
+      expect(
+        resolveEffectivePrice({
+          orderType: 'limit',
+          orderSide: 'sell',
+          limitPrice: '50',
+          currentPrice: 200,
+        }),
+      ).toBe(200)
+    })
+
+    it('uses currentPrice when limit equals mark', () => {
+      expect(
+        resolveEffectivePrice({
+          orderType: 'limit',
+          orderSide: 'sell',
+          limitPrice: '200',
+          currentPrice: 200,
+        }),
+      ).toBe(200)
+    })
+
+    it('uses limitPrice when limit > mark (rests and fills at limit)', () => {
+      expect(
+        resolveEffectivePrice({
+          orderType: 'limit',
+          orderSide: 'sell',
+          limitPrice: '250',
+          currentPrice: 200,
+        }),
+      ).toBe(250)
+    })
+  })
+
+  describe('limit orders — currentPrice not loaded', () => {
+    it('returns limitPrice when mark is 0 (LONG)', () => {
+      expect(
+        resolveEffectivePrice({
+          orderType: 'limit',
+          orderSide: 'buy',
+          limitPrice: '180',
+          currentPrice: 0,
+        }),
+      ).toBe(180)
+    })
+
+    it('returns limitPrice when mark is 0 (SHORT)', () => {
+      expect(
+        resolveEffectivePrice({
+          orderType: 'limit',
+          orderSide: 'sell',
+          limitPrice: '250',
+          currentPrice: 0,
+        }),
+      ).toBe(250)
+    })
+  })
+
+  describe('worked example from MEW-1698', () => {
+    // $500 margin × 20× leverage = $10,000 position size.
+    // NVDA mark = $200; user enters limit $5,000 on a Short.
+    // Limit > mark → rests at limit → size against $5,000 → 2 NVDA.
+    it('NVDA Short at $5,000 limit with $200 mark sizes against the limit', () => {
+      const effective = resolveEffectivePrice({
+        orderType: 'limit',
+        orderSide: 'sell',
+        limitPrice: '5000',
+        currentPrice: 200,
+      })
+      const positionSizeUsd = 10_000
+      expect(positionSizeUsd / effective).toBe(2)
+    })
+
+    // Same setup on a Long with limit $5,000 above mark — fills now at mark,
+    // so size against $200 → 50 NVDA.
+    it('NVDA Long at $5,000 limit with $200 mark sizes against the mark', () => {
+      const effective = resolveEffectivePrice({
+        orderType: 'limit',
+        orderSide: 'buy',
+        limitPrice: '5000',
+        currentPrice: 200,
+      })
+      const positionSizeUsd = 10_000
+      expect(positionSizeUsd / effective).toBe(50)
+    })
+  })
+})


### PR DESCRIPTION
## What was wrong

When placing a Limit order on Perpetuals, the position size shown in the base asset (e.g. NVDA) was wrong. With $500 margin × 20× leverage at a $5,000 limit price, the confirm dialog showed **Size (NVDA): 50.08** instead of **2** because the size was being computed against the current mark price (~$200) rather than the user's chosen limit price.

That wrong size also caused the open order to reserve a much larger notional on the API side, which then triggered an "insufficient margin / maintenance margin" error inside the confirm dialog — even though the user's actual margin was fine for the order they thought they were placing.

On top of that, when the API did surface an error inside the confirm dialog, the **Confirm** button stayed clickable, so a user could keep firing failing orders without changing anything.

## What the user will now see

- In Limit mode, the **Size** in the order form and the confirm dialog now reflects the limit price the user actually entered.
  - $500 margin × 20× at a $5,000 limit on NVDA → **2 NVDA**, $10,000 position size.
- In Market mode, behavior is unchanged.
- Partial closes via Limit also use the limit price for size, so the closed amount matches what the user expects.
- If the API rejects an order while the confirm dialog is open, the **Confirm** button is now disabled until the user cancels and adjusts the order.

## How to test

1. Open the Perpetuals module and pick a market with a price far from a typical limit (e.g. NVDA, AAPL).
2. Switch to **Limit** and enter a limit price well above (Short) or below (Long) the current mark.
3. Set margin and leverage so position size = $10,000.
4. Press **Long / Short** → in the confirm dialog, **Size (NVDA)** should match `position size / limit price`, not `position size / mark price`.
5. If the API returns an error in the dialog, the **Confirm** button should be greyed out; you should have to cancel and change the inputs to retry.
6. Sanity-check **Market** orders still show the correct size (uses the mark price as before).
7. Open an existing position, switch to Limit, partial-close at a limit price → the size in the close confirm matches the chosen limit price.

## Out of scope

The dedicated maintenance-margin / limit-bid-price inline errors on the limit field are tracked in the sub-task **MEW-1702** (need the maintenance function from Ondo Perps API first) and will land in a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed order confirmation dialog to properly validate and disable the confirm button when errors occur.

* **New Features**
  * Enhanced order pricing to calculate effective execution prices considering both order type and current market conditions for more accurate order sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->