### PR TITLE
fix: [MEW-1806] paginate pending orders via api status filter

### DIFF
--- a/src/modules/perps/components/PerpsPositionsTable.vue
+++ b/src/modules/perps/components/PerpsPositionsTable.vue
@@ -30,7 +30,7 @@
                   ·
                   {{
                     openOrdersCountIsCapped
-                      ? `${ORDERS_FETCH_LIMIT}+`
+                      ? `${PERPS_PAGE_SIZE}+`
                       : openOrdersCount
                   }}
                 </span>
@@ -67,7 +67,7 @@
                       ·
                       {{
                         openOrdersCountIsCapped
-                          ? `${ORDERS_FETCH_LIMIT}+`
+                          ? `${PERPS_PAGE_SIZE}+`
                           : openOrdersCount
                       }}
                     </span>
@@ -315,7 +315,7 @@
                   ·
                   {{
                     openOrdersCountIsCapped
-                      ? `${ORDERS_FETCH_LIMIT}+`
+                      ? `${PERPS_PAGE_SIZE}+`
                       : openOrdersCount
                   }}
                 </span></span
@@ -329,7 +329,7 @@
           :columns="ordersSkeletonColumns"
         />
         <div
-          v-else-if="filteredOrders.length === 0 && ordersCurrentPage === 0"
+          v-else-if="orders.length === 0 && ordersCurrentPage === 0"
           class="text-center py-8 text-info text-s-14"
         >
           No orders
@@ -370,7 +370,7 @@
           </thead>
           <tbody>
             <tr
-              v-for="order in filteredOrders"
+              v-for="order in orders"
               :key="order.orderId"
               class="cursor-pointer hoverBGWhite"
               @click="openOrderDialog(order)"
@@ -854,6 +854,7 @@ import {
   usePerpsOrders,
   usePerpsFills,
   usePerpsDepositsWithdrawals,
+  type OrdersStatusFilter,
 } from '../composables/usePerpsHistory'
 import { usePerpsToasts } from '../composables/usePerpsToasts'
 import { usePerpsMarkets } from '../composables/usePerpsMarkets'
@@ -998,6 +999,16 @@ function openOrderDialog(order: ApiOrder) {
   showOrderDialog.value = true
 }
 
+const orderFilterTabs = [
+  { label: 'All', value: 'all' },
+
+  { label: 'Pending', value: 'pending' },
+]
+const selectedOrderFilter = ref(orderFilterTabs[0])
+const ordersStatusFilter = computed<OrdersStatusFilter>(() =>
+  selectedOrderFilter.value.value === 'pending' ? 'pending' : 'all',
+)
+
 const {
   orders,
   loading: ordersLoading,
@@ -1007,7 +1018,7 @@ const {
   hasNext: ordersHasNext,
   nextPage: ordersNextPage,
   prevPage: ordersPrevPage,
-} = usePerpsOrders()
+} = usePerpsOrders(ordersStatusFilter)
 
 const showCancelButton = (order: ApiOrder) => {
   return (
@@ -1156,29 +1167,21 @@ const tabs = [
 const selectedTab = ref(tabs[0])
 const activeTab = computed(() => selectedTab.value.value)
 
-const orderFilterTabs = [
-  { label: 'All', value: 'all' },
-
-  { label: 'Pending', value: 'pending' },
-]
-const selectedOrderFilter = ref(orderFilterTabs[0])
-
-const pendingStatuses = new Set(['pending', 'untriggered', 'open'])
-const filteredOrders = computed(() => {
-  if (selectedOrderFilter.value.value === 'all') return orders.value
-  return orders.value.filter(o => pendingStatuses.has(o.status))
+// Open-orders count for the Orders tab badge. Sourced from the current cursor
+// page. When the Pending filter is active the API already restricts the page
+// to open orders, so the count is just the page length. When "All" is active
+// the page mixes open + closed orders so we filter client-side. The "+" cap
+// only triggers when the page is full AND a next page exists.
+const openOrdersCount = computed(() => {
+  if (ordersStatusFilter.value === 'pending') return orders.value.length
+  return orders.value.filter(
+    o =>
+      o.status === 'pending' ||
+      o.status === 'untriggered' ||
+      o.status === 'open',
+  ).length
 })
-
-// Open-orders count for the Orders tab badge. Source is the current cursor
-// page of orders. The badge only saturates ("100+") when a next page exists
-// AND the current page is itself full of open orders — `ordersHasNext` alone
-// says nothing about open orders, so a few open + many older closed would
-// otherwise mis-render as "3+".
-const ORDERS_FETCH_LIMIT = 100
-const openOrdersCount = computed(
-  () => orders.value.filter(o => pendingStatuses.has(o.status)).length,
-)
 const openOrdersCountIsCapped = computed(
-  () => ordersHasNext.value && openOrdersCount.value >= ORDERS_FETCH_LIMIT,
+  () => ordersHasNext.value && openOrdersCount.value >= PERPS_PAGE_SIZE,
 )
 </script>

--- a/src/modules/perps/composables/usePerpsHistory.ts
+++ b/src/modules/perps/composables/usePerpsHistory.ts
@@ -1,4 +1,4 @@
-import { ref, watchEffect, onUnmounted } from 'vue'
+import { ref, watchEffect, onUnmounted, type Ref } from 'vue'
 import { perpsClient, PERPS_PAGE_SIZE } from '../configs'
 import { usePerpsAuth } from './usePerpsAuth'
 import { usePerpsMarkets } from './usePerpsMarkets'
@@ -11,17 +11,28 @@ import type {
   WalletWithdrawal,
 } from '../sdk/types'
 
+export type OrdersStatusFilter = 'all' | 'pending'
+
 type OrderSnapshot = Pick<
   ApiOrder,
   'orderId' | 'filledSize' | 'filledCost' | 'size' | 'status'
 >
 
-export function usePerpsOrders() {
+export function usePerpsOrders(statusFilter?: Ref<OrdersStatusFilter>) {
   const { token, refreshKey } = usePerpsAuth()
   const { markets } = usePerpsMarkets()
   const perpsToasts = usePerpsToasts()
+  const filter = statusFilter ?? ref<OrdersStatusFilter>('all')
+  // The Pending sub-tab paginates over only open orders so empty middle pages
+  // can't appear. The API's status filter only accepts 'open' | 'canceled' |
+  // 'fullyfilled', so 'untriggered' (stop orders) and the transient 'pending'
+  // state aren't shown under the Pending filter — acceptable trade-off.
   const pagination = useCursorPaginate<ApiOrder>(
-    opts => perpsClient.getOrders(opts),
+    opts =>
+      perpsClient.getOrders({
+        ...opts,
+        status: filter.value === 'pending' ? 'open' : undefined,
+      }),
     PERPS_PAGE_SIZE,
   )
   // Snapshot keyed by orderId — used to diff filledSize between polls so we
@@ -114,17 +125,21 @@ export function usePerpsOrders() {
     }
   }
 
+  let lastFilter: OrdersStatusFilter | null = null
   watchEffect(() => {
     void refreshKey.value
+    void filter.value
     if (pollTimer) clearInterval(pollTimer)
     // Reset diff state only on actual auth changes. triggerRefresh() bumps
     // refreshKey for any post-mutation refetch (place/cancel/close) and must
     // not silently re-seed the snapshot — otherwise the next poll's fills
-    // would be swallowed instead of toasted.
-    if (token.value !== lastToken) {
+    // would be swallowed instead of toasted. Filter changes also re-seed since
+    // the result set differs and stale snapshots would generate false diffs.
+    if (token.value !== lastToken || filter.value !== lastFilter) {
       prevOrdersById = new Map()
       isSeedFetch = true
       lastToken = token.value
+      lastFilter = filter.value
     }
     pagination.reset()
     if (token.value) {


### PR DESCRIPTION
## What was wrong

On the Perps **Orders → Pending** sub-tab, pagination would sometimes show empty pages. Why: the page was fetching the full orders list (open + filled + canceled) from the server and then filtering on the client to only "pending"-ish ones. When a server page happened to contain no pending orders, the user saw an empty page even though the pagination controls said there were more.

## What the user will now see

- The **Pending** sub-tab paginates only over open orders. No more empty intermediate pages.
- The **All** sub-tab continues to paginate over everything as before.
- Order Filled / Partially Filled toasts still fire correctly when fills land while the user is on page 1; switching the sub-tab no longer fires stale toasts.

## How it was fixed

- `usePerpsOrders(statusFilter)` now accepts an optional reactive filter (`'all' | 'pending'`). When `'pending'`, it asks the API for `status=open` so the server returns only open orders and the cursor walks a meaningful set.
- `PerpsPositionsTable.vue` passes the current sub-tab into the composable and drops the client-side filter pass.
- The fill-detection snapshot is reset on filter change so a switch between **All** and **Pending** doesn't generate false-positive fill diffs.

### Trade-off

The Ondo API's `status` query param only accepts `open | canceled | fullyfilled`. So orders in the transient `pending` state or the `untriggered` state (stop-orders waiting on trigger) are not visible under the **Pending** sub-tab. These are rare/short-lived; if it becomes a problem we'd need an API change.

## How to test

1. Log into Perps in the sandbox and place several limit/stop orders so multiple pages of orders exist.
2. Open **Orders → Pending**. Confirm only open orders appear and pagination walks them with no empty page.
3. Open a few of the orders, cancel them, place new ones — confirm toasts fire and the badge count stays sane.
4. Switch to **All**, paginate forward and back — confirm closed/canceled orders show up as before.
5. Sign out / sign in — confirm no false fill toasts on the first poll.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Orders filtering now operates server-side for better performance
  * Updated order count display to reflect actual pagination size
  * Improved empty state detection for the Orders tab

* **New Features**
  * Added filter option to view pending orders separately from all orders

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyEtherWallet/MyEtherWallet/pull/5481)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->