### PR TITLE
fix: [MEW-1671] show withdrawal fee in withdraw dialog

### DIFF
--- a/src/modules/perps/components/PerpsWithdrawDialog.vue
+++ b/src/modules/perps/components/PerpsWithdrawDialog.vue
@@ -79,7 +79,7 @@
           class="mb-4"
         />
         <transition name="fade">
-          <p v-if="error" class="text-error text-s-12 absolute -top-3 left-0">
+          <p v-if="error" class="text-error text-s-12 mb-2">
             {{ error }}
           </p>
         </transition>

--- a/src/modules/perps/components/PerpsWithdrawDialog.vue
+++ b/src/modules/perps/components/PerpsWithdrawDialog.vue
@@ -65,6 +65,11 @@
               </p>
             </div>
           </div>
+          <!-- Withdrawal fee -->
+          <div class="flex justify-between text-s-13">
+            <span class="text-info">Withdrawal fee:</span>
+            <span class="font-medium">${{ formatUsd(withdrawalFeeUSD) }}</span>
+          </div>
         </div>
 
         <app-warning
@@ -132,6 +137,7 @@ const hasOpenPositions = computed(() => positions.value.length > 0)
 const sending = ref(false)
 const error = ref<string | null>(null)
 const walletAddress = ref<string | null>(null)
+const withdrawalFeeUSD = ref('1')
 
 const withdrawableMargin = computed(
   () => balance.value?.withdrawableMargin ?? '0',
@@ -174,6 +180,12 @@ watch(
     error.value = null
     if (wallet.value) {
       walletAddress.value = await wallet.value.getAddress()
+    }
+    try {
+      const accountRes = await perpsClient.getAccount()
+      withdrawalFeeUSD.value = accountRes.result.withdrawalFeeUSD
+    } catch {
+      // Keep the default fee shown if the lookup fails.
     }
   },
 )


### PR DESCRIPTION
## What was wrong

The Withdraw dialog never disclosed the withdrawal fee, so the user didn't know that a $1 charge would be deducted from the amount they were submitting.

## What you'll see now

A new "Withdrawal fee: $X" row inside the Withdraw dialog, right under the destination address. The value is pulled from the Ondo account info endpoint (`withdrawalFeeUSD`), so it stays in sync with whatever fee Ondo is currently charging. If the API lookup fails for any reason, the dialog falls back to displaying $1.

## How to test

1. Open the Perps page, log in.
2. Click **Withdraw**.
3. Confirm a "Withdrawal fee: $1.00" line is visible below the destination address.

## Notes for reviewers

This PR is stacked on top of #5475 (`fix/v7-MEW-1728-close-withdraw-modal-on-success`). The base will switch back to `feat/v7-o-perps` once #5475 merges.