### PR TITLE
feat: ✨ if has watch only, auto request sign on perps page

### DIFF
--- a/src/views/ViewPerps.vue
+++ b/src/views/ViewPerps.vue
@@ -100,7 +100,7 @@ const connectWallet = () => accessStore.openAccessDialog()
 watch(
   () => wallet.value,
   (newVal, oldVal) => {
-    if (newVal && !isWatchOnly.value && oldVal) {
+    if (newVal && oldVal && !isWatchOnly.value && !isAuthenticating.value) {
       login()
     }
   },

--- a/src/views/ViewPerps.vue
+++ b/src/views/ViewPerps.vue
@@ -71,7 +71,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { storeToRefs } from 'pinia'
 import { PERP_INFO_ROUTE_NAME } from '@/router/routeNames'
@@ -90,12 +90,21 @@ import { useAppBreakpoints } from '@/composables/useAppBreakpoints'
 const router = useRouter()
 const walletMenu = useWalletMenuStore()
 const walletStore = useWalletStore()
-const { isWatchOnly } = storeToRefs(walletStore)
+const { isWatchOnly, wallet } = storeToRefs(walletStore)
 const accessStore = useAccessStore()
 const { token, isWalletConnected, isAuthenticating, authError, login, logout } =
   usePerpsAuth()
 const { isDesktopAndUp } = useAppBreakpoints()
 const connectWallet = () => accessStore.openAccessDialog()
+
+watch(
+  () => wallet.value,
+  (newVal, oldVal) => {
+    if (newVal && !isWatchOnly.value && oldVal) {
+      login()
+    }
+  },
+)
 const showDeposit = ref(false)
 const showWithdraw = ref(false)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic login when a wallet becomes connected (excluding watch-only mode). This creates a smoother connection flow by triggering login upon wallet connection while preserving the existing authentication flow and UI behavior; the change is a minimal, opt-in side effect that avoids altering current manual login steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->