### PR TITLE
fix: [MEW-1807] stop positions skeleton flashing on poll

### DIFF
--- a/src/modules/perps/components/PerpsPositionsTable.vue
+++ b/src/modules/perps/components/PerpsPositionsTable.vue
@@ -82,7 +82,7 @@
 
       <!-- Positions loading -->
       <app-table-skeleton
-        v-if="activeTab === 'positions' && loading && positions.length === 0"
+        v-if="activeTab === 'positions' && !positionsHasLoaded"
         :rows="3"
         :columns="positionsSkeletonColumns"
       />
@@ -972,7 +972,7 @@ const dwSkeletonColumns: SkeletonColumn[] = [
   { header: 'Status', align: 'right', hidden: 'hidden xs:table-cell' },
 ]
 
-const { positions, loading } = usePerpsPositions()
+const { positions, hasLoaded: positionsHasLoaded } = usePerpsPositions()
 
 const {
   currentPage: positionsCurrentPage,

--- a/src/modules/perps/composables/usePerpsPositions.ts
+++ b/src/modules/perps/composables/usePerpsPositions.ts
@@ -5,6 +5,7 @@ import type { Position } from '../sdk/types'
 
 const positions = ref<Position[]>([])
 const loading = ref(false)
+const hasLoaded = ref(false)
 const error = ref<string | null>(null)
 let initialized = false
 
@@ -23,6 +24,7 @@ async function fetchPositions() {
     error.value = e instanceof Error ? e.message : 'Failed to load positions'
   } finally {
     loading.value = false
+    hasLoaded.value = true
   }
 }
 
@@ -52,7 +54,10 @@ function startPolling() {
   // an intermediate clearAuth), where the previous account's positions would
   // otherwise linger on screen.
   watch(token, (newToken, oldToken) => {
-    if (oldToken) positions.value = []
+    if (oldToken) {
+      positions.value = []
+      hasLoaded.value = false
+    }
     if (newToken) poll()
   })
 
@@ -79,5 +84,12 @@ async function closePosition(pos: Position) {
 
 export function usePerpsPositions() {
   startPolling()
-  return { positions, loading, error, refetch: fetchPositions, closePosition }
+  return {
+    positions,
+    loading,
+    hasLoaded,
+    error,
+    refetch: fetchPositions,
+    closePosition,
+  }
 }


### PR DESCRIPTION
## What was wrong

On the Perps Portfolio page, the Positions tab loading skeleton would briefly flash every few seconds. The positions data refreshes on a 5-second poll, and on each poll the loading flag would flip on and off — so if you had zero positions, the empty state and the skeleton would alternate, producing a visible flicker.

## What changed

The Positions composable now tracks whether the very first fetch has completed. The skeleton is only shown until that initial load finishes; after that, polls refresh data silently in the background without re-showing the skeleton.

On sign-out (or wallet switch), the flag resets so the skeleton will again show on the next fresh sign-in.

## What the user will see

- First time landing on the Perps page: brief skeleton, then the positions table (or "No open positions").
- Subsequent polls: no flashing. The view stays steady.
- Sign out and sign back in: skeleton shows once on the new session, then steady.

## How to test

1. Sign in to Perps with an account that has **no open positions** — verify "No open positions" displays steadily, no skeleton flash every ~5s.
2. Sign in with an account that **has open positions** — verify the table stays put on each poll, no flash.
3. Sign out, sign back in — verify the skeleton appears once on fresh load.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved position data loading state tracking for more accurate UI feedback during data fetches.
  * Enhanced user session handling when switching accounts or logging out, ensuring positions data and loading states properly reset.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyEtherWallet/MyEtherWallet/pull/5480)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->