### PR TITLE
fix: [MEW-1810] clear Perps auth key on wallet deletion

### DIFF
--- a/src/components/AppWalletCard.vue
+++ b/src/components/AppWalletCard.vue
@@ -167,6 +167,7 @@ import ThePaperWallet from '@/components/core_layouts/wallet/ThePaperWallet.vue'
 import { WalletType } from '@/providers/types'
 import { useAccessStore } from '@/stores/accessStore'
 import { useWatchOnlyStore } from '@/stores/watchOnlyStore'
+import { usePerpsAuth } from '@/modules/perps/composables/usePerpsAuth'
 import { ACCESS_WALLET_VIEWS } from '@/modules/access/common/walletConfigs'
 import { ToastType } from '@/types/notification'
 import {
@@ -283,6 +284,7 @@ const deleteWallet = () => {
     walletAddress.value as string,
     selectedChain.value!,
   )
+  usePerpsAuth().logout()
   disconnectWallet()
   emit('close')
 }


### PR DESCRIPTION
## What was wrong

When the user deleted their wallet from the wallet card menu ("Disconnect and delete wallet" or "Delete watch-only wallet"), the Perps authentication key (JWT) and account ID stored in `localStorage` were left behind. On the next session, the app could attempt to use a stale auth key issued for a wallet that no longer exists.

## What the user will now see

- Deleting a wallet now also clears the Perps auth key from `localStorage`.
- Reconnecting any wallet afterward starts a fresh Perps login flow as expected.
- No visible UI change — the fix is purely about cleaning up auth state.

## How to test

1. Connect a wallet and log in to Perps. Verify `perps_auth_token` and `perps_auth_account` exist in `localStorage` (DevTools → Application → Local Storage).
2. Open the wallet card menu and choose "Disconnect and delete wallet".
3. Confirm both `perps_auth_token` and `perps_auth_account` are removed from `localStorage`.
4. Reconnect a wallet and confirm you are prompted to authenticate Perps again.
5. Repeat with a watch-only wallet via "Delete watch-only wallet" — same expected behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet deletion to properly clear authentication sessions, ensuring a complete logout when removing a wallet.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyEtherWallet/MyEtherWallet/pull/5483)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->