### PR TITLE
feat: [MEW-1667] hide all-time volume row in perpetuals portfolio dialog

### DIFF
--- a/src/modules/perps/components/PerpsBalanceDetailsDialog.vue
+++ b/src/modules/perps/components/PerpsBalanceDetailsDialog.vue
@@ -97,6 +97,5 @@ const balanceRows = computed(() => [
   { label: 'Total Trading Fees', value: fmt(balance.value?.totalTradingFees) },
   { label: 'Volume (7d)', value: fmt(summary.value?.volume7d) },
   { label: 'Volume (30d)', value: fmt(summary.value?.volume30d) },
-  { label: 'Volume (All Time)', value: fmt(summary.value?.volumeAllTime) },
 ])
 </script>


### PR DESCRIPTION
## What's changing

Per design feedback, the **Perpetuals Portfolio** balance details dialog no longer shows the **Volume (All Time)** row.

## What you'll see now

When you open the **Perpetuals Portfolio** dialog from the Perps wallet balance card, the volume section now only shows:

- Volume (7d)
- Volume (30d)

The **Volume (All Time)** row has been removed.

## How to test

1. Open the Perps module while connected with a wallet that has trade history.
2. Click **View More** on the Perpetuals wallet balance card to open the **Perpetuals Portfolio** dialog.
3. Scroll the rows — confirm Volume (7d) and Volume (30d) are still listed and **Volume (All Time) is gone**.
4. Sanity-check the rest of the rows (Used Margin, Margin Ratio, Leverage, Unrealized PnL, Realized PnL, Total Funding Payments, Total Trading Fees) are unchanged.

## Notes

- One file touched: `src/modules/perps/components/PerpsBalanceDetailsDialog.vue`.
- The underlying `volumeAllTime` field is still present in the API response type (`sdk/types.ts`) — only the UI row was removed; no API/data changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Perpetuals balance details have been updated with new trading metrics. Total Trading Fees is now visible along with Volume data for 7-day and 30-day periods to track activity across different timeframes.
  * The All-Time volume metric has been removed from perpetuals balance details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->