### PR TITLE
feat: [MEW-1712] geo-block perpetuals menu and route

### DIFF
--- a/src/components/core_layouts/TheHeader.vue
+++ b/src/components/core_layouts/TheHeader.vue
@@ -147,6 +147,7 @@ import {
 import { type AppMenuListItem, ICON_IDS } from '@/types/components/menuListItem'
 import { type AppSelectOption } from '@/types/components/appSelect'
 import { useWalletStore } from '@/stores/walletStore'
+import { useTradingRestriction } from '@/composables/useTradingRestriction'
 import { storeToRefs } from 'pinia'
 import { WalletType, type HexPrefixedString } from '@/providers/types'
 import { useChainsStore } from '@/stores/chainsStore'
@@ -164,6 +165,7 @@ const { isWalletConnected, wallet } = storeToRefs(store)
 const { setWallet, setWatchOnlyIfExist, disconnectWallet } = store
 const { isEvmChain, isBitcoinChain } = storeToRefs(chainStore)
 const { isMobile, isXLMinAndUp } = useAppBreakpoints()
+const { isTradingRestrictedInRegion } = useTradingRestriction()
 
 /** ------------------------------
  * Breakpoints determine menu visibility
@@ -175,7 +177,7 @@ const showMobileMenu = computed<boolean>(() => !isXLMinAndUp.value)
  * Menu Items
  ------------------------------*/
 const coreMenuList = computed<AppMenuListItem[]>(() => {
-  return [
+  const items: AppMenuListItem[] = [
     {
       title: t('home'),
       routeName: ROUTES_MAIN.HOME.NAME,
@@ -191,17 +193,20 @@ const coreMenuList = computed<AppMenuListItem[]>(() => {
       routeName: ROUTES_MAIN.CRYPTO.NAME,
       iconID: ICON_IDS.CRYPTO,
     },
-    {
+  ]
+  if (!isTradingRestrictedInRegion.value) {
+    items.push({
       title: t('perpetuals'),
       routeName: ROUTES_MAIN.PERPS.NAME,
       iconID: ICON_IDS.PERPS,
-    },
-    {
-      title: t('earn'),
-      routeName: ROUTES_MAIN.EARN.NAME,
-      iconID: ICON_IDS.STAKE,
-    },
-  ]
+    })
+  }
+  items.push({
+    title: t('earn'),
+    routeName: ROUTES_MAIN.EARN.NAME,
+    iconID: ICON_IDS.STAKE,
+  })
+  return items
 })
 const toolsMenuList = computed<AppMenuListItem[]>(() => {
   return [

--- a/src/composables/useTradingRestriction.ts
+++ b/src/composables/useTradingRestriction.ts
@@ -1,5 +1,10 @@
 import { ref } from 'vue'
+import { captureException } from '@sentry/vue'
 import { isTradingRestricted } from '@/modules/trade/providers/ondoHelpers'
+import { SENTRY_MODULE_TAGS } from '@/sentry/constants'
+import Configs from '@/configs'
+
+const isDevMode = Configs.IS_DEV_MODE
 
 const isTradingRestrictedInRegion = ref<boolean>(false)
 let fetchPromise: Promise<boolean> | null = null
@@ -11,9 +16,21 @@ export function fetchTradingRestriction(): Promise<boolean> {
         isTradingRestrictedInRegion.value = result
         return result
       })
-      .catch(() => {
-        isTradingRestrictedInRegion.value = false
-        return false
+      .catch(e => {
+        if (isDevMode) {
+          console.error('Failed to check trading restriction:', e)
+        } else {
+          captureException(e, {
+            ...SENTRY_MODULE_TAGS.TRADE,
+            extra: {
+              title: 'TRADE: Error checking trading restriction',
+              errorMessage: (e as Error).message || 'Unknown error',
+            },
+          })
+        }
+        isTradingRestrictedInRegion.value = true
+        fetchPromise = null
+        return true
       })
   }
   return fetchPromise

--- a/src/composables/useTradingRestriction.ts
+++ b/src/composables/useTradingRestriction.ts
@@ -6,7 +6,7 @@ import Configs from '@/configs'
 
 const isDevMode = Configs.IS_DEV_MODE
 
-const isTradingRestrictedInRegion = ref<boolean>(false)
+const isTradingRestrictedInRegion = ref<boolean>(true)
 let fetchPromise: Promise<boolean> | null = null
 
 export function fetchTradingRestriction(): Promise<boolean> {

--- a/src/composables/useTradingRestriction.ts
+++ b/src/composables/useTradingRestriction.ts
@@ -1,0 +1,25 @@
+import { ref } from 'vue'
+import { isTradingRestricted } from '@/modules/trade/providers/ondoHelpers'
+
+const isTradingRestrictedInRegion = ref<boolean>(false)
+let fetchPromise: Promise<boolean> | null = null
+
+export function fetchTradingRestriction(): Promise<boolean> {
+  if (!fetchPromise) {
+    fetchPromise = isTradingRestricted()
+      .then(result => {
+        isTradingRestrictedInRegion.value = result
+        return result
+      })
+      .catch(() => {
+        isTradingRestrictedInRegion.value = false
+        return false
+      })
+  }
+  return fetchPromise
+}
+
+export function useTradingRestriction() {
+  fetchTradingRestriction()
+  return { isTradingRestrictedInRegion }
+}

--- a/src/router/routesDefault.ts
+++ b/src/router/routesDefault.ts
@@ -10,6 +10,7 @@ import { PERP_INFO_ROUTE } from './routePerpInfo'
 import { ACCESS_ROUTES } from './routesAccess'
 import { CREATE_ROUTES } from './routesCreate'
 import { type RouterOptions } from 'vue-router'
+import { fetchTradingRestriction } from '@/composables/useTradingRestriction'
 
 const TempView = () => import('@/views/ViewTemp.vue')
 const SignMessageView = () => import('@/views/ViewSignMessage.vue')
@@ -90,6 +91,14 @@ const DefaultRoutes = <RouteNameCollection>[
     component: ViewPerps,
     meta: {
       noAuth: true,
+    },
+    beforeEnter: async (_to, _from, next) => {
+      const restricted = await fetchTradingRestriction()
+      if (restricted) {
+        next({ name: ROUTES_MAIN.HOME.NAME })
+      } else {
+        next()
+      }
     },
     children: [
       {


### PR DESCRIPTION
## What's changing
The Perpetuals area is now hidden for users whose IP-compliance check says they can't trade — matching how we already gate Stocks/Trade.

## What the user will see
- **Header menu:** the "Perpetuals" button no longer appears for restricted users (desktop top nav).
- **Mobile side menu:** the "Perpetuals" entry no longer appears for restricted users.
- **Direct URL:** if a restricted user tries to navigate to `/perps` (by typing it, a bookmark, or a deep link), they're redirected to Home.
- **Unrestricted users:** everything looks and works exactly as before.

## Under the hood
Added a small shared composable `useTradingRestriction` that calls the existing `isTradingRestricted` helper once and caches the result, so the header and the router guard both read from the same state without duplicate network calls.

## How to test
1. Pull the branch and run the app.
2. On localhost the IP-comply call is skipped (it only fires on live MEW URLs), so by default Perpetuals shows normally — verify the menu still works and `/perps` loads.
3. To simulate the restricted path, temporarily flip the default in `src/composables/useTradingRestriction.ts` (set the initial ref value to `true`, or force the promise to resolve `true`) and verify:
   - "Perpetuals" disappears from header and from the mobile side menu.
   - Navigating to `/perps` redirects to Home.
4. Revert the override before merging — the live IP-comply endpoint controls real behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Perpetuals now appear in the main navigation only when allowed in the user's region.
  * Direct access to the perpetuals page is blocked for restricted regions and redirects users to the home page.
  * Regional restriction checks run automatically on load and during navigation, with a safe fallback when restrictions apply.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyEtherWallet/MyEtherWallet/pull/5466)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->