### PR TITLE
fix: [MEW-1758] show trigger price on stop loss / take profit orders

### DIFF
--- a/src/modules/perps/components/PerpsCancelOrderConfirmationDialog.vue
+++ b/src/modules/perps/components/PerpsCancelOrderConfirmationDialog.vue
@@ -41,7 +41,9 @@
             class="flex justify-between text-s-14"
           >
             <span class="text-info font-medium">Price</span>
-            <span class="font-bold">{{ formatPrice(order.price) }}</span>
+            <span class="font-bold">{{
+              formatPrice(getOrderPrice(order))
+            }}</span>
           </div>
           <div class="flex justify-between text-s-14">
             <span class="text-info font-medium">Size</span>
@@ -91,7 +93,7 @@ import AppDialog from '@/components/AppDialog.vue'
 import AppTokenLogo from '@/components/AppTokenLogo.vue'
 import AppBaseButton from '@/components/AppBaseButton.vue'
 import AppBtnText from '@/components/AppBtnText.vue'
-import { formatPrice } from '../utils/formatters'
+import { formatPrice, getOrderPrice } from '../utils/formatters'
 import { getLogoUrl } from '../utils/market'
 import type { ApiOrder } from '../sdk/types'
 import { computed } from 'vue'
@@ -114,7 +116,9 @@ defineEmits<{
 
 const orderSizeInUsd = computed(() => {
   return formatPrice(
-    BigNumber(props.order.price).times(BigNumber(props.order.size)).toString(),
+    BigNumber(getOrderPrice(props.order))
+      .times(BigNumber(props.order.size))
+      .toString(),
   )
 })
 

--- a/src/modules/perps/components/PerpsOrderDialog.vue
+++ b/src/modules/perps/components/PerpsOrderDialog.vue
@@ -84,8 +84,8 @@ import { getBase, getLogoUrl } from '../utils/market'
 const orderTypeLabels: Record<string, string> = {
   limit: 'Limit',
   market: 'Market',
-  stopMarket: 'Stop Market',
-  takeProfitMarket: 'Take Profit Market',
+  stopMarket: 'Stop Loss',
+  takeProfitMarket: 'Take Profit',
 }
 
 const orderStatusLabels: Record<string, string> = {

--- a/src/modules/perps/sdk/types.ts
+++ b/src/modules/perps/sdk/types.ts
@@ -341,6 +341,9 @@ export interface ApiOrder {
   timeInForce?: 'GTC' | 'IOC'
   reduceOnly?: boolean
   realizedPnl?: string
+  triggerPrice?: string
+  stopOrderType?: 'stopLoss' | 'takeProfit'
+  closePosition?: boolean
 }
 
 export interface ApiFill {

--- a/src/modules/perps/utils/formatters.ts
+++ b/src/modules/perps/utils/formatters.ts
@@ -5,7 +5,9 @@ import type { ApiOrder } from '../sdk/types'
  */
 
 // Market orders return an empty price from the API; derive it from
-// filledCost / filledSize once the order has filled.
+// filledCost / filledSize once the order has filled. Stop/take-profit
+// orders carry their target in `triggerPrice` and leave `price` empty
+// until they trigger.
 export function getOrderPrice(order: ApiOrder): string {
   if (
     order.type === 'market' &&
@@ -17,6 +19,12 @@ export function getOrderPrice(order: ApiOrder): string {
     return new BigNumber(order.filledCost)
       .dividedBy(order.filledSize)
       .toString()
+  }
+  if (
+    (order.type === 'stopMarket' || order.type === 'takeProfitMarket') &&
+    order.triggerPrice
+  ) {
+    return order.triggerPrice
   }
   return order.price
 }
@@ -163,8 +171,8 @@ export const formatOrderStatus = (status: string): string => {
 export const orderTypeLabels: Record<string, string> = {
   limit: 'Limit',
   market: 'Market',
-  stopMarket: 'Stop Market',
-  takeProfitMarket: 'Take Profit Market',
+  stopMarket: 'Stop Loss',
+  takeProfitMarket: 'Take Profit',
 }
 
 export const formatOrderType = (type: string): string => {


### PR DESCRIPTION
## What was wrong

When you placed a Stop Loss or Take Profit on a perps position, the order showed up in the open-orders list with a **$0.00 price**, and the cancel-order dialog had the same problem. The trigger price you set was being ignored on display.

The order label also read "Stop Market" / "Take Profit Market", which doesn't match how traders refer to these orders.

## What you'll see now

- The orders table (both on the market page and the positions tab) now displays the **trigger price** for stop-loss / take-profit orders, instead of $0.00.
- The cancel-order confirmation dialog shows the trigger price and computes the USD size correctly.
- The order-type label reads **"Stop Loss"** or **"Take Profit"** (no longer "Stop Market" / "Take Profit Market").

## How to test

1. Open a perps position.
2. Set a Stop Loss and/or Take Profit on it.
3. Go to the orders table (positions tab or market page) — confirm the Price column shows your trigger price, not $0.00.
4. Confirm the order-type column reads "Stop Loss" / "Take Profit".
5. Open the row's cancel-order dialog — confirm Price and the USD size below Size are correct.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed order price display for stop loss and take profit orders to show trigger prices instead of regular prices.

* **UI/UX Improvements**
  * Clarified order type labels: "Stop Market" now displays as "Stop Loss" and "Take Profit Market" as "Take Profit" for better clarity.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyEtherWallet/MyEtherWallet/pull/5467)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->