### PR TITLE
fix: [MEW-1703] clean up leverage tag placement next to asset name

### DIFF
--- a/src/modules/perps/components/PerpsSelectMarketDialog.vue
+++ b/src/modules/perps/components/PerpsSelectMarketDialog.vue
@@ -102,12 +102,12 @@
                   class="shrink-0 mr-4"
                 />
                 <div class="text-left">
-                  <div class="flex items-center gap-2 relative">
-                    <span class="font-bold text-s-15">{{
+                  <div class="flex items-center gap-2">
+                    <span class="font-bold text-s-15 whitespace-nowrap">{{
                       contract.baseCurrency
                     }}</span>
                     <span
-                      class="absolute -right-5 bg-surface text-info font-bold rounded px-[6px] py-[1px] text-s-9"
+                      class="shrink-0 bg-surface text-info font-bold rounded px-[6px] py-[1px] text-s-9"
                       >20x</span
                     >
                   </div>


### PR DESCRIPTION
## What was wrong

In the **Select Perps Market** dialog, the small "20x" leverage pill next to each asset symbol was floating on top of the symbol text. On longer tickers like `NVDA`, `INTC`, `NFLX`, and `US500`, the pill visually clipped the last character of the symbol (e.g. `NVDA` looked like `NVD`).

## What you'll see now

The leverage pill now sits cleanly to the right of the asset symbol with proper spacing, never overlapping. Long symbols are no longer clipped.

## How to test

1. Open the Perps trading screen.
2. Tap the asset selector to open the **Select Perps Market** dialog.
3. Scroll the market list and check rows like `NVDA`, `CRCL`, `INTC`, `NFLX`, `US500` — the full symbol should be visible with the `20x` pill placed beside it.
4. Confirm visual parity with the main Perps Market List (which already used this layout).

## Notes

- One file touched: `src/modules/perps/components/PerpsSelectMarketDialog.vue`.
- No behavior or data changes — purely a layout fix that mirrors the pattern already used in `PerpsMarketList.vue`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the display layout for market base currency information, improving visual consistency and readability in market selection dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->