### PR TITLE
feat: [MEW-1714] paginate perps info orders/fills tables and add open-orders count badges

### DIFF
--- a/src/modules/perps/ModulePerpInfo.vue
+++ b/src/modules/perps/ModulePerpInfo.vue
@@ -873,7 +873,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, watchEffect, onUnmounted } from 'vue'
+import { ref, computed, watch, onUnmounted } from 'vue'
 import AppBtnIcon from '@/components/AppBtnIcon.vue'
 import AppBtnGroup from '@/components/AppBtnGroup.vue'
 import AppPopUpMenu from '@/components/AppPopUpMenu.vue'
@@ -1063,8 +1063,9 @@ async function fetchOpenOrdersCount() {
   }
   // Snapshot context so a slow response from a previous market or auth
   // session can't overwrite the badge after the user has switched markets
-  // or logged out. The token guard covers logout, where watchEffect clears
-  // values but doesn't kick off a new fetch (and so doesn't bump the seq).
+  // or logged out. The token guard covers logout, where the auth/market
+  // watcher clears values but doesn't kick off a new fetch (so doesn't
+  // bump the seq).
   const seq = ++openOrdersFetchSeq
   const market = props.market
   const startToken = token.value
@@ -1080,11 +1081,14 @@ async function fetchOpenOrdersCount() {
     )
       return
     const list = res.result ?? []
-    openOrdersCountForMarket.value = list.filter(o =>
+    // Cap on the pending count, not list.length — the fetch returns all order
+    // statuses, so 50 fetched with only 5 pending must not render as "5 · 50+".
+    const pendingCount = list.filter(o =>
       PENDING_STATUSES.has(o.status),
     ).length
+    openOrdersCountForMarket.value = pendingCount
     openOrdersCountIsCapped.value =
-      !!res.pageInfo?.nextCursor && list.length >= OPEN_COUNT_LIMIT
+      !!res.pageInfo?.nextCursor && pendingCount >= OPEN_COUNT_LIMIT
   } catch {
     if (
       seq !== openOrdersFetchSeq ||
@@ -1186,7 +1190,7 @@ async function refreshOrdersPageZero() {
   if (ordersCurrentPage.value !== 0) return
   ordersIsRefreshing = true
   try {
-    await Promise.all([ordersPagination.refetch(), fetchOpenOrdersCount()])
+    await ordersPagination.refetch()
   } finally {
     ordersIsRefreshing = false
   }
@@ -1204,26 +1208,39 @@ async function refreshFillsPageZero() {
   }
 }
 
-watchEffect(() => {
-  void refreshKey.value
-  void props.market
-  if (ordersPollTimer) clearInterval(ordersPollTimer)
-  if (fillsPollTimer) clearInterval(fillsPollTimer)
-  ordersPagination.reset()
-  fillsPagination.reset()
-  openOrdersCountForMarket.value = 0
-  openOrdersCountIsCapped.value = false
-  if (token.value) {
-    void (async () => {
-      await Promise.all([ordersPagination.refetch(), fetchOpenOrdersCount()])
-    })()
+// Hard reset only on auth or market change — those genuinely invalidate the
+// current view. triggerRefresh() (place/cancel/close) bumps refreshKey but
+// must not yank the user back to page 0; that mutation-driven path falls
+// through to the in-place refetch below.
+watch(
+  [token, () => props.market],
+  () => {
+    if (ordersPollTimer) clearInterval(ordersPollTimer)
+    if (fillsPollTimer) clearInterval(fillsPollTimer)
+    ordersPagination.reset()
+    fillsPagination.reset()
+    openOrdersCountForMarket.value = 0
+    openOrdersCountIsCapped.value = false
+    if (!token.value) return
+    void ordersPagination.refetch()
     void fillsPagination.refetch()
-    ordersPollTimer = setInterval(refreshOrdersPageZero, 10_000)
+    void fetchOpenOrdersCount()
+    ordersPollTimer = setInterval(() => {
+      void refreshOrdersPageZero()
+      void fetchOpenOrdersCount()
+    }, 10_000)
     fillsPollTimer = setInterval(refreshFillsPageZero, 10_000)
-  } else {
-    ordersPollTimer = null
-    fillsPollTimer = null
-  }
+  },
+  { immediate: true },
+)
+
+// Post-mutation refresh: refetch first page in place if visible, and update
+// the badge regardless of which page the user is on.
+watch(refreshKey, () => {
+  if (!token.value) return
+  void refreshOrdersPageZero()
+  void refreshFillsPageZero()
+  void fetchOpenOrdersCount()
 })
 
 // Funding countdown timer

--- a/src/modules/perps/ModulePerpInfo.vue
+++ b/src/modules/perps/ModulePerpInfo.vue
@@ -1061,16 +1061,24 @@ async function fetchOpenOrdersCount() {
     openOrdersCountIsCapped.value = false
     return
   }
-  // Snapshot context so a slow response from a previous market can't overwrite
-  // the badge after the user has switched markets.
+  // Snapshot context so a slow response from a previous market or auth
+  // session can't overwrite the badge after the user has switched markets
+  // or logged out. The token guard covers logout, where watchEffect clears
+  // values but doesn't kick off a new fetch (and so doesn't bump the seq).
   const seq = ++openOrdersFetchSeq
   const market = props.market
+  const startToken = token.value
   try {
     const res = await perpsClient.getOrders({
       market,
       limit: OPEN_COUNT_LIMIT,
     })
-    if (seq !== openOrdersFetchSeq || market !== props.market) return
+    if (
+      seq !== openOrdersFetchSeq ||
+      market !== props.market ||
+      startToken !== token.value
+    )
+      return
     const list = res.result ?? []
     openOrdersCountForMarket.value = list.filter(o =>
       PENDING_STATUSES.has(o.status),
@@ -1078,7 +1086,12 @@ async function fetchOpenOrdersCount() {
     openOrdersCountIsCapped.value =
       !!res.pageInfo?.nextCursor && list.length >= OPEN_COUNT_LIMIT
   } catch {
-    if (seq !== openOrdersFetchSeq || market !== props.market) return
+    if (
+      seq !== openOrdersFetchSeq ||
+      market !== props.market ||
+      startToken !== token.value
+    )
+      return
     openOrdersCountForMarket.value = 0
     openOrdersCountIsCapped.value = false
   }

--- a/src/modules/perps/ModulePerpInfo.vue
+++ b/src/modules/perps/ModulePerpInfo.vue
@@ -413,10 +413,8 @@
               <span>
                 {{ data.label }}
                 <span
-                  v-if="
-                    data.value === 'orders' && openOrdersCountForMarket > 0
-                  "
-                  class="ml-1 text-info"
+                  v-if="data.value === 'orders' && openOrdersCountForMarket > 0"
+                  class="ml-1 text-info text-s-12"
                 >
                   ·
                   {{
@@ -450,7 +448,7 @@
                         activeInfoTab === 'orders' &&
                         openOrdersCountForMarket > 0
                       "
-                      class="ml-1 text-info"
+                      class="ml-1 text-info text-s-12"
                     >
                       ·
                       {{
@@ -479,9 +477,7 @@
               :columns="ordersSkeletonColumns"
             />
             <div
-              v-else-if="
-                marketOrders.length === 0 && ordersCurrentPage === 0
-              "
+              v-else-if="marketOrders.length === 0 && ordersCurrentPage === 0"
               class="text-center py-8 text-info text-s-14"
             >
               No orders for {{ baseCurrency }}
@@ -1083,9 +1079,7 @@ async function fetchOpenOrdersCount() {
     const list = res.result ?? []
     // Cap on the pending count, not list.length — the fetch returns all order
     // statuses, so 50 fetched with only 5 pending must not render as "5 · 50+".
-    const pendingCount = list.filter(o =>
-      PENDING_STATUSES.has(o.status),
-    ).length
+    const pendingCount = list.filter(o => PENDING_STATUSES.has(o.status)).length
     openOrdersCountForMarket.value = pendingCount
     openOrdersCountIsCapped.value =
       !!res.pageInfo?.nextCursor && pendingCount >= OPEN_COUNT_LIMIT

--- a/src/modules/perps/ModulePerpInfo.vue
+++ b/src/modules/perps/ModulePerpInfo.vue
@@ -418,8 +418,12 @@
                   "
                   class="ml-1 text-info"
                 >
-                  · {{ openOrdersCountForMarket
-                  }}{{ openOrdersCountIsCapped ? '+' : '' }}
+                  ·
+                  {{
+                    openOrdersCountIsCapped
+                      ? `${OPEN_COUNT_LIMIT}+`
+                      : openOrdersCountForMarket
+                  }}
                 </span>
               </span>
             </template>
@@ -439,9 +443,23 @@
                 @click="toggleSelect"
               >
                 <div class="flex items-center justify-between">
-                  <span class="text-s-16 font-medium">{{
-                    activeInfoTabObj.label
-                  }}</span>
+                  <span class="text-s-16 font-medium">
+                    {{ activeInfoTabObj.label }}
+                    <span
+                      v-if="
+                        activeInfoTab === 'orders' &&
+                        openOrdersCountForMarket > 0
+                      "
+                      class="ml-1 text-info"
+                    >
+                      ·
+                      {{
+                        openOrdersCountIsCapped
+                          ? `${OPEN_COUNT_LIMIT}+`
+                          : openOrdersCountForMarket
+                      }}
+                    </span>
+                  </span>
                   <chevron-down-icon class="w-4 h-4 ml-1" />
                 </div>
               </button>
@@ -1035,6 +1053,7 @@ const OPEN_COUNT_LIMIT = 50
 const PENDING_STATUSES = new Set(['pending', 'untriggered', 'open'])
 const openOrdersCountForMarket = ref(0)
 const openOrdersCountIsCapped = ref(false)
+let openOrdersFetchSeq = 0
 
 async function fetchOpenOrdersCount() {
   if (!token.value) {
@@ -1042,11 +1061,16 @@ async function fetchOpenOrdersCount() {
     openOrdersCountIsCapped.value = false
     return
   }
+  // Snapshot context so a slow response from a previous market can't overwrite
+  // the badge after the user has switched markets.
+  const seq = ++openOrdersFetchSeq
+  const market = props.market
   try {
     const res = await perpsClient.getOrders({
-      market: props.market,
+      market,
       limit: OPEN_COUNT_LIMIT,
     })
+    if (seq !== openOrdersFetchSeq || market !== props.market) return
     const list = res.result ?? []
     openOrdersCountForMarket.value = list.filter(o =>
       PENDING_STATUSES.has(o.status),
@@ -1054,6 +1078,7 @@ async function fetchOpenOrdersCount() {
     openOrdersCountIsCapped.value =
       !!res.pageInfo?.nextCursor && list.length >= OPEN_COUNT_LIMIT
   } catch {
+    if (seq !== openOrdersFetchSeq || market !== props.market) return
     openOrdersCountForMarket.value = 0
     openOrdersCountIsCapped.value = false
   }

--- a/src/modules/perps/ModulePerpInfo.vue
+++ b/src/modules/perps/ModulePerpInfo.vue
@@ -410,7 +410,18 @@
             class="ml-2"
           >
             <template #btn-content="{ data }">
-              {{ data.label }}
+              <span>
+                {{ data.label }}
+                <span
+                  v-if="
+                    data.value === 'orders' && openOrdersCountForMarket > 0
+                  "
+                  class="ml-1 text-info"
+                >
+                  · {{ openOrdersCountForMarket
+                  }}{{ openOrdersCountIsCapped ? '+' : '' }}
+                </span>
+              </span>
             </template>
           </app-btn-group>
         </div>
@@ -450,12 +461,18 @@
               :columns="ordersSkeletonColumns"
             />
             <div
-              v-else-if="marketOrders.length === 0"
+              v-else-if="
+                marketOrders.length === 0 && ordersCurrentPage === 0
+              "
               class="text-center py-8 text-info text-s-14"
             >
               No orders for {{ baseCurrency }}
             </div>
-            <table v-else class="w-full text-s-14 table-fixed">
+            <table
+              v-else
+              ref="ordersTable"
+              class="w-full text-s-14 table-fixed"
+            >
               <thead>
                 <tr
                   class="text-left text-s-11 uppercase text-info tracking-sp-06 font-bold border-b border-grey-10"
@@ -625,6 +642,20 @@
                 </tr>
               </tbody>
             </table>
+            <div
+              v-if="ordersHasPrev || ordersHasNext"
+              class="flex justify-end mt-4 px-2"
+            >
+              <perps-pagination
+                :current-page="ordersCurrentPage"
+                :has-prev="ordersHasPrev"
+                :has-next="ordersHasNext"
+                :disabled="ordersLoading"
+                :scroll-target="ordersTable"
+                @prev="ordersPrevPage"
+                @next="ordersNextPage"
+              />
+            </div>
           </div>
           <!--Fills tab -->
           <div
@@ -638,13 +669,13 @@
               :columns="fillsSkeletonColumns"
             />
             <div
-              v-else-if="marketFills.length === 0"
+              v-else-if="marketFills.length === 0 && fillsCurrentPage === 0"
               class="text-center py-6 text-info text-s-14"
             >
               No fills for {{ baseCurrency }}
             </div>
             <div v-else class="w-full">
-              <table class="w-full text-s-14 table-fixed">
+              <table ref="fillsTable" class="w-full text-s-14 table-fixed">
                 <thead>
                   <tr
                     class="text-left text-s-11 uppercase text-info tracking-sp-06 font-bold border-b border-grey-10"
@@ -729,6 +760,20 @@
                   </tr>
                 </tbody>
               </table>
+              <div
+                v-if="fillsHasPrev || fillsHasNext"
+                class="flex justify-end mt-4 px-2"
+              >
+                <perps-pagination
+                  :current-page="fillsCurrentPage"
+                  :has-prev="fillsHasPrev"
+                  :has-next="fillsHasNext"
+                  :disabled="fillsLoading"
+                  :scroll-target="fillsTable"
+                  @prev="fillsPrevPage"
+                  @next="fillsNextPage"
+                />
+              </div>
             </div>
           </div>
         </transition>
@@ -810,7 +855,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, onUnmounted } from 'vue'
+import { ref, computed, watch, watchEffect, onUnmounted } from 'vue'
 import AppBtnIcon from '@/components/AppBtnIcon.vue'
 import AppBtnGroup from '@/components/AppBtnGroup.vue'
 import AppPopUpMenu from '@/components/AppPopUpMenu.vue'
@@ -820,6 +865,7 @@ import AppTableSkeleton, {
 } from '@/components/AppTableSkeleton.vue'
 import PerpsOrderDialog from './components/PerpsOrderDialog.vue'
 import PerpsFillDetailsDialog from './components/PerpsFillDetailsDialog.vue'
+import PerpsPagination from './components/PerpsPagination.vue'
 import { EllipsisVerticalIcon, ChevronRightIcon } from '@heroicons/vue/24/solid'
 import AppTokenLogo from '@/components/AppTokenLogo.vue'
 import AppBtnText from '@/components/AppBtnText.vue'
@@ -830,7 +876,8 @@ import {
   ArrowTrendingUpIcon,
   ChevronDownIcon,
 } from '@heroicons/vue/24/outline'
-import { perpsClient } from './configs'
+import { perpsClient, PERPS_INFO_PAGE_SIZE } from './configs'
+import { useCursorPaginate } from './composables/useCursorPaginate'
 import {
   usePerpsMarkets,
   usePerpsContracts,
@@ -949,11 +996,68 @@ const markPrice = computed(() => {
   return mp?.price
 })
 
-// Orders and fills for this market
-const marketOrders = ref<ApiOrder[]>([])
-const marketFills = ref<ApiFill[]>([])
-const ordersLoading = ref(false)
-const fillsLoading = ref(false)
+// Cursor-paginated orders & fills for this market (page size 5).
+const ordersTable = ref<HTMLElement | null>(null)
+const fillsTable = ref<HTMLElement | null>(null)
+
+const ordersPagination = useCursorPaginate<ApiOrder>(
+  opts => perpsClient.getOrders({ ...opts, market: props.market }),
+  PERPS_INFO_PAGE_SIZE,
+)
+const {
+  items: marketOrders,
+  loading: ordersLoading,
+  currentPage: ordersCurrentPage,
+  hasPrev: ordersHasPrev,
+  hasNext: ordersHasNext,
+  nextPage: ordersNextPage,
+  prevPage: ordersPrevPage,
+} = ordersPagination
+
+const fillsPagination = useCursorPaginate<ApiFill>(
+  opts => perpsClient.getFills({ ...opts, market: props.market }),
+  PERPS_INFO_PAGE_SIZE,
+)
+const {
+  items: marketFills,
+  loading: fillsLoading,
+  currentPage: fillsCurrentPage,
+  hasPrev: fillsHasPrev,
+  hasNext: fillsHasNext,
+  nextPage: fillsNextPage,
+  prevPage: fillsPrevPage,
+} = fillsPagination
+
+// Open-orders count for the tab badge. The cursor-paginated table only loads
+// 5 orders per page, so a separate fetch is needed to know how many open
+// orders exist for this market. Limit caps the count at 50 ("50+" if more).
+const OPEN_COUNT_LIMIT = 50
+const PENDING_STATUSES = new Set(['pending', 'untriggered', 'open'])
+const openOrdersCountForMarket = ref(0)
+const openOrdersCountIsCapped = ref(false)
+
+async function fetchOpenOrdersCount() {
+  if (!token.value) {
+    openOrdersCountForMarket.value = 0
+    openOrdersCountIsCapped.value = false
+    return
+  }
+  try {
+    const res = await perpsClient.getOrders({
+      market: props.market,
+      limit: OPEN_COUNT_LIMIT,
+    })
+    const list = res.result ?? []
+    openOrdersCountForMarket.value = list.filter(o =>
+      PENDING_STATUSES.has(o.status),
+    ).length
+    openOrdersCountIsCapped.value =
+      !!res.pageInfo?.nextCursor && list.length >= OPEN_COUNT_LIMIT
+  } catch {
+    openOrdersCountForMarket.value = 0
+    openOrdersCountIsCapped.value = false
+  }
+}
 
 const cancellingOrderId = ref<string | null>(null)
 
@@ -981,19 +1085,6 @@ const showCancelButton = (order: ApiOrder) => {
   )
 }
 
-const fetchMarketOrders = async () => {
-  if (!token.value) return
-  ordersLoading.value = true
-  try {
-    const res = await perpsClient.getOrders({ market: props.market })
-    marketOrders.value = res.result ?? []
-  } catch {
-    marketOrders.value = []
-  } finally {
-    ordersLoading.value = false
-  }
-}
-
 const cancelInfoOrder = async (order: ApiOrder) => {
   if (cancellingOrderId.value === order.orderId) return
   cancellingOrderId.value = order.orderId
@@ -1009,7 +1100,7 @@ const cancelInfoOrder = async (order: ApiOrder) => {
       price: order.price,
     })
     showOrderDialog.value = false
-    await fetchMarketOrders()
+    await Promise.all([ordersPagination.refetch(), fetchOpenOrdersCount()])
   } catch (e) {
     console.error('Failed to cancel order:', e)
     const msg = (e instanceof Error ? e.message : String(e)).toLowerCase()
@@ -1025,19 +1116,6 @@ const cancelInfoOrder = async (order: ApiOrder) => {
     }
   } finally {
     cancellingOrderId.value = null
-  }
-}
-
-const fetchMarketFills = async () => {
-  if (!token.value) return
-  fillsLoading.value = true
-  try {
-    const res = await perpsClient.getFills({ market: props.market })
-    marketFills.value = res.result ?? []
-  } catch {
-    marketFills.value = []
-  } finally {
-    fillsLoading.value = false
   }
 }
 
@@ -1059,37 +1137,54 @@ const fillsSkeletonColumns: SkeletonColumn[] = [
   { header: '', width: '36px' },
 ]
 
-watch(
-  () => token.value,
-  t => {
-    if (t) {
-      fetchMarketOrders()
-      fetchMarketFills()
-    }
-  },
-  { immediate: true },
-)
-
 let ordersPollTimer: ReturnType<typeof setInterval> | null = null
-if (token.value) {
-  ordersPollTimer = setInterval(fetchMarketOrders, 10_000)
-}
-watch(
-  () => token.value,
-  t => {
-    if (ordersPollTimer) {
-      clearInterval(ordersPollTimer)
-      ordersPollTimer = null
-    }
-    if (t) {
-      ordersPollTimer = setInterval(fetchMarketOrders, 10_000)
-    }
-  },
-)
+let fillsPollTimer: ReturnType<typeof setInterval> | null = null
+let ordersIsRefreshing = false
+let fillsIsRefreshing = false
 
-watch(refreshKey, () => {
+async function refreshOrdersPageZero() {
+  if (ordersIsRefreshing) return
+  if (ordersLoading.value) return
+  if (ordersCurrentPage.value !== 0) return
+  ordersIsRefreshing = true
+  try {
+    await Promise.all([ordersPagination.refetch(), fetchOpenOrdersCount()])
+  } finally {
+    ordersIsRefreshing = false
+  }
+}
+
+async function refreshFillsPageZero() {
+  if (fillsIsRefreshing) return
+  if (fillsLoading.value) return
+  if (fillsCurrentPage.value !== 0) return
+  fillsIsRefreshing = true
+  try {
+    await fillsPagination.refetch()
+  } finally {
+    fillsIsRefreshing = false
+  }
+}
+
+watchEffect(() => {
+  void refreshKey.value
+  void props.market
+  if (ordersPollTimer) clearInterval(ordersPollTimer)
+  if (fillsPollTimer) clearInterval(fillsPollTimer)
+  ordersPagination.reset()
+  fillsPagination.reset()
+  openOrdersCountForMarket.value = 0
+  openOrdersCountIsCapped.value = false
   if (token.value) {
-    fetchMarketOrders()
+    void (async () => {
+      await Promise.all([ordersPagination.refetch(), fetchOpenOrdersCount()])
+    })()
+    void fillsPagination.refetch()
+    ordersPollTimer = setInterval(refreshOrdersPageZero, 10_000)
+    fillsPollTimer = setInterval(refreshFillsPageZero, 10_000)
+  } else {
+    ordersPollTimer = null
+    fillsPollTimer = null
   }
 })
 
@@ -1120,6 +1215,7 @@ updateFundingCountdown()
 onUnmounted(() => {
   if (countdownTimer) clearInterval(countdownTimer)
   if (ordersPollTimer) clearInterval(ordersPollTimer)
+  if (fillsPollTimer) clearInterval(fillsPollTimer)
 })
 
 // Tabs

--- a/src/modules/perps/components/PerpsPositionsTable.vue
+++ b/src/modules/perps/components/PerpsPositionsTable.vue
@@ -879,6 +879,7 @@ function openOrderDialog(order: ApiOrder) {
 const {
   orders,
   loading: ordersLoading,
+  hasMore: ordersHasMore,
   refetch: refetchOrders,
 } = usePerpsOrders()
 
@@ -1017,13 +1018,11 @@ const filteredOrders = computed(() => {
 })
 
 // Open-orders count for the Orders tab badge. Source is the polled orders
-// list (limit 100 in usePerpsOrders); count saturates at 100 and is flagged
-// with "+" when so.
+// list (limit 100 in usePerpsOrders); when the server signals more pages
+// beyond the fetched window the badge saturates and is flagged with "+".
 const ORDERS_FETCH_LIMIT = 100
 const openOrdersCount = computed(
   () => orders.value.filter(o => pendingStatuses.has(o.status)).length,
 )
-const openOrdersCountIsCapped = computed(
-  () => orders.value.length >= ORDERS_FETCH_LIMIT,
-)
+const openOrdersCountIsCapped = computed(() => ordersHasMore.value)
 </script>

--- a/src/modules/perps/components/PerpsPositionsTable.vue
+++ b/src/modules/perps/components/PerpsPositionsTable.vue
@@ -917,7 +917,6 @@ function openOrderDialog(order: ApiOrder) {
 const {
   orders,
   loading: ordersLoading,
-  hasMore: ordersHasMore,
   refetch: refetchOrders,
   currentPage: ordersCurrentPage,
   hasPrev: ordersHasPrev,
@@ -1069,16 +1068,16 @@ const filteredOrders = computed(() => {
   return orders.value.filter(o => pendingStatuses.has(o.status))
 })
 
-// Open-orders count for the Orders tab badge. Source is the polled orders
-// list (limit 100 in usePerpsOrders). The badge only saturates ("100+") when
-// more total orders exist beyond the fetched window AND that window is itself
-// full of open orders — `ordersHasMore` alone says nothing about open orders,
-// so a few open + many older closed would otherwise mis-render as "3+".
+// Open-orders count for the Orders tab badge. Source is the current cursor
+// page of orders. The badge only saturates ("100+") when a next page exists
+// AND the current page is itself full of open orders — `ordersHasNext` alone
+// says nothing about open orders, so a few open + many older closed would
+// otherwise mis-render as "3+".
 const ORDERS_FETCH_LIMIT = 100
 const openOrdersCount = computed(
   () => orders.value.filter(o => pendingStatuses.has(o.status)).length,
 )
 const openOrdersCountIsCapped = computed(
-  () => ordersHasMore.value && openOrdersCount.value >= ORDERS_FETCH_LIMIT,
+  () => ordersHasNext.value && openOrdersCount.value >= ORDERS_FETCH_LIMIT,
 )
 </script>

--- a/src/modules/perps/components/PerpsPositionsTable.vue
+++ b/src/modules/perps/components/PerpsPositionsTable.vue
@@ -19,13 +19,13 @@
                 {{ data.label }}
                 <span
                   v-if="data.value === 'positions' && positions.length > 0"
-                  class="ml-1 text-info"
+                  class="ml-1 text-info text-s-12"
                 >
                   · {{ positions.length }}
                 </span>
                 <span
                   v-else-if="data.value === 'orders' && openOrdersCount > 0"
-                  class="ml-1 text-info"
+                  class="ml-1 text-info text-s-12"
                 >
                   ·
                   {{
@@ -95,11 +95,7 @@
         >
           No open positions
         </div>
-        <table
-          v-else
-          ref="positionsTable"
-          class="w-full text-s-14 table-fixed"
-        >
+        <table v-else ref="positionsTable" class="w-full text-s-14 table-fixed">
           <thead>
             <tr
               class="text-left text-s-11 uppercase text-info tracking-sp-06 font-bold"
@@ -291,7 +287,20 @@
             size="xs"
           >
             <template #btn-content="{ data }">
-              <span class="px-2">{{ data.label }}</span>
+              <span class="px-2"
+                >{{ data.label }}
+                <span
+                  v-if="data.value === 'pending' && openOrdersCount > 0"
+                  class="ml-1 text-info text-s-11"
+                >
+                  ·
+                  {{
+                    openOrdersCountIsCapped
+                      ? `${ORDERS_FETCH_LIMIT}+`
+                      : openOrdersCount
+                  }}
+                </span></span
+              >
             </template>
           </app-btn-group>
         </div>
@@ -914,8 +923,7 @@ async function cancelOrder(order: ApiOrder) {
   if (cancellingOrderId.value === order.orderId) return
   cancellingOrderId.value = order.orderId
   const market = markets.value.find(m => m.market === order.market)
-  const displayMarket =
-    market?.longName ?? market?.displayName ?? order.market
+  const displayMarket = market?.longName ?? market?.displayName ?? order.market
   try {
     await perpsClient.cancelOrder(order.orderId)
     perpsToasts.toastOrderCanceled({

--- a/src/modules/perps/components/PerpsPositionsTable.vue
+++ b/src/modules/perps/components/PerpsPositionsTable.vue
@@ -1018,11 +1018,15 @@ const filteredOrders = computed(() => {
 })
 
 // Open-orders count for the Orders tab badge. Source is the polled orders
-// list (limit 100 in usePerpsOrders); when the server signals more pages
-// beyond the fetched window the badge saturates and is flagged with "+".
+// list (limit 100 in usePerpsOrders). The badge only saturates ("100+") when
+// more total orders exist beyond the fetched window AND that window is itself
+// full of open orders — `ordersHasMore` alone says nothing about open orders,
+// so a few open + many older closed would otherwise mis-render as "3+".
 const ORDERS_FETCH_LIMIT = 100
 const openOrdersCount = computed(
   () => orders.value.filter(o => pendingStatuses.has(o.status)).length,
 )
-const openOrdersCountIsCapped = computed(() => ordersHasMore.value)
+const openOrdersCountIsCapped = computed(
+  () => ordersHasMore.value && openOrdersCount.value >= ORDERS_FETCH_LIMIT,
+)
 </script>

--- a/src/modules/perps/components/PerpsPositionsTable.vue
+++ b/src/modules/perps/components/PerpsPositionsTable.vue
@@ -27,7 +27,12 @@
                   v-else-if="data.value === 'orders' && openOrdersCount > 0"
                   class="ml-1 text-info"
                 >
-                  · {{ openOrdersCount }}{{ openOrdersCountIsCapped ? '+' : '' }}
+                  ·
+                  {{
+                    openOrdersCountIsCapped
+                      ? `${ORDERS_FETCH_LIMIT}+`
+                      : openOrdersCount
+                  }}
                 </span>
               </span>
             </template>
@@ -47,9 +52,26 @@
                 @click="toggleSelect"
               >
                 <div class="flex items-center justify-between">
-                  <span class="text-s-16 font-medium">{{
-                    selectedTab.label
-                  }}</span>
+                  <span class="text-s-16 font-medium">
+                    {{ selectedTab.label }}
+                    <span
+                      v-if="activeTab === 'positions' && positions.length > 0"
+                      class="ml-1 text-info"
+                    >
+                      · {{ positions.length }}
+                    </span>
+                    <span
+                      v-else-if="activeTab === 'orders' && openOrdersCount > 0"
+                      class="ml-1 text-info"
+                    >
+                      ·
+                      {{
+                        openOrdersCountIsCapped
+                          ? `${ORDERS_FETCH_LIMIT}+`
+                          : openOrdersCount
+                      }}
+                    </span>
+                  </span>
                   <chevron-down-icon class="w-4 h-4 ml-2" />
                 </div>
               </button>

--- a/src/modules/perps/components/PerpsPositionsTable.vue
+++ b/src/modules/perps/components/PerpsPositionsTable.vue
@@ -23,6 +23,12 @@
                 >
                   · {{ positions.length }}
                 </span>
+                <span
+                  v-else-if="data.value === 'orders' && openOrdersCount > 0"
+                  class="ml-1 text-info"
+                >
+                  · {{ openOrdersCount }}{{ openOrdersCountIsCapped ? '+' : '' }}
+                </span>
               </span>
             </template>
           </app-btn-group>
@@ -987,4 +993,15 @@ const filteredOrders = computed(() => {
   if (selectedOrderFilter.value.value === 'all') return orders.value
   return orders.value.filter(o => pendingStatuses.has(o.status))
 })
+
+// Open-orders count for the Orders tab badge. Source is the polled orders
+// list (limit 100 in usePerpsOrders); count saturates at 100 and is flagged
+// with "+" when so.
+const ORDERS_FETCH_LIMIT = 100
+const openOrdersCount = computed(
+  () => orders.value.filter(o => pendingStatuses.has(o.status)).length,
+)
+const openOrdersCountIsCapped = computed(
+  () => orders.value.length >= ORDERS_FETCH_LIMIT,
+)
 </script>

--- a/src/modules/perps/composables/usePerpsHistory.ts
+++ b/src/modules/perps/composables/usePerpsHistory.ts
@@ -22,6 +22,10 @@ export function usePerpsOrders() {
   const perpsToasts = usePerpsToasts()
   const orders = ref<ApiOrder[]>([])
   const loading = ref(false)
+  // True when the server signals more orders beyond the fetched window via
+  // pageInfo.nextCursor. Lets callers distinguish "exactly N orders" from
+  // "N orders fetched and more exist" without guessing from list length.
+  const hasMore = ref(false)
   // Snapshot keyed by orderId — used to diff filledSize between polls so we
   // can fire Order Filled / Order Partially Filled exactly on the transition.
   // First poll after login seeds the snapshot without firing toasts to avoid
@@ -109,9 +113,11 @@ export function usePerpsOrders() {
       const next = res.result ?? []
       detectFillsAndToast(next)
       orders.value = next
+      hasMore.value = !!res.pageInfo?.nextCursor
     } catch {
       if (seq !== fetchSeq) return
       orders.value = []
+      hasMore.value = false
     } finally {
       if (seq === fetchSeq) loading.value = false
     }
@@ -134,6 +140,7 @@ export function usePerpsOrders() {
       pollTimer = setInterval(fetchOrders, 10_000)
     } else {
       orders.value = []
+      hasMore.value = false
       pollTimer = null
     }
   })
@@ -142,7 +149,7 @@ export function usePerpsOrders() {
     if (pollTimer) clearInterval(pollTimer)
   })
 
-  return { orders, loading, refetch: fetchOrders }
+  return { orders, loading, hasMore, refetch: fetchOrders }
 }
 
 export function usePerpsFills() {

--- a/src/modules/perps/configs.ts
+++ b/src/modules/perps/configs.ts
@@ -25,6 +25,7 @@ const BUILDER_CODE = 'myetherwallet'
 const MAINNET_ENABLED = false
 
 const PERPS_PAGE_SIZE = 10
+const PERPS_INFO_PAGE_SIZE = 5
 
 export {
   IS_PERPS_LIVE,
@@ -36,4 +37,5 @@ export {
   MAINNET_ENABLED,
   BUILDER_CODE,
   PERPS_PAGE_SIZE,
+  PERPS_INFO_PAGE_SIZE,
 }


### PR DESCRIPTION
## What's new

On the per-market **Perps Info page**, the **Orders** and **Fills** tables now paginate at **5 rows per page** instead of dumping the full history into one long list. Each table has Prev/Next controls below it that scroll back to the top of the table on click.

Both the **per-market Info page** and the **main-screen Positions** table now show an **open-orders count** next to the Orders tab — e.g. `Orders · 3` — so users can see at a glance how many of their orders are still working without opening the tab. Counts only show when there's at least one open order.

"Open" here means orders with status `pending`, `untriggered`, or `open` (the same set of statuses for which the Cancel action is available).

## Count caveats (worth flagging for QA)

The Perps API does not return a true total count for orders — only paged results. So the badge is derived from a single capped fetch:

- **Info page (per-market):** counts up to 50 of the most recent orders for that market. If there are more, the badge shows `· 50+`.
- **Main screen (all markets):** counts within the already-loaded 100-order window used by the existing position view. If hit, the badge shows `· 100+`.

In practice, hitting either cap requires an unusually large open-order book, but the `+` makes it explicit when we can't show an exact number.

**Fills** and **Deposits/Withdrawals** intentionally do **not** get count badges — they have no "open vs. closed" semantic, so a count would just be "everything we've fetched so far" and would be misleading.

## How to test

1. Open Perps and connect a wallet that has order/fill history on a given market.
2. Navigate into the per-market Info page.
3. **Orders tab:**
   - Confirm only 5 rows show at a time.
   - Confirm Prev/Next controls work and current page indicator updates.
   - Confirm the tab label shows `Orders · N` when you have open orders, and just `Orders` when you don't.
   - Cancel an open order and confirm the count drops by 1 and the table refreshes.
4. **Fills tab:**
   - Confirm only 5 rows show at a time, and Prev/Next works.
   - Confirm there is no count badge on this tab.
5. Go back to the main wallet view → **Positions table** → click the **Orders** tab.
   - Confirm the tab shows `Orders · N` matching your open-order count.
6. Switch between markets on the Info page and confirm pagination resets to page 1 and the count refreshes for the new market.

## Summary by CodeRabbit

* **New Features**
  * Orders and fills in the Perps module now load with pagination for improved performance
  * Open orders count badge added to the Orders tab with capacity status indicators
  * Automatic periodic background refresh of orders and fills data


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-market cursor-based pagination for Orders and Fills with visible pagination controls and capped per-page sizing
  * Live open-orders count badge on Orders (desktop & mobile), showing "+" when capped
  * Periodic background refresh of page-zero for Orders/Fills with cleanup on close
  * Contextual "No orders"/"No fills" only shown for first page

* **Bug Fixes**
  * More accurate open-orders badge and timely refresh after mutations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->