### PR TITLE
fix: [MEW-1785] prevent empty-state flash on perps positions table

### DIFF
--- a/src/modules/perps/composables/usePerpsPositions.ts
+++ b/src/modules/perps/composables/usePerpsPositions.ts
@@ -46,14 +46,14 @@ function startPolling() {
 
   // The singleton is often initialised by PerpsMarketList (mounted before auth)
   // so the first poll() runs with no token and never sets loading=true. React
-  // to login/logout immediately so PerpsPositionsTable sees a loading state on
-  // mount instead of an empty-state flash until the 5s interval ticks.
+  // to any token change immediately so PerpsPositionsTable sees a loading state
+  // on mount instead of an empty-state flash until the 5s interval ticks. Drop
+  // stale data on the way out — covers logout and wallet-switch (A->B without
+  // an intermediate clearAuth), where the previous account's positions would
+  // otherwise linger on screen.
   watch(token, (newToken, oldToken) => {
-    if (newToken && !oldToken) {
-      poll()
-    } else if (!newToken && oldToken) {
-      positions.value = []
-    }
+    if (oldToken) positions.value = []
+    if (newToken) poll()
   })
 
   // Watch for refreshKey changes by storing last seen value

--- a/src/modules/perps/composables/usePerpsPositions.ts
+++ b/src/modules/perps/composables/usePerpsPositions.ts
@@ -1,4 +1,4 @@
-import { ref } from 'vue'
+import { ref, watch } from 'vue'
 import { perpsClient } from '../configs'
 import { usePerpsAuth } from './usePerpsAuth'
 import type { Position } from '../sdk/types'
@@ -43,6 +43,18 @@ function startPolling() {
 
   poll()
   setInterval(poll, 5_000)
+
+  // The singleton is often initialised by PerpsMarketList (mounted before auth)
+  // so the first poll() runs with no token and never sets loading=true. React
+  // to login/logout immediately so PerpsPositionsTable sees a loading state on
+  // mount instead of an empty-state flash until the 5s interval ticks.
+  watch(token, (newToken, oldToken) => {
+    if (newToken && !oldToken) {
+      poll()
+    } else if (!newToken && oldToken) {
+      positions.value = []
+    }
+  })
 
   // Watch for refreshKey changes by storing last seen value
   let lastRefreshKey = refreshKey.value


### PR DESCRIPTION
## What was wrong

On the Perpetuals landing page, the main positions table briefly showed **"No open positions"** before switching to the loading skeleton and then to the actual list of active positions. Users with active positions saw a confusing empty-state flicker every time they signed in or returned to the page after a sign-in.

## Why it was happening

The positions data is served by a singleton composable (`usePerpsPositions`). On the landing page, the **Markets list** is rendered outside of the auth gate, so it is the very first component to subscribe to positions — usually before the user has signed in. With no auth token at that moment, the first poll silently no-ops and never flips the table into the loading state. The next refresh only fires once the 5-second background timer ticks, which leaves a window where the positions table mounts with no data and no loading flag — hence the "No open positions" flash.

## What was changed

The positions feed now reacts to sign-in/sign-out the instant it happens, instead of waiting for the background timer:

- **On sign-in**: a fresh positions fetch is kicked off immediately, so the table mounts already in its loading state and goes directly to the skeleton until the real data arrives.
- **On sign-out**: cached positions are cleared right away.

No UI was changed; the fix is entirely in the data layer.

## What the user will now see

- Sign in → land on `/perps` → positions table goes **skeleton → table** with no "No open positions" text in between.
- Hard-reload `/perps` while already signed in → same clean transition.
- Sign out → table is hidden behind the auth banner as before.

## How to test

1. Open the app while signed out and navigate to `/perps`.
2. Sign in with a wallet that has at least one open perp position.
3. Watch the positions table on the landing page — it should go straight from skeleton to populated rows, with no "No open positions" message appearing first.
4. Sign out, sign back in a couple of times to confirm the flash does not return.
5. Open a market via the Perp Info page and confirm the per-market position panel still renders correctly when you have/don't have a position in that market.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminated the initial empty-state flash by loading positions immediately after login, improving perceived responsiveness.
  * Ensured positions are cleared promptly on logout, preventing stale account data from persisting across sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyEtherWallet/MyEtherWallet/pull/5474)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->