### PR TITLE
fix: [MEW-1799] show submit error inline in withdraw dialog

### DIFF
--- a/src/modules/perps/components/PerpsWithdrawDialog.vue
+++ b/src/modules/perps/components/PerpsWithdrawDialog.vue
@@ -79,7 +79,7 @@
           class="mb-4"
         />
         <transition name="fade">
-          <p v-if="error" class="text-error text-s-12 absolute -top-3 left-0">
+          <p v-if="error" class="text-error text-s-12 mb-2">
             {{ error }}
           </p>
         </transition>


### PR DESCRIPTION
## What was wrong
When a user clicked **Withdraw** in the Perps Withdraw dialog and the request failed (for example, the address-book challenge endpoint errored or the user rejected the sign request), no error message appeared anywhere in the dialog. The user was left guessing whether anything happened.

## Root cause
The error text element was positioned with `absolute -top-3 left-0` but had no positioned ancestor, so the message was rendered against the viewport — effectively off-screen and invisible.

## What the user sees now
If a withdrawal submit fails, an inline error message (red text) appears just above the **Withdraw** button so the user knows the action failed and can read the reason.

## How to test
1. Open the Perps section and connect a wallet.
2. Click **Withdraw**, enter a valid amount, and click the **Withdraw** button.
3. Trigger a failure path (e.g., reject the wallet's signature request for the address-book challenge, or disconnect the network).
4. Confirm a red error message is visible directly above the **Withdraw** button.
5. Retry with a valid flow — the error clears on the next submit.

## Stacked PR
This branch is stacked on `fix/v7-MEW-1671-withdrawal-fee` (PR #5476), which itself stacks on `fix/v7-MEW-1728-close-withdraw-modal-on-success` (PR #5475). Once #5475 and #5476 merge, the base will roll forward automatically.