### PR TITLE
fix: 🐛 rewards swap button width

### DIFF
--- a/src/modules/rewards/RewardsRows.vue
+++ b/src/modules/rewards/RewardsRows.vue
@@ -58,7 +58,7 @@
         v-if="!swapClaimed && !swapNoRewards"
         size="small"
         is-outline
-        class="shrink-0"
+        class="grow max-w-[150px]"
         @click="$emit('swap')"
       >
         Swap $50+


### PR DESCRIPTION
### Fix

## What
Fixed the rewards row swap action button width so it can grow while staying capped at a consistent maximum size.

## Why
The previous shrink-only styling could make the button render with an incorrect or unbalanced width in the rewards row.

## How
- Replaced the shrink-only class with a grow class
- Added a max width constraint for the swap button
- Scoped the change to `RewardsRows.vue`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Swap button layout in the rewards section to optimize spacing and visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->