### PR TITLE
feat: ✨ add rewards not eligible and market close logic

### DIFF
--- a/src/analytics/amplitude.ts
+++ b/src/analytics/amplitude.ts
@@ -114,6 +114,12 @@ export class Analytics {
     if (properties.canClaimRewards !== undefined) {
       identify.set('canClaimRewards', properties.canClaimRewards)
     }
+    if (properties.canClaimTrade !== undefined) {
+      identify.set('canClaimTrade', properties.canClaimTrade)
+    }
+    if (properties.canClaimSwap !== undefined) {
+      identify.set('canClaimSwap', properties.canClaimSwap)
+    }
     if (properties.canTrade !== undefined) {
       identify.set('canTrade', properties.canTrade)
     }

--- a/src/analytics/events.ts
+++ b/src/analytics/events.ts
@@ -286,6 +286,7 @@ export type RewardsPayload = {
     | 'small-banner-trade'
     | 'small-banner-bridge'
     | 'learn-more-dialog'
+  type?: 'swap' | 'trade'
 }
 
 // =============================================================================

--- a/src/analytics/user.ts
+++ b/src/analytics/user.ts
@@ -45,5 +45,7 @@ export type UserProperties = {
   isPartnerHolder?: boolean
   hasBalance?: boolean
   canClaimRewards?: boolean
+  canClaimTrade?: boolean
+  canClaimSwap?: boolean
   canTrade?: boolean
 }

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -17,9 +17,7 @@ const configs = {
     'GNOSIS',
     'ROOTSTOCK',
   ],
-  MEW_REWARDS_API_URL:
-    import.meta.env.VITE_MEW_REWARDS_API ||
-    'https://mew-rewards-prod.ethvm.dev',
+  MEW_REWARDS_API_URL: 'https://mew-rewards-prod.ethvm.dev',
   MEW_LIVE_URLS: ['app.beta.myetherwallet.com', 'app.myetherwallet.com'],
   MEW_SENTRY_DSN:
     import.meta.env.VITE_SENTRY_DSN ||

--- a/src/modules/rewards/RewardsLearnMore.vue
+++ b/src/modules/rewards/RewardsLearnMore.vue
@@ -29,6 +29,10 @@
                 v-else-if="item.icon === 'trophy'"
                 class="w-4 h-4 text-primary"
               />
+              <trade-icon
+                v-else-if="item.icon === 'trade'"
+                class="w-4 h-4 text-primary"
+              />
               <currency-dollar-icon
                 v-else-if="item.icon === 'currency-dollar'"
                 class="w-4 h-4 text-primary"
@@ -84,6 +88,7 @@ import {
   CalendarIcon,
   CurrencyDollarIcon,
 } from '@heroicons/vue/24/solid'
+import TradeIcon from '@/assets/icons/core_menu/icon-trade.vue'
 import { ArrowPathRoundedSquareIcon } from '@heroicons/vue/24/outline'
 import { analytics, RewardsEvent } from '@/analytics'
 import { useWalletMenuStore } from '@/stores/walletMenuStore'
@@ -146,7 +151,7 @@ const infoItems = [
     text: 'Be among the first 10 users per hour, per swap.',
   },
   {
-    icon: 'graph',
+    icon: 'trade',
     text: 'Be among the first 15 users per hour, per trade.',
   },
   {

--- a/src/modules/rewards/RewardsLearnMore.vue
+++ b/src/modules/rewards/RewardsLearnMore.vue
@@ -143,7 +143,11 @@ const infoItems = [
   },
   {
     icon: 'trophy',
-    text: 'Be among the first 10 users per hour, per action.',
+    text: 'Be among the first 10 users per hour, per swap.',
+  },
+  {
+    icon: 'graph',
+    text: 'Be among the first 15 users per hour, per trade.',
   },
   {
     icon: 'currency-dollar',

--- a/src/modules/rewards/RewardsLearnMore.vue
+++ b/src/modules/rewards/RewardsLearnMore.vue
@@ -64,12 +64,14 @@
           :swap-total="swapTotal"
           :trade-claimed="tradeClaimed"
           :trade-no-rewards="tradeNoRewards"
+          :trade-market-closed="tradeMarketClosed"
           :trade-remaining-pct="tradeRemainingPct"
           :trade-remaining-count="tradeRemainingCount"
           :trade-total="tradeTotal"
           :time-until-hour-reset="timeUntilHourReset"
           :time-until-swap-next-eligible="timeUntilSwapNextEligible"
           :time-until-trade-next-eligible="timeUntilTradeNextEligible"
+          :time-until-market-open="timeUntilMarketOpen"
           class="mt-0"
           @swap="onNavigate('swap')"
           @trade="onNavigate('trade')"
@@ -110,12 +112,14 @@ const props = defineProps<{
   swapTotal: number | null
   tradeClaimed: boolean
   tradeNoRewards: boolean
+  tradeMarketClosed: boolean
   tradeRemainingPct: number
   tradeRemainingCount: number | null
   tradeTotal: number | null
   timeUntilHourReset: string
   timeUntilSwapNextEligible: string
   timeUntilTradeNextEligible: string
+  timeUntilMarketOpen: string
 }>()
 
 const isOpenModel = defineModel('isOpen', {

--- a/src/modules/rewards/RewardsLearnMore.vue
+++ b/src/modules/rewards/RewardsLearnMore.vue
@@ -64,7 +64,8 @@
           :trade-remaining-count="tradeRemainingCount"
           :trade-total="tradeTotal"
           :time-until-hour-reset="timeUntilHourReset"
-          :time-until-next-eligible="timeUntilNextEligible"
+          :time-until-swap-next-eligible="timeUntilSwapNextEligible"
+          :time-until-trade-next-eligible="timeUntilTradeNextEligible"
           class="mt-0"
           @swap="onNavigate('swap')"
           @trade="onNavigate('trade')"
@@ -108,7 +109,8 @@ const props = defineProps<{
   tradeRemainingCount: number | null
   tradeTotal: number | null
   timeUntilHourReset: string
-  timeUntilNextEligible: string
+  timeUntilSwapNextEligible: string
+  timeUntilTradeNextEligible: string
 }>()
 
 const isOpenModel = defineModel('isOpen', {

--- a/src/modules/rewards/RewardsPortfolio.vue
+++ b/src/modules/rewards/RewardsPortfolio.vue
@@ -13,9 +13,7 @@
       class="bg-white rounded-16 h-full flex flex-col justify-between px-5 pb-5 relative overflow-hidden xl:max-h-[293px]"
     >
       <!-- Top: Title + Image -->
-      <div
-        class="flex items-start justify-between gap-2 mb-5"
-      >
+      <div class="flex items-start justify-between gap-2 mb-5">
         <div class="flex flex-col pt-5">
           <h3 class="text-s-20 font-bold leading-none">Earn rewards</h3>
           <p class="text-s-16 text-[#575757] leading-[22px] mt-2 max-w-[295px]">
@@ -37,7 +35,7 @@
           :class="
             isOpenSideMenu
               ? 'xl:hidden 2xl:block 2xl:w-[60px] 2xl:h-[90px]'
-              : 'xl:block 2xl:block'
+              : 'xl:block xl:w-[80px] xl:h-[120px] 2xl:w-[92px] 2xl:h-[130px]'
           "
         />
       </div>
@@ -72,7 +70,10 @@
         <p class="text-s-14 font-semibold text-error leading-5">
           Not eligible for rewards
         </p>
-        <p class="text-s-14 text-[#575757] leading-5 mt-1">
+        <p
+          class="text-s-14 text-[#575757] leading-5 mt-1"
+          :class="{ '2xl:hidden ': isOpenSideMenu }"
+        >
           Wallets created after March 31st are not eligible for rewards. Try
           connecting an older wallet.
         </p>

--- a/src/modules/rewards/RewardsPortfolio.vue
+++ b/src/modules/rewards/RewardsPortfolio.vue
@@ -15,7 +15,6 @@
       <!-- Top: Title + Image -->
       <div
         class="flex items-start justify-between gap-2 mb-5"
-        :class="{ 'opacity-20 pointer-events-none': isBanned }"
       >
         <div class="flex flex-col pt-5">
           <h3 class="text-s-20 font-bold leading-none">Earn rewards</h3>
@@ -37,7 +36,7 @@
           class="shrink-0 object-contain w-[92px] h-[130px] flex-none -mt-2 hidden 3xl:w-[92px] 3xl:h-[130px]"
           :class="
             isOpenSideMenu
-              ? 'xl:hidden 2xl:block  2xl:w-[60px] 2xl:h-[90px]'
+              ? 'xl:hidden 2xl:block 2xl:w-[60px] 2xl:h-[90px]'
               : 'xl:block 2xl:block'
           "
         />
@@ -45,6 +44,7 @@
 
       <!-- Reward Rows -->
       <rewards-rows
+        v-if="!isBanned"
         :swap-claimed="swapClaimed"
         :swap-no-rewards="swapNoRewards"
         :swap-remaining-pct="swapRemainingPct"
@@ -52,31 +52,35 @@
         :swap-total="swapTotal"
         :trade-claimed="tradeClaimed"
         :trade-no-rewards="tradeNoRewards"
+        :trade-market-closed="tradeMarketClosed"
         :trade-remaining-pct="tradeRemainingPct"
         :trade-remaining-count="tradeRemainingCount"
         :trade-total="tradeTotal"
         :time-until-hour-reset="timeUntilRewardHourReset"
         :time-until-swap-next-eligible="timeUntilSwapNextEligible"
         :time-until-trade-next-eligible="timeUntilTradeNextEligible"
+        :time-until-market-open="timeUntilMarketOpen"
         @swap="goToSwap"
         @trade="goToTrade"
         class="max-w-[360px] 2xl:max-w-none"
-        :class="[
-          isOpenSideMenu ? '2xl:-ml-2 2xl:-mr-2' : '',
-          { 'opacity-20 pointer-events-none': isBanned },
-        ]"
+        :class="[isOpenSideMenu ? '2xl:-ml-2 2xl:-mr-2' : '']"
         is-rewards-view
       />
-      <div
-        v-if="isBanned"
-        class="text-center font-medium text-s-16 p-5 bg-appBackground rounded-20 absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-1 xl:min-w-[300px]"
-      >
-        <p>You are not eligible for rewards at this time</p>
+
+      <!-- Not Eligible State -->
+      <div v-else class="border-t border-grey-10 pt-4 pb-1">
+        <p class="text-s-14 font-semibold text-error leading-5">
+          Not eligible for rewards
+        </p>
+        <p class="text-s-14 text-[#575757] leading-5 mt-1">
+          Wallets created after March 31st are not eligible for rewards. Try
+          connecting an older wallet.
+        </p>
         <button
-          class="text-s-16 underline text-left w-fit mt-1 hoverOpacity"
-          @click="onLearnMore"
+          class="mt-4 bg-grey-5 text-black font-medium text-s-16 rounded-full py-2 px-5 hoverOpacity"
+          @click="onConnectAddress"
         >
-          Learn more
+          Connect another address
         </button>
       </div>
       <img
@@ -84,11 +88,8 @@
         alt=""
         width="650"
         height="292"
-        class="shrink-0 object-contain hidden xs:block 3xl:hidden flex-none absolute right-[20px] mx-auto pointer-events-none max-h-[140px] max-w-[140px] sm:max-h-[225px] sm:max-w-[234px] 2xl:hidden"
-        :class="[
-          isOpenSideMenu ? '' : 'xl:hidden',
-          { 'opacity-20 pointer-events-none': isBanned },
-        ]"
+        class="shrink-0 object-contain hidden xs:block 3xl:hidden flex-none absolute top-0 right-[20px] mx-auto pointer-events-none max-h-[140px] max-w-[140px] 2xl:hidden"
+        :class="[isOpenSideMenu ? '' : 'xl:hidden']"
       />
 
       <rewards-learn-more
@@ -101,12 +102,14 @@
         :swap-total="swapTotal"
         :trade-claimed="tradeClaimed"
         :trade-no-rewards="tradeNoRewards"
+        :trade-market-closed="tradeMarketClosed"
         :trade-remaining-pct="tradeRemainingPct"
         :trade-remaining-count="tradeRemainingCount"
         :trade-total="tradeTotal"
         :time-until-hour-reset="timeUntilRewardHourReset"
         :time-until-swap-next-eligible="timeUntilSwapNextEligible"
         :time-until-trade-next-eligible="timeUntilTradeNextEligible"
+        :time-until-market-open="timeUntilMarketOpen"
       />
     </div>
   </div>
@@ -124,6 +127,8 @@ import { storeToRefs } from 'pinia'
 import { analytics, RewardsEvent } from '@/analytics'
 import { useToastStore } from '@/stores/toastStore'
 import { useRewardsStore } from '@/stores/rewardsStore'
+import { useAccessStore } from '@/stores/accessStore'
+import { useMarketStatus } from '@/modules/trade/composables/useMarketStatus'
 
 const walletMenuStore = useWalletMenuStore()
 const { isOpenSideMenu } = storeToRefs(walletMenuStore)
@@ -139,6 +144,7 @@ const {
   tradeClaimed,
   swapNoRewards,
   tradeNoRewards,
+  tradeMarketClosed,
   swapTotal,
   swapRemainingPct,
   swapRemainingCount,
@@ -153,8 +159,10 @@ const isLearnMoreOpen = ref(false)
 const timeUntilRewardHourReset = ref('--')
 const timeUntilSwapNextEligible = ref('--')
 const timeUntilTradeNextEligible = ref('--')
-
 let countdownTimer: ReturnType<typeof setInterval> | null = null
+
+const { countdownText: timeUntilMarketOpen, fetchMarketStatus } =
+  useMarketStatus()
 
 function formatDiff(ms: number): string {
   const d = Math.floor(ms / 86_400_000)
@@ -194,6 +202,7 @@ function updateCountdowns() {
 onMounted(() => {
   analytics.trackRewardsEvent(RewardsEvent.MAIN_BANNER_SHOWN)
   rewardsStore.fetchPool()
+  fetchMarketStatus()
   updateCountdowns()
   countdownTimer = setInterval(updateCountdowns, 60_000)
 })
@@ -230,6 +239,11 @@ const goToTrade = () => {
 
 const onLearnMore = () => {
   isLearnMoreOpen.value = true
+}
+
+const accessStore = useAccessStore()
+const onConnectAddress = () => {
+  accessStore.openAccessDialog()
 }
 </script>
 

--- a/src/modules/rewards/RewardsPortfolio.vue
+++ b/src/modules/rewards/RewardsPortfolio.vue
@@ -55,8 +55,9 @@
         :trade-remaining-pct="tradeRemainingPct"
         :trade-remaining-count="tradeRemainingCount"
         :trade-total="tradeTotal"
-        :time-until-hour-reset="timeUntilHourReset"
-        :time-until-next-eligible="timeUntilNextEligible"
+        :time-until-hour-reset="timeUntilRewardHourReset"
+        :time-until-swap-next-eligible="timeUntilSwapNextEligible"
+        :time-until-trade-next-eligible="timeUntilTradeNextEligible"
         @swap="goToSwap"
         @trade="goToTrade"
         class="max-w-[360px] 2xl:max-w-none"
@@ -103,8 +104,9 @@
         :trade-remaining-pct="tradeRemainingPct"
         :trade-remaining-count="tradeRemainingCount"
         :trade-total="tradeTotal"
-        :time-until-hour-reset="timeUntilHourReset"
-        :time-until-next-eligible="timeUntilNextEligible"
+        :time-until-hour-reset="timeUntilRewardHourReset"
+        :time-until-swap-next-eligible="timeUntilSwapNextEligible"
+        :time-until-trade-next-eligible="timeUntilTradeNextEligible"
       />
     </div>
   </div>
@@ -132,7 +134,7 @@ const toastStore = useToastStore()
 const rewardsStore = useRewardsStore()
 const {
   hadInitialLoad,
-  eligibility,
+  eligibilityV2,
   swapClaimed,
   tradeClaimed,
   swapNoRewards,
@@ -148,8 +150,10 @@ const {
 } = storeToRefs(rewardsStore)
 
 const isLearnMoreOpen = ref(false)
-const timeUntilHourReset = ref('--')
-const timeUntilNextEligible = ref('--')
+const timeUntilRewardHourReset = ref('--')
+const timeUntilSwapNextEligible = ref('--')
+const timeUntilTradeNextEligible = ref('--')
+
 let countdownTimer: ReturnType<typeof setInterval> | null = null
 
 function formatDiff(ms: number): string {
@@ -163,13 +167,27 @@ function formatDiff(ms: number): string {
 
 function updateCountdowns() {
   const hourTarget = nextHourStart.value
-  timeUntilHourReset.value = hourTarget
+  timeUntilRewardHourReset.value = hourTarget
     ? formatDiff(Math.max(0, new Date(hourTarget).getTime() - Date.now()))
     : '--'
 
-  const eligibleTarget = eligibility.value?.nextEligibleDate
-  timeUntilNextEligible.value = eligibleTarget
-    ? formatDiff(Math.max(0, new Date(eligibleTarget).getTime() - Date.now()))
+  timeUntilSwapNextEligible.value = eligibilityV2.value?.swap.nextEligibleDate
+    ? formatDiff(
+        Math.max(
+          0,
+          new Date(eligibilityV2.value?.swap.nextEligibleDate).getTime() -
+            Date.now(),
+        ),
+      )
+    : '--'
+  timeUntilTradeNextEligible.value = eligibilityV2.value?.trade.nextEligibleDate
+    ? formatDiff(
+        Math.max(
+          0,
+          new Date(eligibilityV2.value?.trade.nextEligibleDate).getTime() -
+            Date.now(),
+        ),
+      )
     : '--'
 }
 

--- a/src/modules/rewards/RewardsPortfolio.vue
+++ b/src/modules/rewards/RewardsPortfolio.vue
@@ -20,7 +20,7 @@
         <div class="flex flex-col pt-5">
           <h3 class="text-s-20 font-bold leading-none">Earn rewards</h3>
           <p class="text-s-16 text-[#575757] leading-[22px] mt-2 max-w-[295px]">
-            First 10 trades of $25+ and swaps of $50+ earn 5 USDC each hour.
+            First trades of $25+ and swaps of $50+ earn 5 USDC each hour.
           </p>
           <button
             class="text-s-16 underline text-left w-fit mt-1 hoverOpacity"

--- a/src/modules/rewards/RewardsRows.vue
+++ b/src/modules/rewards/RewardsRows.vue
@@ -70,7 +70,8 @@
           '2xl:text-s-11 3xl:text-s-13': isOpenSideMenu,
         }"
       >
-        Back in {{ swapClaimed ? timeUntilNextEligible : timeUntilHourReset }}
+        Back in
+        {{ swapClaimed ? timeUntilSwapNextEligible : timeUntilHourReset }}
         <clock-icon
           class="w-3.5 h-3.5 ml-auto"
           :class="{
@@ -153,7 +154,7 @@
         }"
       >
         Back in
-        {{ tradeClaimed ? timeUntilNextEligible : timeUntilHourReset }}
+        {{ tradeClaimed ? timeUntilTradeNextEligible : timeUntilHourReset }}
         <clock-icon
           class="w-3.5 h-3.5 ml-auto"
           :class="{
@@ -188,7 +189,8 @@ defineProps<{
   tradeRemainingCount: number | null
   tradeTotal: number | null
   timeUntilHourReset: string
-  timeUntilNextEligible: string
+  timeUntilSwapNextEligible: string
+  timeUntilTradeNextEligible: string
   isRewardsView?: boolean
 }>()
 

--- a/src/modules/rewards/RewardsRows.vue
+++ b/src/modules/rewards/RewardsRows.vue
@@ -27,7 +27,7 @@
             :class="{
               '2xl:text-s-13 3xl:text-s-14': isOpenSideMenu,
             }"
-            >Swap → Earn $5</span
+            >Swap and Earn $5</span
           >
           <template v-if="!swapClaimed && !swapNoRewards">
             <div
@@ -58,7 +58,7 @@
         v-if="!swapClaimed && !swapNoRewards"
         size="small"
         is-outline
-        class="shrink-0"
+        class="grow max-w-[150px]"
         @click="$emit('swap')"
       >
         Swap $50+
@@ -92,13 +92,15 @@
         <div
           class="rounded-lg p-1.5 flex-none h-10 w-10 flex items-center justify-center"
           :class="[
-            !tradeClaimed && !tradeNoRewards ? 'bg-blue-10' : 'bg-grey-5',
+            !tradeClaimed && !tradeNoRewards && !tradeMarketClosed
+              ? 'bg-blue-10'
+              : 'bg-grey-5',
           ]"
         >
           <icon-trade
             class="w-6 h-6"
             :class="[
-              !tradeClaimed && !tradeNoRewards
+              !tradeClaimed && !tradeNoRewards && !tradeMarketClosed
                 ? 'text-primary'
                 : 'text-[#A5A5A5]',
             ]"
@@ -110,9 +112,11 @@
             :class="{
               '2xl:text-s-13 3xl:text-s-14': isOpenSideMenu,
             }"
-            >Trade → Earn $5</span
+            >Trade and Earn $5</span
           >
-          <template v-if="!tradeClaimed && !tradeNoRewards">
+          <template
+            v-if="!tradeClaimed && !tradeNoRewards && !tradeMarketClosed"
+          >
             <div
               class="w-full h-1.5 bg-blue-10 rounded-full overflow-hidden mt-1 flex"
             >
@@ -132,13 +136,19 @@
           >
             Reward claimed
           </p>
+          <p
+            v-else-if="tradeMarketClosed"
+            class="text-s-12 font-medium mt-0.5 text-error"
+          >
+            Market is closed
+          </p>
           <p v-else class="text-s-12 font-medium mt-0.5 text-error">
             No rewards left
           </p>
         </div>
       </div>
       <app-base-button
-        v-if="!tradeClaimed && !tradeNoRewards"
+        v-if="!tradeClaimed && !tradeNoRewards && !tradeMarketClosed"
         size="small"
         is-outline
         class="grow max-w-[150px]"
@@ -154,7 +164,13 @@
         }"
       >
         Back in
-        {{ tradeClaimed ? timeUntilTradeNextEligible : timeUntilHourReset }}
+        {{
+          tradeClaimed
+            ? timeUntilTradeNextEligible
+            : tradeMarketClosed
+              ? timeUntilMarketOpen
+              : timeUntilHourReset
+        }}
         <clock-icon
           class="w-3.5 h-3.5 ml-auto"
           :class="{
@@ -185,12 +201,14 @@ defineProps<{
   swapTotal: number | null
   tradeClaimed: boolean
   tradeNoRewards: boolean
+  tradeMarketClosed: boolean
   tradeRemainingPct: number
   tradeRemainingCount: number | null
   tradeTotal: number | null
   timeUntilHourReset: string
   timeUntilSwapNextEligible: string
   timeUntilTradeNextEligible: string
+  timeUntilMarketOpen: string
   isRewardsView?: boolean
 }>()
 

--- a/src/modules/rewards/RewardsSmallBanner.vue
+++ b/src/modules/rewards/RewardsSmallBanner.vue
@@ -29,12 +29,14 @@
       :swap-total="swapTotal"
       :trade-claimed="tradeClaimed"
       :trade-no-rewards="tradeNoRewards"
+      :trade-market-closed="tradeMarketClosed"
       :trade-remaining-pct="tradeRemainingPct"
       :trade-remaining-count="tradeRemainingCount"
       :trade-total="tradeTotal"
       :time-until-hour-reset="timeUntilRewardHourReset"
       :time-until-swap-next-eligible="timeUntilSwapNextEligible"
       :time-until-trade-next-eligible="timeUntilTradeNextEligible"
+      :time-until-market-open="timeUntilMarketOpen"
     />
   </div>
 </template>
@@ -44,6 +46,7 @@ import { ref, onMounted, onUnmounted } from 'vue'
 import RewardsLearnMore from '@/modules/rewards/RewardsLearnMore.vue'
 import { storeToRefs } from 'pinia'
 import { useRewardsStore } from '@/stores/rewardsStore'
+import { useMarketStatus } from '@/modules/trade/composables/useMarketStatus'
 
 const props = defineProps<{
   location: 'small-banner-swap' | 'small-banner-trade' | 'small-banner-bridge'
@@ -56,6 +59,7 @@ const {
   tradeClaimed,
   swapNoRewards,
   tradeNoRewards,
+  tradeMarketClosed,
   swapTotal,
   swapRemainingPct,
   swapRemainingCount,
@@ -68,10 +72,12 @@ const {
 
 const isLearnMoreOpen = ref(false)
 const timeUntilRewardHourReset = ref('--')
-
 const timeUntilSwapNextEligible = ref('--')
 const timeUntilTradeNextEligible = ref('--')
 let countdownTimer: ReturnType<typeof setInterval> | null = null
+
+const { countdownText: timeUntilMarketOpen, fetchMarketStatus } =
+  useMarketStatus()
 
 function formatDiff(ms: number): string {
   const d = Math.floor(ms / 86_400_000)
@@ -109,6 +115,7 @@ function updateCountdowns() {
 }
 
 onMounted(() => {
+  fetchMarketStatus()
   updateCountdowns()
   countdownTimer = setInterval(updateCountdowns, 60_000)
 })

--- a/src/modules/rewards/RewardsSmallBanner.vue
+++ b/src/modules/rewards/RewardsSmallBanner.vue
@@ -32,8 +32,9 @@
       :trade-remaining-pct="tradeRemainingPct"
       :trade-remaining-count="tradeRemainingCount"
       :trade-total="tradeTotal"
-      :time-until-hour-reset="timeUntilHourReset"
-      :time-until-next-eligible="timeUntilNextEligible"
+      :time-until-hour-reset="timeUntilRewardHourReset"
+      :time-until-swap-next-eligible="timeUntilSwapNextEligible"
+      :time-until-trade-next-eligible="timeUntilTradeNextEligible"
     />
   </div>
 </template>
@@ -50,7 +51,7 @@ const props = defineProps<{
 
 const rewardsStore = useRewardsStore()
 const {
-  eligibility,
+  eligibilityV2,
   swapClaimed,
   tradeClaimed,
   swapNoRewards,
@@ -66,8 +67,10 @@ const {
 } = storeToRefs(rewardsStore)
 
 const isLearnMoreOpen = ref(false)
-const timeUntilHourReset = ref('--')
-const timeUntilNextEligible = ref('--')
+const timeUntilRewardHourReset = ref('--')
+
+const timeUntilSwapNextEligible = ref('--')
+const timeUntilTradeNextEligible = ref('--')
 let countdownTimer: ReturnType<typeof setInterval> | null = null
 
 function formatDiff(ms: number): string {
@@ -81,12 +84,27 @@ function formatDiff(ms: number): string {
 
 function updateCountdowns() {
   const hourTarget = nextHourStart.value
-  timeUntilHourReset.value = hourTarget
+  timeUntilRewardHourReset.value = hourTarget
     ? formatDiff(Math.max(0, new Date(hourTarget).getTime() - Date.now()))
     : '--'
-  const eligibleTarget = eligibility.value?.nextEligibleDate
-  timeUntilNextEligible.value = eligibleTarget
-    ? formatDiff(Math.max(0, new Date(eligibleTarget).getTime() - Date.now()))
+
+  timeUntilSwapNextEligible.value = eligibilityV2.value?.swap.nextEligibleDate
+    ? formatDiff(
+        Math.max(
+          0,
+          new Date(eligibilityV2.value?.swap.nextEligibleDate).getTime() -
+            Date.now(),
+        ),
+      )
+    : '--'
+  timeUntilTradeNextEligible.value = eligibilityV2.value?.trade.nextEligibleDate
+    ? formatDiff(
+        Math.max(
+          0,
+          new Date(eligibilityV2.value?.trade.nextEligibleDate).getTime() -
+            Date.now(),
+        ),
+      )
     : '--'
 }
 

--- a/src/modules/swap/ModuleSwap.vue
+++ b/src/modules/swap/ModuleSwap.vue
@@ -728,7 +728,8 @@ const proceedWithSwap = async (quoteId: string) => {
       const fromUsdValue =
         parseFloat(fromAmount.value) * (fromTokenSelected.value?.price || 0)
       if (fromUsdValue > 50) {
-        const canEarn = await rewardsStore.checkAvailabilityAfterTransaction()
+        const canEarn =
+          await rewardsStore.checkAvailabilityAfterTransaction('swap')
         canEarnReward = canEarn ? true : undefined
       }
       analytics.trackSwapEventStatus(SwapEventStatus.INITIATED, {

--- a/src/modules/trade/composables/useTradeExecution.ts
+++ b/src/modules/trade/composables/useTradeExecution.ts
@@ -196,7 +196,7 @@ export function useTradeExecution(options: UseTradeExecutionOptions) {
       const fromUsdValue =
         parseFloat(fromAmount.value) * (fromTokenSelected.value?.price || 0)
       if (fromUsdValue > 25) {
-        const canEarn = await rewardsStore.checkAvailabilityAfterTransaction()
+        const canEarn = await rewardsStore.checkAvailabilityAfterTransaction('trade')
         canEarnReward = canEarn ? true : undefined
       }
       analytics.trackTradeEventStatus(TradeEventStatus.INITIATED, {

--- a/src/modules/trade/composables/useTradeExecution.ts
+++ b/src/modules/trade/composables/useTradeExecution.ts
@@ -195,7 +195,7 @@ export function useTradeExecution(options: UseTradeExecutionOptions) {
       let canEarnReward: undefined | boolean = undefined
       const fromUsdValue =
         parseFloat(fromAmount.value) * (fromTokenSelected.value?.price || 0)
-      if (fromUsdValue > 50) {
+      if (fromUsdValue > 25) {
         const canEarn = await rewardsStore.checkAvailabilityAfterTransaction()
         canEarnReward = canEarn ? true : undefined
       }

--- a/src/stores/rewardsStore.ts
+++ b/src/stores/rewardsStore.ts
@@ -343,7 +343,7 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
         r.type === 'POOL_LOW_USDC',
     )
 
-    if (!tradeRecentlyRewarded || swapRecentlyRewarded) {
+    if (!tradeRecentlyRewarded || !swapRecentlyRewarded) {
       return tradeGeneric || swapGeneric
     }
     return false

--- a/src/stores/rewardsStore.ts
+++ b/src/stores/rewardsStore.ts
@@ -174,6 +174,12 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
       tradePool.value?.hourlyRemainingRewardCount === 0,
   )
 
+  const tradeMarketClosed = computed(
+    () =>
+      tradePool.value?.reasons.some(r => r.type === 'TRADE_REWARDS_DISABLED') ??
+      false,
+  )
+
   const swapTotal = computed(() => {
     const p = swapPool.value
     if (!p || p.hourlyRemainingRewardCount === null) return null
@@ -331,16 +337,10 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
     const swapRecentlyRewarded = eligibilityV2.value?.swap.reasons.some(r => r.type === 'USER_RECENTLY_REWARDED')
 
     const tradeGeneric = eligibilityV2.value?.trade.reasons.some(
-      r =>
-        r.type === 'REWARDS_DISABLED' ||
-        r.type === 'POOL_LOW_ETH' ||
-        r.type === 'POOL_LOW_USDC',
+      r => r.type === 'REWARDS_DISABLED',
     )
     const swapGeneric = eligibilityV2.value?.swap.reasons.some(
-      r =>
-        r.type === 'REWARDS_DISABLED' ||
-        r.type === 'POOL_LOW_ETH' ||
-        r.type === 'POOL_LOW_USDC',
+      r => r.type === 'REWARDS_DISABLED',
     )
 
     if (!tradeRecentlyRewarded || !swapRecentlyRewarded) {
@@ -382,6 +382,7 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
     tradeClaimed,
     swapNoRewards,
     tradeNoRewards,
+    tradeMarketClosed,
     swapTotal,
     swapRemainingPct,
     swapRemainingCount,

--- a/src/stores/rewardsStore.ts
+++ b/src/stores/rewardsStore.ts
@@ -144,7 +144,7 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
         )
       eligibilityV2.value = result
       const eligible = result?.swap.eligible ?? result?.trade.eligible ?? false
-      analytics.setUserProperties({ canClaimRewards: eligible })
+      analytics.setUserProperties({ canClaimRewards: eligible, canClaimSwap: result?.trade.eligible, canClaimTrade: result?.swap.eligible })
     } catch (error) {
       console.error('Failed to fetch reward eligibility:', error)
     } finally {

--- a/src/stores/rewardsStore.ts
+++ b/src/stores/rewardsStore.ts
@@ -68,7 +68,10 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
   /** Pool */
   const isPoolOpen = computed(() => poolV2.value?.open ?? false)
   const rewardsLeft = computed(
-    () => poolV2.value?.swap.hourlyRemainingRewardCount ?? poolV2.value?.trade.hourlyRemainingRewardCount ?? '0',
+    () =>
+      poolV2.value?.swap.hourlyRemainingRewardCount ??
+      poolV2.value?.trade.hourlyRemainingRewardCount ??
+      '0',
   )
   const nextHourStart = computed(() => poolV2.value?.nextHourStart ?? null)
   const poolReasons = computed(() => poolV2.value?.reasons ?? [])
@@ -79,7 +82,8 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
     if (isBitcoinChain.value) return
     isLoadingPool.value = true
     try {
-      const v2Result = await fetchRewards<V2PoolStatusResponse>('/v2/rewards/pool')
+      const v2Result =
+        await fetchRewards<V2PoolStatusResponse>('/v2/rewards/pool')
       poolV2.value = v2Result
     } catch (error) {
       console.error('Failed to fetch reward pool status:', error)
@@ -128,23 +132,38 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
   }
 
   /** Eligibility */
-  const isEligible = computed(() => eligibilityV2.value?.swap.eligible ?? eligibilityV2.value?.trade.eligible ?? false)
-  const nextEligibleDate = computed(
-    () => eligibilityV2.value?.swap.nextEligibleDate ?? eligibilityV2.value?.trade.nextEligibleDate ?? false,
+  const isEligible = computed(() =>
+    eligibilityV2.value
+      ? eligibilityV2.value.swap.eligible || eligibilityV2.value.trade.eligible
+      : false,
   )
-  const eligibilityReasons = computed(() => eligibilityV2.value?.swap.reasons ?? eligibilityV2.value?.trade.reasons ?? [])
+  const nextEligibleDate = computed(
+    () =>
+      eligibilityV2.value?.swap.nextEligibleDate ??
+      eligibilityV2.value?.trade.nextEligibleDate ??
+      false,
+  )
+  const eligibilityReasons = computed(
+    () =>
+      eligibilityV2.value?.swap.reasons ??
+      eligibilityV2.value?.trade.reasons ??
+      [],
+  )
 
   const fetchEligibility = async () => {
     if (!walletAddress.value || isBitcoinChain.value) return
     isLoadingEligibility.value = true
     try {
-      const result = await
-        fetchRewards<V2EligibilityResponse>(
-          `/v2/addresses/${walletAddress.value}/rewards/eligibility`,
-        )
+      const result = await fetchRewards<V2EligibilityResponse>(
+        `/v2/addresses/${walletAddress.value}/rewards/eligibility`,
+      )
       eligibilityV2.value = result
       const eligible = result?.swap.eligible ?? result?.trade.eligible ?? false
-      analytics.setUserProperties({ canClaimRewards: eligible, canClaimSwap: result?.trade.eligible, canClaimTrade: result?.swap.eligible })
+      analytics.setUserProperties({
+        canClaimRewards: eligible,
+        canClaimSwap: result?.trade.eligible,
+        canClaimTrade: result?.swap.eligible,
+      })
     } catch (error) {
       console.error('Failed to fetch reward eligibility:', error)
     } finally {
@@ -216,9 +235,15 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
 
   const checkAvailabilityAfterTransaction = async (type: 'swap' | 'trade') => {
     // This function can be called after a transaction to check if user has earned a potential reward, and if so, set the badge immediately without waiting for the next eligibility fetch
-    if (eligibilityV2.value === null || (eligibilityV2.value.swap.eligible ?? eligibilityV2.value.trade.eligible)) {
+    if (
+      eligibilityV2.value === null ||
+      (eligibilityV2.value.swap.eligible ?? eligibilityV2.value.trade.eligible)
+    ) {
       await fetchEligibility()
-      if (eligibilityV2.value?.swap.eligible || eligibilityV2.value?.trade.eligible) {
+      if (
+        eligibilityV2.value?.swap.eligible ||
+        eligibilityV2.value?.trade.eligible
+      ) {
         earnedPotentialRewardAddresses.value.push(walletAddress.value!)
         return eligibilityV2.value[type].eligible
       }
@@ -328,13 +353,20 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
   }
 
   const isBanned = computed(() => {
-    const tradeEligibility = eligibilityV2.value?.trade.reasons.some(r => r.type === 'ACCOUNT_TOO_NEW')
-    const swapEligibility = eligibilityV2.value?.swap.reasons.some(r => r.type === 'ACCOUNT_TOO_NEW')
-    if (tradeEligibility || swapEligibility)
-      return true
+    const tradeEligibility = eligibilityV2.value?.trade.reasons.some(
+      r => r.type === 'ACCOUNT_TOO_NEW',
+    )
+    const swapEligibility = eligibilityV2.value?.swap.reasons.some(
+      r => r.type === 'ACCOUNT_TOO_NEW',
+    )
+    if (tradeEligibility || swapEligibility) return true
 
-    const tradeRecentlyRewarded = eligibilityV2.value?.trade.reasons.some(r => r.type === 'USER_RECENTLY_REWARDED')
-    const swapRecentlyRewarded = eligibilityV2.value?.swap.reasons.some(r => r.type === 'USER_RECENTLY_REWARDED')
+    const tradeRecentlyRewarded = eligibilityV2.value?.trade.reasons.some(
+      r => r.type === 'USER_RECENTLY_REWARDED',
+    )
+    const swapRecentlyRewarded = eligibilityV2.value?.swap.reasons.some(
+      r => r.type === 'USER_RECENTLY_REWARDED',
+    )
 
     const tradeGeneric = eligibilityV2.value?.trade.reasons.some(
       r => r.type === 'REWARDS_DISABLED',
@@ -352,7 +384,9 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
   const canClaimReward = computed(() => {
     if (isBitcoinChain.value) return true
     if (!eligibilityV2.value) return false
-    return eligibilityV2.value.swap.eligible || eligibilityV2.value.trade.eligible
+    return (
+      eligibilityV2.value.swap.eligible || eligibilityV2.value.trade.eligible
+    )
   })
 
   const isLoading = computed(() => {

--- a/src/stores/rewardsStore.ts
+++ b/src/stores/rewardsStore.ts
@@ -171,18 +171,6 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
     }
   }
 
-  const swapClaimed = computed(() => {
-    const e = eligibilityV2.value?.swap
-    if (!e || e.eligible) return false
-    return e.reasons.some(r => r.type === 'USER_RECENTLY_REWARDED')
-  })
-
-  const tradeClaimed = computed(() => {
-    const e = eligibilityV2.value?.trade
-    if (!e || e.eligible) return false
-    return e.reasons.some(r => r.type === 'USER_RECENTLY_REWARDED')
-  })
-
   const swapNoRewards = computed(
     () =>
       !swapPool.value?.open || swapPool.value?.hourlyRemainingRewardCount === 0,
@@ -254,6 +242,9 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
   /** User Rewards */
   const todaysRewardSwap = ref<V2RewardItem | null>(null)
   const todayTradeReward = ref<V2RewardItem | null>(null)
+
+  const swapClaimed = computed(() => todaysRewardSwap.value !== null)
+  const tradeClaimed = computed(() => todayTradeReward.value !== null)
 
   const hasRewards = computed(() => rewards.value.length > 0)
 

--- a/src/stores/rewardsStore.ts
+++ b/src/stores/rewardsStore.ts
@@ -9,11 +9,9 @@ import { analytics, RewardsEvent } from '@/analytics'
 import useBalanceHandler from '@/utils/balanceHandler'
 import type { TokenBalancesRaw } from '@/mew_api/types'
 
-type PoolStatusResponse = components['schemas']['PoolStatusResponse']
 type V2PoolStatusResponse = components['schemas']['V2PoolStatusResponse']
-type EligibilityResponse = components['schemas']['EligibilityResponse']
 type V2EligibilityResponse = components['schemas']['V2EligibilityResponse']
-type RewardItem = components['schemas']['RewardItem']
+type V2RewardItem = components['schemas']['V2RewardItem']
 
 const REWARDS_BASE_URL = Configs.MEW_REWARDS_API_URL
 
@@ -59,23 +57,21 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
     }
   }
 
-  const pool = ref<PoolStatusResponse | null>(null)
   const poolV2 = ref<V2PoolStatusResponse | null>(null)
-  const eligibility = ref<EligibilityResponse | null>(null)
   const eligibilityV2 = ref<V2EligibilityResponse | null>(null)
-  const rewards = ref<RewardItem[]>([])
+  const rewards = ref<V2RewardItem[]>([])
   const isLoadingPool = ref(false)
   const isLoadingEligibility = ref(false)
   const isLoadingRewards = ref(false)
   const hadInitialLoad = ref(false)
 
   /** Pool */
-  const isPoolOpen = computed(() => pool.value?.open ?? false)
+  const isPoolOpen = computed(() => poolV2.value?.open ?? false)
   const rewardsLeft = computed(
-    () => pool.value?.hourlyRemainingRewardCount ?? '0',
+    () => poolV2.value?.swap.hourlyRemainingRewardCount ?? poolV2.value?.trade.hourlyRemainingRewardCount ?? '0',
   )
-  const nextHourStart = computed(() => pool.value?.nextHourStart ?? null)
-  const poolReasons = computed(() => pool.value?.reasons ?? [])
+  const nextHourStart = computed(() => poolV2.value?.nextHourStart ?? null)
+  const poolReasons = computed(() => poolV2.value?.reasons ?? [])
   const swapPool = computed(() => poolV2.value?.swap ?? null)
   const tradePool = computed(() => poolV2.value?.trade ?? null)
 
@@ -83,11 +79,7 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
     if (isBitcoinChain.value) return
     isLoadingPool.value = true
     try {
-      const [v1Result, v2Result] = await Promise.all([
-        fetchRewards<PoolStatusResponse>('/v1/rewards/pool'),
-        fetchRewards<V2PoolStatusResponse>('/v2/rewards/pool'),
-      ])
-      pool.value = v1Result
+      const v2Result = await fetchRewards<V2PoolStatusResponse>('/v2/rewards/pool')
       poolV2.value = v2Result
     } catch (error) {
       console.error('Failed to fetch reward pool status:', error)
@@ -136,27 +128,22 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
   }
 
   /** Eligibility */
-  const isEligible = computed(() => eligibility.value?.eligible ?? false)
+  const isEligible = computed(() => eligibilityV2.value?.swap.eligible ?? eligibilityV2.value?.trade.eligible ?? false)
   const nextEligibleDate = computed(
-    () => eligibility.value?.nextEligibleDate ?? null,
+    () => eligibilityV2.value?.swap.nextEligibleDate ?? eligibilityV2.value?.trade.nextEligibleDate ?? false,
   )
-  const eligibilityReasons = computed(() => eligibility.value?.reasons ?? [])
+  const eligibilityReasons = computed(() => eligibilityV2.value?.swap.reasons ?? eligibilityV2.value?.trade.reasons ?? [])
 
   const fetchEligibility = async () => {
     if (!walletAddress.value || isBitcoinChain.value) return
     isLoadingEligibility.value = true
     try {
-      const [v1Result, v2Result] = await Promise.all([
-        fetchRewards<EligibilityResponse>(
-          `/v1/addresses/${walletAddress.value}/rewards/eligibility`,
-        ),
+      const result = await
         fetchRewards<V2EligibilityResponse>(
           `/v2/addresses/${walletAddress.value}/rewards/eligibility`,
-        ),
-      ])
-      eligibility.value = v1Result
-      eligibilityV2.value = v2Result
-      const eligible = v1Result?.eligible ?? false
+        )
+      eligibilityV2.value = result
+      const eligible = result?.swap.eligible ?? result?.trade.eligible ?? false
       analytics.setUserProperties({ canClaimRewards: eligible })
     } catch (error) {
       console.error('Failed to fetch reward eligibility:', error)
@@ -223,9 +210,9 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
 
   const checkAvailabilityAfterTransaction = async () => {
     // This function can be called after a transaction to check if user has earned a potential reward, and if so, set the badge immediately without waiting for the next eligibility fetch
-    if (eligibility.value === null || eligibility.value.eligible) {
+    if (eligibilityV2.value === null || (eligibilityV2.value.swap.eligible ?? eligibilityV2.value.trade.eligible)) {
       await fetchEligibility()
-      if (eligibility.value?.eligible) {
+      if (eligibilityV2.value?.swap.eligible || eligibilityV2.value?.trade.eligible) {
         earnedPotentialRewardAddresses.value.push(walletAddress.value!)
         return true
       }
@@ -245,8 +232,8 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
     if (!walletAddress.value || isBitcoinChain.value) return
     isLoadingRewards.value = true
     try {
-      rewards.value = await fetchRewards<RewardItem[]>(
-        `/v1/addresses/${walletAddress.value}/rewards`,
+      rewards.value = await fetchRewards<V2RewardItem[]>(
+        `/v2/addresses/${walletAddress.value}/rewards`,
       )
     } catch (error) {
       console.error('Failed to fetch user rewards:', error)
@@ -261,7 +248,6 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
       fetchEligibility()
       fetchUserRewards()
     } else {
-      eligibility.value = null
       eligibilityV2.value = null
       rewards.value = []
     }
@@ -270,7 +256,7 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
   /** Poll rewards when eligible until today's reward is found */
   let rewardsPollInterval: ReturnType<typeof setInterval> | null = null
 
-  const isRewardEarnedDuringCampaign = (reward: RewardItem): boolean => {
+  const isRewardEarnedDuringCampaign = (reward: V2RewardItem): boolean => {
     const CAMPAIGN_START = new Date('2026-04-22T00:00:00.000Z')
     const CAMPAIGN_END = new Date('2026-04-29T00:00:00.000Z')
     if (!reward.rewardBroadcastAt) return false
@@ -310,7 +296,7 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
   }
 
   watch(
-    () => eligibility.value?.eligible,
+    () => isEligible.value,
     eligible => {
       if (eligible) {
         // Check immediately if we already have today's reward
@@ -336,27 +322,37 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
   }
 
   const isBanned = computed(() => {
-    if (eligibility.value?.reasons.some(r => r.type === 'ACCOUNT_TOO_NEW'))
+    const tradeEligibility = eligibilityV2.value?.trade.reasons.some(r => r.type === 'ACCOUNT_TOO_NEW')
+    const swapEligibility = eligibilityV2.value?.swap.reasons.some(r => r.type === 'ACCOUNT_TOO_NEW')
+    if (tradeEligibility || swapEligibility)
       return true
 
-    const userRecentlyRewarded = eligibility.value?.reasons.some(
-      r => r.type === 'USER_RECENTLY_REWARDED',
+    const tradeRecentlyRewarded = eligibilityV2.value?.trade.reasons.some(r => r.type === 'USER_RECENTLY_REWARDED')
+    const swapRecentlyRewarded = eligibilityV2.value?.swap.reasons.some(r => r.type === 'USER_RECENTLY_REWARDED')
+
+    const tradeGeneric = eligibilityV2.value?.trade.reasons.some(
+      r =>
+        r.type === 'REWARDS_DISABLED' ||
+        r.type === 'POOL_LOW_ETH' ||
+        r.type === 'POOL_LOW_USDC',
     )
-    if (!userRecentlyRewarded) {
-      return eligibility.value?.reasons.some(
-        r =>
-          r.type === 'REWARDS_DISABLED' ||
-          r.type === 'POOL_LOW_ETH' ||
-          r.type === 'POOL_LOW_USDC',
-      )
+    const swapGeneric = eligibilityV2.value?.swap.reasons.some(
+      r =>
+        r.type === 'REWARDS_DISABLED' ||
+        r.type === 'POOL_LOW_ETH' ||
+        r.type === 'POOL_LOW_USDC',
+    )
+
+    if (!tradeRecentlyRewarded || swapRecentlyRewarded) {
+      return tradeGeneric || swapGeneric
     }
     return false
   })
 
   const canClaimReward = computed(() => {
     if (isBitcoinChain.value) return true
-    if (!eligibility.value) return false
-    return eligibility.value.eligible
+    if (!eligibilityV2.value) return false
+    return eligibilityV2.value.swap.eligible || eligibilityV2.value.trade.eligible
   })
 
   const isLoading = computed(() => {
@@ -369,7 +365,6 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
 
   return {
     // Pool
-    pool,
     isPoolOpen,
     rewardsLeft,
     nextHourStart,
@@ -379,7 +374,7 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
     isLoadingPool,
     fetchPool,
     // Eligibility
-    eligibility,
+    eligibilityV2,
     isEligible,
     nextEligibleDate,
     eligibilityReasons,

--- a/src/stores/rewardsStore.ts
+++ b/src/stores/rewardsStore.ts
@@ -4,7 +4,7 @@ import type { components } from '@/mew_api/schemaRewards'
 import Configs from '@/configs'
 import { useWalletStore } from './walletStore'
 import { useChainsStore } from './chainsStore'
-import { useToastStore } from './toastStore'
+// import { useToastStore } from './toastStore'
 import { analytics, RewardsEvent } from '@/analytics'
 import useBalanceHandler from '@/utils/balanceHandler'
 import type { TokenBalancesRaw } from '@/mew_api/types'
@@ -252,11 +252,9 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
   }
 
   /** User Rewards */
-  const todaysReward = computed(() => {
-    const reward = rewards.value[0]
-    if (reward && isRewardEarnedDuringCampaign(reward)) return reward
-    return null
-  })
+  const todaysRewardSwap = ref<V2RewardItem | null>(null)
+  const todayTradeReward = ref<V2RewardItem | null>(null)
+
   const hasRewards = computed(() => rewards.value.length > 0)
 
   const fetchUserRewards = async () => {
@@ -288,8 +286,11 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
   let rewardsPollInterval: ReturnType<typeof setInterval> | null = null
 
   const isRewardEarnedDuringCampaign = (reward: V2RewardItem): boolean => {
-    const CAMPAIGN_START = new Date('2026-04-22T00:00:00.000Z')
-    const CAMPAIGN_END = new Date('2026-04-29T00:00:00.000Z')
+    if (!poolV2.value) return false
+    const CAMPAIGN_START = new Date(poolV2.value.campaignStartDate)
+    const CAMPAIGN_END = new Date(
+      CAMPAIGN_START.getTime() + 7 * 24 * 60 * 60 * 1000,
+    )
     if (!reward.rewardBroadcastAt) return false
     const rewardDate = new Date(reward.rewardBroadcastAt)
     return rewardDate >= CAMPAIGN_START && rewardDate < CAMPAIGN_END
@@ -306,22 +307,39 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
     stopRewardsPoll()
     rewardsPollInterval = setInterval(async () => {
       await fetchUserRewards()
-      if (rewards.value[0] && isRewardEarnedDuringCampaign(rewards.value[0])) {
-        setEarnedPotentialReward(false)
+      const _rewards = rewards.value.slice(0, 2)
+      if (_rewards.length === 0) return
+      _rewards.forEach(r => {
+        if (
+          todaysRewardSwap.value == null &&
+          r.swapType === 'SWAP' &&
+          isRewardEarnedDuringCampaign(r)
+        ) {
+          todaysRewardSwap.value = r
+          analytics.trackRewardsEvent(RewardsEvent.REWARD_EARNED, {
+            type: 'swap',
+          })
+          wallet.value?.getBalance().then((balances: TokenBalancesRaw) => {
+            useBalanceHandler(balances, setTokens, setIsLoadingBalances)
+          })
+        } else if (
+          todayTradeReward.value == null &&
+          r.swapType === 'TRADE' &&
+          isRewardEarnedDuringCampaign(r)
+        ) {
+          todayTradeReward.value = r
+          analytics.trackRewardsEvent(RewardsEvent.REWARD_EARNED, {
+            type: 'trade',
+          })
+          wallet.value?.getBalance().then((balances: TokenBalancesRaw) => {
+            useBalanceHandler(balances, setTokens, setIsLoadingBalances)
+          })
+        }
+      })
+
+      if (todayTradeReward.value && todaysRewardSwap.value) {
         analytics.setUserProperties({ canClaimRewards: false })
-        analytics.trackRewardsEvent(RewardsEvent.REWARD_EARNED)
-      }
-      if (
-        rewards.value[0] &&
-        isRewardEarnedDuringCampaign(rewards.value[0]) &&
-        rewards.value[0].rewardStatus === 'SUCCESS'
-      ) {
-        const toastStore = useToastStore()
-        toastStore.toggleRewardToast(true)
         stopRewardsPoll()
-        wallet.value?.getBalance().then((balances: TokenBalancesRaw) => {
-          useBalanceHandler(balances, setTokens, setIsLoadingBalances)
-        })
       }
     }, 5000)
   }
@@ -331,12 +349,6 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
     eligible => {
       if (eligible) {
         // Check immediately if we already have today's reward
-        if (
-          rewards.value[0] &&
-          isRewardEarnedDuringCampaign(rewards.value[0]) &&
-          rewards.value[0].rewardStatus === 'SUCCESS'
-        )
-          return
         startRewardsPoll()
       } else {
         stopRewardsPoll()
@@ -428,7 +440,6 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
     checkAvailabilityAfterTransaction,
     // User Rewards
     rewards,
-    todaysReward,
     hasRewards,
     isLoadingRewards,
     fetchUserRewards,

--- a/src/stores/rewardsStore.ts
+++ b/src/stores/rewardsStore.ts
@@ -222,6 +222,9 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
 
   /** User Rewards */
   const todaysReward = computed(() => {
+    const reward = rewards.value[0]
+    if (reward && isRewardEarnedDuringCampaign(reward)) return reward
+    return null
   })
   const hasRewards = computed(() => rewards.value.length > 0)
 

--- a/src/stores/rewardsStore.ts
+++ b/src/stores/rewardsStore.ts
@@ -208,13 +208,13 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
     () => tradePool.value?.hourlyRemainingRewardCount ?? null,
   )
 
-  const checkAvailabilityAfterTransaction = async () => {
+  const checkAvailabilityAfterTransaction = async (type: 'swap' | 'trade') => {
     // This function can be called after a transaction to check if user has earned a potential reward, and if so, set the badge immediately without waiting for the next eligibility fetch
     if (eligibilityV2.value === null || (eligibilityV2.value.swap.eligible ?? eligibilityV2.value.trade.eligible)) {
       await fetchEligibility()
       if (eligibilityV2.value?.swap.eligible || eligibilityV2.value?.trade.eligible) {
         earnedPotentialRewardAddresses.value.push(walletAddress.value!)
-        return true
+        return eligibilityV2.value[type].eligible
       }
     }
     return false
@@ -222,9 +222,6 @@ export const useRewardsStore = defineStore('rewardsStore', () => {
 
   /** User Rewards */
   const todaysReward = computed(() => {
-    const reward = rewards.value[0]
-    if (reward && isRewardEarnedDuringCampaign(reward)) return reward
-    return null
   })
   const hasRewards = computed(() => rewards.value.length > 0)
 


### PR DESCRIPTION
### Feature

## What
Added rewards logic for not eligible users and market close states.

## Why
The rewards flow needs to handle cases where users cannot claim rewards or when reward availability depends on market timing.

## How
- Added handling for not eligible reward states
- Added market close logic to the rewards flow
- Updated rewards UI behavior to reflect the new availability states



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Market-closed indicator and a shared "time until market open" countdown shown across rewards screens and banners.
  * Trade row visuals and the Trade action button are disabled/greyed when the market is closed; "Back in…" countdown shows time until market open.
  * Added "Connect another address" CTA to check alternate-address eligibility.

* **Bug Fixes**
  * Clarified ineligible reward messaging to distinguish market closure from other eligibility restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->