### PR TITLE
feat: [MEW-1719] add all/pending filter to market info orders tab

### DIFF
--- a/src/modules/perps/ModulePerpInfo.vue
+++ b/src/modules/perps/ModulePerpInfo.vue
@@ -471,13 +471,41 @@
             class="w-full"
             key="position-orders"
           >
+            <div class="mb-4 xs:pl-4">
+              <app-btn-group
+                v-model:selected="selectedOrderFilter"
+                :btn-list="orderFilterTabs"
+                size="xs"
+              >
+                <template #btn-content="{ data }">
+                  <span class="px-2"
+                    >{{ data.label }}
+                    <span
+                      v-if="
+                        data.value === 'pending' && openOrdersCountForMarket > 0
+                      "
+                      class="ml-1 text-info text-s-11"
+                    >
+                      ·
+                      {{
+                        openOrdersCountIsCapped
+                          ? `${OPEN_COUNT_LIMIT}+`
+                          : openOrdersCountForMarket
+                      }}
+                    </span></span
+                  >
+                </template>
+              </app-btn-group>
+            </div>
             <app-table-skeleton
               v-if="ordersLoading && marketOrders.length === 0"
               :rows="3"
               :columns="ordersSkeletonColumns"
             />
             <div
-              v-else-if="marketOrders.length === 0 && ordersCurrentPage === 0"
+              v-else-if="
+                filteredMarketOrders.length === 0 && ordersCurrentPage === 0
+              "
               class="text-center py-8 text-info text-s-14"
             >
               No orders for {{ baseCurrency }}
@@ -516,7 +544,7 @@
               </thead>
               <tbody>
                 <tr
-                  v-for="order in marketOrders"
+                  v-for="order in filteredMarketOrders"
                   :key="order.orderId"
                   class="hoverBGWhite"
                   @click="openOrderDialog(order)"
@@ -1064,6 +1092,17 @@ const PENDING_STATUSES = new Set(['pending', 'untriggered', 'open'])
 const openOrdersCountForMarket = ref(0)
 const openOrdersCountIsCapped = ref(false)
 let openOrdersFetchSeq = 0
+
+const orderFilterTabs = [
+  { label: 'All', value: 'all' },
+  { label: 'Pending', value: 'pending' },
+]
+const selectedOrderFilter = ref(orderFilterTabs[0])
+
+const filteredMarketOrders = computed(() => {
+  if (selectedOrderFilter.value.value === 'all') return marketOrders.value
+  return marketOrders.value.filter(o => PENDING_STATUSES.has(o.status))
+})
 
 async function fetchOpenOrdersCount() {
   if (!token.value) {


### PR DESCRIPTION
## What's new

The Market Info panel's **Orders** tab now has the same **All / Pending** filter that exists on the portfolio Orders tab, so you can quickly narrow the list to just orders that are still working.

## What you'll see

- A small toggle (All · Pending) sits above the orders list on the Market Info panel.
- **All** behaves the way the tab does today.
- **Pending** hides filled and canceled orders, leaving only pending / untriggered / open ones.
- The pending button shows a count badge (e.g. `· 7`) when there are pending orders, and `· 50+` if there are at least 50.

## How to test

1. Open the perps wallet panel and click into a market that has a mix of order statuses (or place a limit order to create a pending one).
2. On the Market Info view, switch to the **Orders** tab.
3. Click **Pending** — only pending / open / untriggered orders should remain.
4. Click **All** — every order for the market should be visible again.
5. Confirm the count badge on **Pending** matches what you see in the list.
6. Paginate forward/back — the filter selection should persist across pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added order status filters ("All" and "Pending") to the Orders tab, enabling users to view orders based on their current status. The display now accurately reflects filtered results and corresponding empty states.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyEtherWallet/MyEtherWallet/pull/5472)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->