### PR TITLE
fix: [MEW-1728][MEW-1671][MEW-1799] perps withdraw dialog fixes (close on success, fee, error feedback)

### DIFF
--- a/src/modules/perps/components/PerpsWithdrawDialog.vue
+++ b/src/modules/perps/components/PerpsWithdrawDialog.vue
@@ -79,7 +79,7 @@
           class="mb-4"
         />
         <transition name="fade">
-          <p v-if="error" class="text-error text-s-12 absolute -top-3 left-0">
+          <p v-if="error" class="text-error text-s-12 mb-2">
             {{ error }}
           </p>
         </transition>

--- a/src/modules/perps/components/PerpsWithdrawDialog.vue
+++ b/src/modules/perps/components/PerpsWithdrawDialog.vue
@@ -79,9 +79,14 @@
           class="mb-4"
         />
         <transition name="fade">
-          <p v-if="error" class="text-error text-s-12 mb-2">
-            {{ error }}
-          </p>
+          <div
+            v-if="error"
+            class="w-full p-4 bg-error-10 border border-error rounded-12 mb-2"
+          >
+            <p class="text-error text-s-14 text-center">
+              {{ error }}
+            </p>
+          </div>
         </transition>
         <app-base-button
           :disabled="sending || !isValidAmount"

--- a/src/modules/perps/components/PerpsWithdrawDialog.vue
+++ b/src/modules/perps/components/PerpsWithdrawDialog.vue
@@ -110,6 +110,8 @@ import { storeToRefs } from 'pinia'
 import { usePerpsToasts } from '@/modules/perps/composables/usePerpsToasts'
 import { hasInvalidPrecision } from '../utils/formatters'
 import AppBlockie from '@/components/AppBlockie.vue'
+import { captureException } from '@sentry/vue'
+import { SENTRY_MODULE_TAGS } from '@/sentry/constants'
 const props = defineProps<{
   visible: boolean
 }>()
@@ -186,8 +188,14 @@ watch(
       const accountRes = await perpsClient.getAccount()
       withdrawalFeeUSD.value =
         accountRes?.result?.withdrawalFeeUSD ?? DEFAULT_WITHDRAWAL_FEE_USD
-    } catch {
+    } catch (e) {
       // Keep the default fee shown if the lookup fails.
+      captureException(e, {
+        ...SENTRY_MODULE_TAGS.PERPS,
+        extra: {
+          title: 'PERPS: Error fetching withdrawal fee',
+        },
+      })
     }
   },
 )

--- a/src/modules/perps/components/PerpsWithdrawDialog.vue
+++ b/src/modules/perps/components/PerpsWithdrawDialog.vue
@@ -65,6 +65,11 @@
               </p>
             </div>
           </div>
+          <!-- Withdrawal fee -->
+          <div class="flex justify-between text-s-13">
+            <span class="text-info">Withdrawal fee:</span>
+            <span class="font-medium">${{ formatUsd(withdrawalFeeUSD) }}</span>
+          </div>
         </div>
 
         <app-warning
@@ -132,6 +137,7 @@ const hasOpenPositions = computed(() => positions.value.length > 0)
 const sending = ref(false)
 const error = ref<string | null>(null)
 const walletAddress = ref<string | null>(null)
+const withdrawalFeeUSD = ref('1')
 
 const withdrawableMargin = computed(
   () => balance.value?.withdrawableMargin ?? '0',
@@ -174,6 +180,12 @@ watch(
     error.value = null
     if (wallet.value) {
       walletAddress.value = await wallet.value.getAddress()
+    }
+    try {
+      const accountRes = await perpsClient.getAccount()
+      withdrawalFeeUSD.value = accountRes.result.withdrawalFeeUSD
+    } catch {
+      // Keep the default fee shown if the lookup fails.
     }
   },
 )

--- a/src/modules/perps/components/PerpsWithdrawDialog.vue
+++ b/src/modules/perps/components/PerpsWithdrawDialog.vue
@@ -67,18 +67,8 @@
           </div>
         </div>
 
-        <!-- Success -->
-        <div
-          v-if="withdrawalSuccess"
-          class="bg-light-green-1 rounded-12 p-4 mb-4"
-        >
-          <p class="text-success font-medium text-s-14">
-            Withdrawal submitted!
-          </p>
-        </div>
-
         <app-warning
-          v-if="!withdrawalSuccess && hasOpenPositions"
+          v-if="hasOpenPositions"
           title="Liquidation Risk"
           text="You have open positions. Withdrawing funds will reduce your account equity and increase your effective leverage, which may increase your liquidation risk."
           class="mb-4"
@@ -89,15 +79,11 @@
           </p>
         </transition>
         <app-base-button
-          v-if="!withdrawalSuccess"
           :disabled="sending || !isValidAmount"
           :is-loading="sending"
           class="w-full"
           @click="submitWithdraw"
           >Withdraw</app-base-button
-        >
-        <app-base-button v-else class="w-full" @click="$emit('close')"
-          >Done</app-base-button
         >
       </div>
     </template>
@@ -123,7 +109,7 @@ const props = defineProps<{
   visible: boolean
 }>()
 
-defineEmits<{
+const emit = defineEmits<{
   close: []
 }>()
 
@@ -145,7 +131,6 @@ const hasOpenPositions = computed(() => positions.value.length > 0)
 
 const sending = ref(false)
 const error = ref<string | null>(null)
-const withdrawalSuccess = ref(false)
 const walletAddress = ref<string | null>(null)
 
 const withdrawableMargin = computed(
@@ -187,7 +172,6 @@ watch(
     amount.value = null
     amountError.value = ''
     error.value = null
-    withdrawalSuccess.value = false
     if (wallet.value) {
       walletAddress.value = await wallet.value.getAddress()
     }
@@ -231,9 +215,9 @@ async function submitWithdraw() {
       address: walletAddress.value,
       from: { id: accountId.value, wallet: 'margin' },
     })
-    withdrawalSuccess.value = true
     triggerRefresh()
     perpsToasts.toastWithdrawalComplete()
+    emit('close')
   } catch (e) {
     // TODO(perps-toasts): spec has no withdrawal-failure toast; revisit with design if needed
     error.value = e instanceof Error ? e.message : 'Withdrawal failed'

--- a/src/modules/perps/components/PerpsWithdrawDialog.vue
+++ b/src/modules/perps/components/PerpsWithdrawDialog.vue
@@ -137,6 +137,7 @@ const hasOpenPositions = computed(() => positions.value.length > 0)
 const sending = ref(false)
 const error = ref<string | null>(null)
 const walletAddress = ref<string | null>(null)
+// TODO: revisit using accountRes.result.withdrawalFeeUSD once the API value is reliable.
 const DEFAULT_WITHDRAWAL_FEE_USD = '1'
 const withdrawalFeeUSD = ref(DEFAULT_WITHDRAWAL_FEE_USD)
 
@@ -181,13 +182,6 @@ watch(
     error.value = null
     if (wallet.value) {
       walletAddress.value = await wallet.value.getAddress()
-    }
-    try {
-      const accountRes = await perpsClient.getAccount()
-      withdrawalFeeUSD.value =
-        accountRes?.result?.withdrawalFeeUSD ?? DEFAULT_WITHDRAWAL_FEE_USD
-    } catch {
-      // Keep the default fee shown if the lookup fails.
     }
   },
 )

--- a/src/modules/perps/components/PerpsWithdrawDialog.vue
+++ b/src/modules/perps/components/PerpsWithdrawDialog.vue
@@ -137,7 +137,8 @@ const hasOpenPositions = computed(() => positions.value.length > 0)
 const sending = ref(false)
 const error = ref<string | null>(null)
 const walletAddress = ref<string | null>(null)
-const withdrawalFeeUSD = ref('1')
+const DEFAULT_WITHDRAWAL_FEE_USD = '1'
+const withdrawalFeeUSD = ref(DEFAULT_WITHDRAWAL_FEE_USD)
 
 const withdrawableMargin = computed(
   () => balance.value?.withdrawableMargin ?? '0',
@@ -183,7 +184,8 @@ watch(
     }
     try {
       const accountRes = await perpsClient.getAccount()
-      withdrawalFeeUSD.value = accountRes.result.withdrawalFeeUSD
+      withdrawalFeeUSD.value =
+        accountRes?.result?.withdrawalFeeUSD ?? DEFAULT_WITHDRAWAL_FEE_USD
     } catch {
       // Keep the default fee shown if the lookup fails.
     }

--- a/src/modules/perps/components/PerpsWithdrawDialog.vue
+++ b/src/modules/perps/components/PerpsWithdrawDialog.vue
@@ -137,7 +137,6 @@ const hasOpenPositions = computed(() => positions.value.length > 0)
 const sending = ref(false)
 const error = ref<string | null>(null)
 const walletAddress = ref<string | null>(null)
-// TODO: revisit using accountRes.result.withdrawalFeeUSD once the API value is reliable.
 const DEFAULT_WITHDRAWAL_FEE_USD = '1'
 const withdrawalFeeUSD = ref(DEFAULT_WITHDRAWAL_FEE_USD)
 
@@ -182,6 +181,13 @@ watch(
     error.value = null
     if (wallet.value) {
       walletAddress.value = await wallet.value.getAddress()
+    }
+    try {
+      const accountRes = await perpsClient.getAccount()
+      withdrawalFeeUSD.value =
+        accountRes?.result?.withdrawalFeeUSD ?? DEFAULT_WITHDRAWAL_FEE_USD
+    } catch {
+      // Keep the default fee shown if the lookup fails.
     }
   },
 )

--- a/src/modules/perps/composables/usePerpsMarkets.ts
+++ b/src/modules/perps/composables/usePerpsMarkets.ts
@@ -42,10 +42,12 @@ const contracts = ref<Contract[]>([])
 const contractsLoading = ref(false)
 const contractsError = ref<string | null>(null)
 let contractsInitialized = false
+let isFirstContractsFetch = true
 
 async function fetchContracts() {
-  if (!contractsInitialized) {
+  if (isFirstContractsFetch) {
     contractsLoading.value = true
+    isFirstContractsFetch = false
   }
   contractsError.value = null
   try {

--- a/src/sentry/constants.ts
+++ b/src/sentry/constants.ts
@@ -5,4 +5,5 @@ export const SENTRY_MODULE_TAGS = {
   SEND: { tags: { module: 'send' } },
   NOTIFICATIONS: { tags: { module: 'notifications' } },
   PORTFOLIO: { tags: { module: 'portfolio' } },
+  PERPS: { tags: { module: 'perps' } },
 } as const


### PR DESCRIPTION
Three small fixes to the Perps Withdraw dialog, bundled into one PR to make review easier. Originally three stacked PRs (#5475 / #5476 / #5477) — now consolidated here.

---

## 1. [MEW-1728] Close the dialog after a successful withdrawal

### What was wrong
After submitting a withdrawal, the dialog stayed open and showed an in-modal "Withdrawal submitted!" panel with the amount field still editable. Users could accidentally edit the amount after the request had already been sent.

### What the user sees now
On a successful submit the dialog closes automatically and the existing toast ("Withdrawal complete") confirms the action — same pattern as the Deposit flow.

### How to test
1. Connect a wallet, open the Perps section, click **Withdraw**.
2. Enter a valid amount and click **Withdraw**.
3. The dialog should close and a confirmation toast should appear.
4. Balances should refresh.

---

## 2. [MEW-1671] Show the withdrawal fee in the dialog

### What was wrong
The dialog never told the user that a withdrawal fee would be charged. Users had no way to know about the $1 fee until after the transaction.

### What the user sees now
A new "Withdrawal fee: $1.00" row in the dialog, below the destination address. The fee is hardcoded to `$1.00` for now — a TODO is left in the component to switch to the `withdrawalFeeUSD` value from the Ondo account info API once that value can be trusted.

### How to test
1. Open the **Withdraw** dialog.
2. Confirm a **"Withdrawal fee: $1.00"** row appears below the destination address.

---

## 3. [MEW-1799] Show submit errors inline in the dialog

### What was wrong
When the Withdraw submit failed (e.g. the user rejected the wallet signature for the address-book challenge, or the API errored), no feedback appeared anywhere. The error text was being rendered with absolute positioning against no positioned ancestor, so it ended up off-screen.

### What the user sees now
If the submit fails, an inline red error message appears just above the **Withdraw** button so the user can see what went wrong and retry.

### How to test
1. Open the **Withdraw** dialog and enter a valid amount.
2. Click **Withdraw** and reject the wallet signature request when prompted.
3. Confirm a red error message appears above the **Withdraw** button.
4. Retry with a valid signature — the error clears.

---

## Jira tickets
- MEW-1728 — Withdraw edit after transaction is complete
- MEW-1671 — Missing withdrawal fee
- MEW-1799 — Withdraw dialog: error message not visible when withdraw fails



## Summary by CodeRabbit

* **Bug Fixes**
  * Withdrawal dialog now displays withdrawal fee information
  * Simplified withdrawal completion flow for improved user experience



[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyEtherWallet/MyEtherWallet/pull/5475)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Withdrawal dialog now shows a "Withdrawal fee", uses a single "Withdraw" action, and closes automatically after success.
  * Initial market contracts loading now shows a proper loading state on first load.

* **Chores**
  * Added perps module tag to error/reporting configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyEtherWallet/MyEtherWallet/pull/5475)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->