### PR TITLE
feat: [MEW-1691] paginate orders and deposits/withdrawals tables

### DIFF
--- a/src/modules/perps/components/PerpsPositionsTable.vue
+++ b/src/modules/perps/components/PerpsPositionsTable.vue
@@ -273,13 +273,13 @@
           :columns="ordersSkeletonColumns"
         />
         <div
-          v-else-if="filteredOrders.length === 0"
+          v-else-if="filteredOrders.length === 0 && ordersCurrentPage === 0"
           class="text-center py-8 text-info text-s-14"
         >
           No orders
         </div>
 
-        <table v-else class="w-full text-s-14 table-fixed">
+        <table v-else ref="ordersTable" class="w-full text-s-14 table-fixed">
           <thead>
             <tr
               class="text-left text-s-11 uppercase text-info tracking-sp-06 font-bold"
@@ -454,6 +454,20 @@
             </tr>
           </tbody>
         </table>
+        <div
+          v-if="ordersHasPrev || ordersHasNext"
+          class="flex justify-end mt-4 px-2"
+        >
+          <perps-pagination
+            :current-page="ordersCurrentPage"
+            :has-prev="ordersHasPrev"
+            :has-next="ordersHasNext"
+            :disabled="ordersLoading"
+            :scroll-target="ordersTable"
+            @prev="ordersPrevPage"
+            @next="ordersNextPage"
+          />
+        </div>
       </template>
 
       <!-- Fills tab -->
@@ -610,7 +624,7 @@
           No deposits or withdrawals
         </div>
         <div v-else class="overflow-x-auto">
-          <table class="w-full text-s-14 table-fixed">
+          <table ref="dwTable" class="w-full text-s-14 table-fixed">
             <thead>
               <tr
                 class="text-left text-s-11 uppercase text-info tracking-sp-06 font-bold"
@@ -637,7 +651,7 @@
               </tr>
             </thead>
             <tbody>
-              <tr v-for="item in combinedDW" :key="item.key" class="">
+              <tr v-for="item in paginatedDW" :key="item.key" class="">
                 <!-- Type -->
                 <td class="px-1 sm:pl-4 py-3 rounded-l-12 hidden xs:table-cell">
                   <span
@@ -706,6 +720,19 @@
               </tr>
             </tbody>
           </table>
+          <div
+            v-if="dwTotalPages > 1"
+            class="flex justify-end mt-4 px-2"
+          >
+            <perps-pagination
+              :current-page="dwCurrentPage"
+              :total-pages="dwTotalPages"
+              :disabled="dwLoading"
+              :scroll-target="dwTable"
+              @prev="dwPrevPage"
+              @next="dwNextPage"
+            />
+          </div>
         </div>
       </template>
     </app-sheet>
@@ -780,6 +807,8 @@ defineEmits<{
 
 const positionsTable = ref<HTMLElement | null>(null)
 const fillsTable = ref<HTMLElement | null>(null)
+const ordersTable = ref<HTMLElement | null>(null)
+const dwTable = ref<HTMLElement | null>(null)
 
 const positionsSkeletonColumns: SkeletonColumn[] = [
   { header: 'Market' },
@@ -852,6 +881,11 @@ const {
   orders,
   loading: ordersLoading,
   refetch: refetchOrders,
+  currentPage: ordersCurrentPage,
+  hasPrev: ordersHasPrev,
+  hasNext: ordersHasNext,
+  nextPage: ordersNextPage,
+  prevPage: ordersPrevPage,
 } = usePerpsOrders()
 
 const showCancelButton = (order: ApiOrder) => {
@@ -916,17 +950,19 @@ async function cancelOrder(order: ApiOrder) {
   }
 }
 
-const combinedDW = computed(() => {
-  const items: Array<{
-    key: string
-    type: string
-    coin: string
-    size: string
-    usdValue?: string
-    statusLabel: string
-    statusColor: string
-    time: string
-  }> = []
+type CombinedDWRow = {
+  key: string
+  type: string
+  coin: string
+  size: string
+  usdValue?: string
+  statusLabel: string
+  statusColor: string
+  time: string
+}
+
+const combinedDW = computed<CombinedDWRow[]>(() => {
+  const items: CombinedDWRow[] = []
   for (const d of deposits.value) {
     items.push({
       key: `d-${d.txid ?? d.time}`,
@@ -964,6 +1000,14 @@ const combinedDW = computed(() => {
   items.sort((a, b) => new Date(b.time).getTime() - new Date(a.time).getTime())
   return items
 })
+
+const {
+  currentPage: dwCurrentPage,
+  paginatedArray: paginatedDW,
+  totalPages: dwTotalPages,
+  nextPage: dwNextPage,
+  prevPage: dwPrevPage,
+} = usePaginate<CombinedDWRow>(combinedDW, PERPS_PAGE_SIZE)
 
 const tabs = [
   { label: 'Positions', value: 'positions' },

--- a/src/modules/perps/composables/useCursorPaginate.ts
+++ b/src/modules/perps/composables/useCursorPaginate.ts
@@ -33,12 +33,13 @@ export function useCursorPaginate<T>(
     }
   }
 
-  async function refetch() {
+  async function refetch(): Promise<boolean> {
     const ok = await fetchPage(undefined)
     if (ok) {
       cursorStack.value = [undefined]
       currentPage.value = 0
     }
+    return ok
   }
 
   async function nextPage() {

--- a/src/modules/perps/composables/usePerpsHistory.ts
+++ b/src/modules/perps/composables/usePerpsHistory.ts
@@ -105,8 +105,8 @@ export function usePerpsOrders() {
     if (pagination.currentPage.value !== 0) return
     isRefreshing = true
     try {
-      await pagination.refetch()
-      if (pagination.currentPage.value === 0) {
+      const ok = await pagination.refetch()
+      if (ok && pagination.currentPage.value === 0) {
         detectFillsAndToast(pagination.items.value)
       }
     } finally {
@@ -129,8 +129,8 @@ export function usePerpsOrders() {
     pagination.reset()
     if (token.value) {
       void (async () => {
-        await pagination.refetch()
-        detectFillsAndToast(pagination.items.value)
+        const ok = await pagination.refetch()
+        if (ok) detectFillsAndToast(pagination.items.value)
       })()
       pollTimer = setInterval(refreshFirstPageIfActive, 10_000)
     } else {

--- a/src/modules/perps/composables/usePerpsHistory.ts
+++ b/src/modules/perps/composables/usePerpsHistory.ts
@@ -20,19 +20,22 @@ export function usePerpsOrders() {
   const { token, refreshKey } = usePerpsAuth()
   const { markets } = usePerpsMarkets()
   const perpsToasts = usePerpsToasts()
-  const orders = ref<ApiOrder[]>([])
-  const loading = ref(false)
+  const pagination = useCursorPaginate<ApiOrder>(
+    opts => perpsClient.getOrders(opts),
+    PERPS_PAGE_SIZE,
+  )
   // Snapshot keyed by orderId — used to diff filledSize between polls so we
   // can fire Order Filled / Order Partially Filled exactly on the transition.
   // First poll after login seeds the snapshot without firing toasts to avoid
   // re-announcing orders that already had fills before the user opened the page.
+  // With cursor pagination, fill detection only runs while the user is on
+  // page 0; fills on orders that have scrolled past page 0 won't toast — same
+  // trade-off the Fills tab already accepts.
   let prevOrdersById = new Map<string, OrderSnapshot>()
   let isSeedFetch = true
   let lastToken: string | null | undefined = undefined
-  // Monotonic sequence so an out-of-order in-flight response doesn't roll the
-  // diff snapshot backward and replay or drop fill toasts.
-  let fetchSeq = 0
   let pollTimer: ReturnType<typeof setInterval> | null = null
+  let isRefreshing = false
 
   function resolveDisplayMarket(market: string): string {
     const m = markets.value.find(x => x.market === market)
@@ -96,24 +99,18 @@ export function usePerpsOrders() {
     )
   }
 
-  async function fetchOrders() {
-    if (!token.value) {
-      orders.value = []
-      return
-    }
-    const seq = ++fetchSeq
-    loading.value = true
+  async function refreshFirstPageIfActive() {
+    if (isRefreshing) return
+    if (pagination.loading.value) return
+    if (pagination.currentPage.value !== 0) return
+    isRefreshing = true
     try {
-      const res = await perpsClient.getOrders({ limit: 100 })
-      if (seq !== fetchSeq) return
-      const next = res.result ?? []
-      detectFillsAndToast(next)
-      orders.value = next
-    } catch {
-      if (seq !== fetchSeq) return
-      orders.value = []
+      await pagination.refetch()
+      if (pagination.currentPage.value === 0) {
+        detectFillsAndToast(pagination.items.value)
+      }
     } finally {
-      if (seq === fetchSeq) loading.value = false
+      isRefreshing = false
     }
   }
 
@@ -129,11 +126,14 @@ export function usePerpsOrders() {
       isSeedFetch = true
       lastToken = token.value
     }
+    pagination.reset()
     if (token.value) {
-      fetchOrders()
-      pollTimer = setInterval(fetchOrders, 10_000)
+      void (async () => {
+        await pagination.refetch()
+        detectFillsAndToast(pagination.items.value)
+      })()
+      pollTimer = setInterval(refreshFirstPageIfActive, 10_000)
     } else {
-      orders.value = []
       pollTimer = null
     }
   })
@@ -142,7 +142,16 @@ export function usePerpsOrders() {
     if (pollTimer) clearInterval(pollTimer)
   })
 
-  return { orders, loading, refetch: fetchOrders }
+  return {
+    orders: pagination.items,
+    loading: pagination.loading,
+    refetch: pagination.refetch,
+    currentPage: pagination.currentPage,
+    hasNext: pagination.hasNext,
+    hasPrev: pagination.hasPrev,
+    nextPage: pagination.nextPage,
+    prevPage: pagination.prevPage,
+  }
 }
 
 export function usePerpsFills() {


### PR DESCRIPTION
## What's changing
The **Orders** and **Deposits & Withdrawals** tabs in the Perpetuals trading view now show a maximum of 10 rows per page with prev/next pagination, matching the existing Fills and Positions tabs.

## What you'll see now
- **Orders tab** — Up to 10 orders per page. Prev/Next chevrons appear once you have more than 10 orders. The "Pending" filter applies to the current page.
- **Deposits & Withdrawals tab** — Up to 10 combined entries per page, sorted across both lists by time. A "Page X of N" indicator shows on the right.
- Existing Order Filled / Order Partially Filled toasts continue to fire while you're on page 1, which is where new fills will land first.

## How to test
1. Open the Perpetuals trading view as an authenticated user with more than 10 orders and more than 10 wallet entries (deposits + withdrawals).
2. Switch to the **Orders** tab — verify exactly 10 rows render and the pagination control appears at the bottom right. Click Next/Prev and confirm the rows change.
3. Place a new order while sitting on page 1; verify the existing fill toast still fires once it fills.
4. Switch to **Deposits & Withdrawals** — verify max 10 rows, "Page X of N" indicator, and that the items remain sorted by time across deposits + withdrawals.
5. Switch tabs back and forth — pagination state should reset cleanly on auth changes (sign out / sign in).

## Notes
- Orders use server-side cursor pagination (`getOrders({ limit, cursor })`), mirroring the Fills tab — polling continues every 10s but only refreshes page 0 to avoid disrupting the user's scroll position.
- Deposits & Withdrawals use client-side pagination (`usePaginate`) over the merged list because `/v1/wallet/deposits` and `/v1/wallet/withdrawals` don't expose cursor params.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-tab pagination added for Orders and Deposits/Withdrawals in the Perps history view
  * Cursor-based pagination backend for more efficient data loading
  * Separate paginated view for combined Deposits/Withdrawals

* **UX Improvements**
  * Automatic refresh of first page with fill notifications when visible
  * Improved empty-state messaging and anchored scrolling for paginated tables
<!-- end of auto-generated comment: release notes by coderabbit.ai -->