### PR TITLE
fix: [MEW-1762] order details dialog opens behind market info page

### DIFF
--- a/src/modules/perps/components/PerpsOrderDialog.vue
+++ b/src/modules/perps/components/PerpsOrderDialog.vue
@@ -4,8 +4,8 @@
     has-content-gutter
     class="sm:w-[440px] sm:mx-auto"
     @close-dialog="$emit('close')"
-    z-index-container="110"
-    z-index-overlay="111"
+    z-index-overlay="z-[110]"
+    z-index-container="z-[111]"
   >
     <template #content>
       <div class="flex items-center gap-3 w-full mt-5 px-4">


### PR DESCRIPTION
## What was wrong
On the Market Info page (the per-market detail dialog), clicking on an order row in the Orders tab would open the order details dialog *behind* the Market Info page, making it invisible to the user.

## Why it was happening
The order details dialog (`PerpsOrderDialog`) tried to override its z-index by passing raw numbers (`"110"` / `"111"`) to `AppDialog`. But `AppDialog` expects those props to be Tailwind class strings (e.g. `z-[100]`), so Tailwind didn't generate any CSS for them. The dialog ended up with no z-index at all and was painted underneath the Market Info wrapper.

## What the user will now see
The order details dialog opens correctly on top of the Market Info page when an order row is clicked.

## How to test
1. Sign in to Perps with a wallet that has at least one order in any market.
2. Navigate to the Market Info page (click the market name on the Portfolio page, or open the per-market view from any market list).
3. Switch to the **Orders** tab inside the position info section.
4. Click on any order row.
5. **Expected:** The order details dialog appears on top of the Market Info page, fully visible and interactive.
6. Close the dialog — Market Info should still be visible behind it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated dialog layering styles for improved consistency and maintainability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyEtherWallet/MyEtherWallet/pull/5471)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->