### PR TITLE
fix: [MEW-1713] hide close-mode UI when position is fully closed

### DIFF
--- a/src/modules/perps/ModulePerpsTrade.vue
+++ b/src/modules/perps/ModulePerpsTrade.vue
@@ -180,6 +180,7 @@
             </button>
           </div>
           <app-pop-up-menu
+            v-if="!activePosition || manageMode === 'add'"
             :placeholder="orderType === 'market' ? 'Market' : 'Limit'"
             location="right"
             class="ml-3"
@@ -498,7 +499,7 @@
         </template>
 
         <!-- ========== ADD / CLOSE POSITION VIEW (has position) ========== -->
-        <template v-if="manageMode === 'close'">
+        <template v-if="activePosition && manageMode === 'close'">
           <!-- ADD MODE -->
 
           <!-- CLOSE MODE -->
@@ -609,7 +610,7 @@
         {{ getMainBtnText }}
       </app-base-button>
       <app-base-button
-        v-if="manageMode === 'close'"
+        v-if="activePosition && manageMode === 'close'"
         :theme="orderSide === 'buy' ? 'success' : 'error'"
         :disabled="closeDisabled"
         @click="showCloseConfirmation"

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -997,6 +997,33 @@ export function usePerpsTradeForm() {
     },
   )
 
+  // Close orders are market-only — switching into close mode forces market so
+  // the (now hidden) order-type selector can't leave a stale 'limit' selection
+  // that would route handleClosePosition() down the limit branch.
+  watch(
+    () => manageMode.value,
+    mode => {
+      if (mode === 'close' && orderType.value !== 'market') {
+        orderType.value = 'market'
+      }
+    },
+  )
+
+  // When the active position disappears (full close) the close form has nothing
+  // to act on; flip back to 'add' so reopening a position doesn't land in a
+  // close UI that referenced the now-gone position.
+  watch(
+    () => activePosition.value,
+    (pos, prev) => {
+      if (prev && !pos && manageMode.value === 'close') {
+        manageMode.value = 'add'
+        closeAmount.value = ''
+        closeSliderValue.value = 0
+        closeError.value = ''
+      }
+    },
+  )
+
   watch(
     () => token.value,
     () => {


### PR DESCRIPTION
## What was wrong

On the Perps trade panel, after a user fully closed a position from the **Close** tab, leftover close-mode UI stayed on screen — the "Amount to close" input, slider, percentage pills, and the red **Close** submit button were still rendered even though there was no longer a position to close. On top of that, the order-type selector (Market / Limit) was still available in close mode, which doesn't fit the close UX since closes are always market orders.

## What the user will now see

- **When a position is fully closed**, the close form disappears immediately. The trade panel falls back to the empty Long / Short add view, ready for a new entry.
- **While closing a position**, the order-type popup (Market / Limit) is hidden — closes are always market orders, so the selector no longer suggests otherwise.
- If a user had previously selected "Limit" and then switches to **Close**, the form silently snaps back to **Market** so the close can't accidentally be routed through the limit path.
- After a full close, reopening a new position lands the panel in **Add** mode by default (no stale close state).

## How to test

1. Connect to perps and open any position (long or short, market or limit — doesn't matter).
2. Switch the trade panel to the **Close** tab.
3. Confirm the **Market / Limit** dropdown is no longer shown to the right of the Add/Close toggle.
4. Move the slider to 100% and submit.
5. Once the position fully closes, confirm the close form (amount input, slider, %-pills, Close submit button) disappears and the panel shows the empty-state Long / Short add view.
6. Open a new position — the panel should be in **Add** mode (not Close).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token chooser availability in perpetuals trading interface.
  * Fixed close-position UI visibility to only appear when closing an active position.
  * Automatically sets order type to market when entering close mode.
  * Properly resets trading interface state when positions are closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->