### PR TITLE
fix: [MEW-1804] route Manage menu to Perps panel on token info page

### DIFF
--- a/src/modules/perps/ModulePerpInfo.vue
+++ b/src/modules/perps/ModulePerpInfo.vue
@@ -944,7 +944,8 @@ import { storeToRefs } from 'pinia'
 import { useAppBreakpoints } from '@/composables/useAppBreakpoints'
 import type { ApiOrder, ApiFill, MarketInfoData } from './sdk/types'
 import { useWalletMenuStore } from '@/stores/walletMenuStore'
-const { setSelectedTradeManageMode } = useWalletMenuStore()
+const { setSelectedTradeManageMode, setWalletPanel, setIsOpenSideMenu } =
+  useWalletMenuStore()
 import {
   formatUsd,
   formatPrice,
@@ -1370,10 +1371,10 @@ const saveLeverage = async () => {
 
 watch(selectedManageAction, action => {
   if (!action) return
-  if (action.value === 'add') {
-    setSelectedTradeManageMode('add')
-  } else if (action.value === 'close') {
-    setSelectedTradeManageMode('close')
+  if (action.value === 'add' || action.value === 'close') {
+    setSelectedTradeManageMode(action.value)
+    setWalletPanel('perps')
+    setIsOpenSideMenu(true)
   } else if (action.value === 'leverage') {
     tempLeverage.value = parseInt(marketPosition.value?.leverage ?? '1') || 1
     leverageError.value = ''


### PR DESCRIPTION
## What was wrong

On a perp token info page, when the wallet side panel was showing Swap, Trade, Bridge, or Send, opening the **Manage** menu on an open position and clicking **Add to Position** or **Close Position** appeared to do nothing. The user was not taken to the Perps order form.

## What's fixed

Those two actions now correctly route the user to the Perps trade form:

- **Add to Position** → opens the Perps panel in **Add** mode
- **Close Position** → opens the Perps panel in **Close** mode
- **Change Leverage** → unchanged, still opens the leverage dialog

The handler now mirrors what already happens elsewhere in the app (the markets list and positions table use the same routing pattern).

## How to test

1. Connect a wallet with an open Perps position.
2. Open the token info page for that perpetual (e.g. via the markets list).
3. In the wallet side panel, switch to **Swap** (or **Trade**, **Bridge**, **Send**).
4. On the position card, click **Manage** → **Add to Position**.
   - Side panel should switch to the **Perps** trade form in **Add** mode.
5. Repeat with **Close Position** — should land in **Close** mode.
6. **Change Leverage** should still open the leverage dialog as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced wallet side menu behavior when managing perpetual positions. The side menu now consistently opens and displays the correct panel when users select position management actions, providing a more seamless experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyEtherWallet/MyEtherWallet/pull/5484)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->