### PR TITLE
feat: [MEW-1720] replace ETFs filter with Indices for US100/US500

### DIFF
--- a/src/modules/perps/components/PerpsMarketList.vue
+++ b/src/modules/perps/components/PerpsMarketList.vue
@@ -610,7 +610,7 @@ const filterOptions: FilterOption[] = [
   { label: 'All Markets', value: 'all' },
   { label: 'Stocks', value: 'stocks' },
   { label: 'Commodities', value: 'commodities' },
-  { label: 'ETFs', value: 'etfs' },
+  { label: 'Indices', value: 'indices' },
   { label: 'Watchlist', value: 'watchlist' },
 ]
 
@@ -645,10 +645,10 @@ const filteredContracts = computed(() => {
     list = list.filter(c => watchlist.value.has(c.baseCurrency))
   } else if (selectedFilter.value.value === 'commodities') {
     list = list.filter(c => hasTag(c, 'commodity'))
-  } else if (selectedFilter.value.value === 'etfs') {
-    list = list.filter(c => hasTag(c, 'etf'))
+  } else if (selectedFilter.value.value === 'indices') {
+    list = list.filter(c => hasTag(c, 'index'))
   } else if (selectedFilter.value.value === 'stocks') {
-    list = list.filter(c => !hasTag(c, 'commodity') && !hasTag(c, 'etf'))
+    list = list.filter(c => !hasTag(c, 'commodity') && !hasTag(c, 'index'))
   }
 
   if (searchQuery.value) {

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -548,7 +548,7 @@ export function usePerpsTradeForm() {
     { key: 'all', label: 'All' },
     { key: 'Equities', label: 'Equities' },
     { key: 'Commodities', label: 'Commodities' },
-    { key: 'ETFs', label: 'ETFs' },
+    { key: 'Indices', label: 'Indices' },
   ]
 
   const marketSortOptions: MarketSortOption[] = [

--- a/src/modules/perps/utils/market.ts
+++ b/src/modules/perps/utils/market.ts
@@ -27,7 +27,7 @@ export function hasTag(contract: Contract, tag: string): boolean {
 
 export function getCategory(contract: Contract): string {
   if (hasTag(contract, 'commodity')) return 'Commodities'
-  if (hasTag(contract, 'etf')) return 'ETFs'
+  if (hasTag(contract, 'index')) return 'Indices'
   return 'Equities'
 }
 


### PR DESCRIPTION
## What changed

The Perps market browser previously had an **ETFs** category, which was the home of QQQ. The Ondo perps platform is moving that exposure to the index instruments **US100** (Nasdaq-100) and **US500** (S&P 500), which the API tags as `Index` rather than `ETF`.

## What you'll see

- The market filter pill on the **Markets** list now reads **Indices** instead of **ETFs**. Selecting it shows US100 and US500.
- The **Select Perps Market** dialog (used during order placement) shows the same **Indices** tab.
- The market info page categorises US100 / US500 as **Indices**.
- The **Stocks** tab no longer accidentally includes index instruments.

QQQ, while still present in the sandbox API, is tagged `ETF` and will simply not appear under Indices — once the API removes it, it disappears entirely with no further front-end work.

## How to test

1. Open the Perps module.
2. On the markets list, click the **Indices** filter pill → only US100 and US500 should show.
3. Click **Stocks** → US100/US500 should not be there.
4. Click any market to open the order panel; open the market selector dialog → the **Indices** tab should list the same two markets.
5. Open a market's info page for US100 → the **Category** field should read **Indices**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Indices market category has been added to the markets filter and trade form selector, replacing the previous ETFs category.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->