### PR TITLE
fix: [MEW-1809] show error when deposit amount is zero

### DIFF
--- a/src/modules/perps/components/PerpsDepositDialog.vue
+++ b/src/modules/perps/components/PerpsDepositDialog.vue
@@ -395,8 +395,8 @@ const checkAmountForError = () => {
     : BigInt(0)
   // if (amount.value === undefined || amount.value === '')
   //   amountError.value = t('error.amount.required') // amount is undefined or blank
-  if (baseAmount < 0)
-    amountError.value = t('error.amount.less_than_zero') // amount less than 0
+  if (amount.value !== '' && baseAmount <= BigInt(0))
+    amountError.value = t('error.amount.less_than_zero') // amount is 0 or negative
   else if (BigInt(baseTokenBalance) < baseAmount) {
     amountError.value = t('error.balance.insufficient') // amount greater than selected balance
   } else if (
@@ -633,6 +633,8 @@ const sendLiveDeposit = async () => {
 }
 
 function sendDeposit() {
+  const amt = parseFloat(amount.value)
+  if (!amt || amt <= 0) return
   if (showIsLive.value) {
     sendLiveDeposit()
   } else {


### PR DESCRIPTION
## What was wrong

In the Perps Deposit dialog, entering `0` (or `0.0`) as the amount produced no validation feedback. The Deposit button was visually disabled, but the underlying send logic still treated the string `'0'` as a valid value, meaning a request with `amount: 0.00` could be dispatched if the disabled state were ever bypassed.

## What the user will now see

- Entering `0` (or `0.0`) immediately shows **"amount must be greater than 0"** under the input.
- The Deposit button stays disabled while the amount is `0` or empty.
- A valid positive amount continues to behave exactly as before.
- Clearing the field after typing does **not** trigger an error (no change to existing empty-field behavior).

## How to test

1. Open the Perps Deposit dialog (both Sandbox and Live modes).
2. Type `0`, then `0.0` — confirm the min-amount error appears.
3. Type a valid amount (e.g. `10`) — confirm the error clears and Deposit becomes enabled.
4. Clear the field — confirm no error is shown.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened deposit amount validation to reject zero and invalid amounts.
  * Added additional checks during deposit initiation to prevent processing incomplete or invalid deposit requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyEtherWallet/MyEtherWallet/pull/5482)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->