### PR TITLE
fix: [MEW-1729] show min amount error and disable submit below min

### DIFF
--- a/src/modules/perps/ModulePerpsTrade.vue
+++ b/src/modules/perps/ModulePerpsTrade.vue
@@ -381,6 +381,15 @@
                     : 'Insufficient margin available'
                 }}
               </div>
+              <div
+                v-else-if="
+                  Number(inputAmount || '0') > 0 &&
+                  positionSizeUsd < minOrderAmount
+                "
+                class="text-error text-s-12 mb-1"
+              >
+                Min. amount {{ formatUsd(minOrderAmount) }}
+              </div>
             </transition>
 
             <!-- Slider -->
@@ -812,6 +821,7 @@ const {
   leverage,
   sliderValue,
   positionSizeUsd,
+  minOrderAmount,
   estimatedLiquidation,
   orderSize,
   availableMargin,
@@ -926,10 +936,6 @@ const selectedToken = computed(() => ({
 }))
 
 const getMainBtnText = computed(() => {
-  if (!activePosition.value) {
-    const side = orderSide.value === 'buy' ? 'Long' : 'Short'
-    return `${side} ${displaySymbol.value}`
-  }
   if (manageMode.value === 'close') {
     return closeButtonLabel.value
   }

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -463,7 +463,7 @@ export function usePerpsTradeForm() {
     if (availableMargin.value * leverage.value < minOrderAmount.value) {
       return `Min. margin required ${formatUsd(minOrderAmount.value)}`
     }
-    if (positionSizeUsd.value < minOrderAmount.value) {
+    if (amt > 0 && positionSizeUsd.value < minOrderAmount.value) {
       return `Min. amount ${formatUsd(minOrderAmount.value)}`
     }
     if (amt > availableMargin.value) {
@@ -1086,6 +1086,7 @@ export function usePerpsTradeForm() {
     leverage,
     sliderValue,
     positionSizeUsd,
+    minOrderAmount,
     estimatedLiquidation,
     orderSize,
     availableMargin,


### PR DESCRIPTION
## What was wrong
When opening a position on a perp market, the trade form's submit button always showed the default `Long X` / `Short X` label even if the typed amount was below the market's minimum order size. The button was correctly disabled, but the user had no idea **why** — no inline error in the input area, no hint on the button.

## What the user sees now
- If you type an amount whose position size (amount × leverage) falls below the market minimum, an inline red error appears under the input: `Min. amount $X.XX`.
- The submit button label switches from `Long AAPL` to `Min. amount $X.XX` while the input is below the minimum.
- The button remains disabled exactly as before — this fix does **not** change when the button is enabled/disabled, only when the reason is shown.
- An empty input still shows the default `Long / Short [market]` label (no error spam before the user types anything).

## How to test
1. Open the perps side-drawer on a market (e.g. AAPL).
2. With margin available, type a very small amount (e.g. `0.01` with 20× leverage on a market priced ~$200, so position size ≈ $0.20 vs. min ~$2).
3. Confirm:
   - Inline `Min. amount $X.XX` error shows under the input.
   - Submit button label reads `Min. amount $X.XX` and the button is disabled.
4. Increase the amount until position size ≥ minimum:
   - Inline error clears.
   - Button label returns to `Long AAPL` / `Short AAPL` and becomes enabled.
5. Clear the input:
   - Button returns to default `Long AAPL` label (no error), stays disabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced minimum order amount validation with inline error messaging when input exceeds zero but falls below the minimum required.
  * Improved submit button labeling logic to correctly reflect the active trading mode (close position vs. standard submission).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyEtherWallet/MyEtherWallet/pull/5478)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->