### PR TITLE
fix: [MEW-1688] disable tp/sl save until edited and add cancel

### DIFF
--- a/src/modules/perps/ModulePerpsTrade.vue
+++ b/src/modules/perps/ModulePerpsTrade.vue
@@ -712,6 +712,7 @@
       :take-profit-error="takeProfitPrecisionError"
       :stop-loss-error="stopLossPrecisionError"
       :quote-decimals="quoteDecimals"
+      :has-edits="hasAutoCloseEdits"
       @clear-take-profit="clearTempTakeProfit"
       @clear-stop-loss="clearTempStopLoss"
       @set-take-profit-pct="setTakeProfitPct"
@@ -851,6 +852,7 @@ const {
   clearTempTakeProfit,
   clearTempStopLoss,
   confirmAutoClose,
+  hasAutoCloseEdits,
   // Submit
   isSubmitting,
   submitDisabled,

--- a/src/modules/perps/components/PerpsTakeProfitStopLossDialog.vue
+++ b/src/modules/perps/components/PerpsTakeProfitStopLossDialog.vue
@@ -167,10 +167,23 @@
           </button>
         </transition>
 
-        <!-- Add Button -->
-        <app-base-button class="w-full" @click="$emit('confirm')">
-          Save
-        </app-base-button>
+        <!-- Actions -->
+        <div class="flex flex-col gap-1">
+          <app-base-button
+            :disabled="!hasEdits"
+            class="w-full"
+            @click="$emit('confirm')"
+          >
+            Save
+          </app-base-button>
+          <app-btn-text
+            class="mx-auto w-full"
+            is-large
+            @click="isOpen = false"
+          >
+            Cancel
+          </app-btn-text>
+        </div>
       </div>
     </template>
   </app-dialog>
@@ -199,6 +212,7 @@ const props = defineProps<{
   takeProfitError?: boolean
   stopLossError?: boolean
   quoteDecimals?: number
+  hasEdits?: boolean
 }>()
 
 const precisionMessage = computed(() => {

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -830,6 +830,12 @@ export function usePerpsTradeForm() {
     showAutoCloseModal.value = false
   }
 
+  const hasAutoCloseEdits = computed(
+    () =>
+      tempTakeProfitPrice.value !== takeProfitPrice.value ||
+      tempStopLossPrice.value !== stopLossPrice.value,
+  )
+
   function clearTakeProfit() {
     takeProfitPrice.value = null
   }
@@ -1125,6 +1131,7 @@ export function usePerpsTradeForm() {
     clearTempTakeProfit,
     clearTempStopLoss,
     confirmAutoClose,
+    hasAutoCloseEdits,
     clearTakeProfit,
     clearStopLoss,
     // Submit


### PR DESCRIPTION
## What was wrong

On the Perps Auto Close popup (Manage position → "Add take profit or stop losses"), the **Save** button was always active — even when no value had been entered or changed. The popup also had no **Cancel** button; closing it required clicking the dialog's X.

## What changes

- **Save** is now disabled until the user actually edits the take-profit or stop-loss value (either by typing, picking a percentage pill, or removing a previously-set value).
- A **Cancel** text button has been added below Save. It closes the popup without applying any changes, mirroring the existing pattern from the order-confirmation dialog.

## How to test

1. Open a Perps position and click **Manage** (or the Auto Close pill on the trade form).
2. Open the **Auto Close** popup — Save should be disabled.
3. Add a Take Profit or Stop Loss (via pill or by typing) — Save enables.
4. Click **Remove** to take it back to the original state — Save disables again.
5. Click **Cancel** — popup closes, no TP/SL is applied to the position.
6. With TP and/or SL already set, reopen the popup — Save stays disabled until a value is changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cancel button to take-profit/stop-loss dialog for easier dismissal without saving
  * Save button now disables when no changes are pending, preventing unintended submissions

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyEtherWallet/MyEtherWallet/pull/5465)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->