### PR TITLE
fix: [MEW-1803] block limit orders outside +/- 10% price tolerance

### DIFF
--- a/src/modules/perps/ModulePerpsTrade.vue
+++ b/src/modules/perps/ModulePerpsTrade.vue
@@ -294,6 +294,12 @@
                   : `Price supports up to ${quoteDecimals} decimal place${quoteDecimals === 1 ? '' : 's'}`
               }}
             </div>
+            <div
+              v-else-if="limitPriceOutOfTolerance"
+              class="text-error text-s-12 mb-1"
+            >
+              Price must be within +/- 10% tolerance
+            </div>
           </transition>
 
           <div class="flex justify-start gap-2 mt-1">
@@ -653,6 +659,7 @@
       :order-error="orderError"
       :leverage-error="leverageError"
       :is-submitting="isSubmitting"
+      :limit-price-out-of-tolerance="limitPriceOutOfTolerance"
       @confirm="confirmAndSubmitAndSetLeverage"
     />
 
@@ -861,6 +868,7 @@ const {
   submitDisabled,
   submitButtonLabel,
   limitPriceHasError,
+  limitPriceOutOfTolerance,
   limitPricePrecisionError,
   marginPrecisionError,
   closeAmountPrecisionError,

--- a/src/modules/perps/components/PerpsOrderConfirmationDialog.vue
+++ b/src/modules/perps/components/PerpsOrderConfirmationDialog.vue
@@ -91,11 +91,15 @@
 
         <!-- Error -->
         <div
-          v-if="orderError || leverageError"
+          v-if="orderError || leverageError || limitPriceOutOfTolerance"
           class="bg-[#fff0f0] border border-[#ffcccc] rounded-[16px] p-4"
         >
           <p class="text-error text-s-14 font-medium">
-            {{ orderError || leverageError }}
+            {{
+              orderError ||
+              leverageError ||
+              'Price must be within +/- 10% tolerance'
+            }}
           </p>
         </div>
 
@@ -103,7 +107,12 @@
         <div class="flex flex-col gap-1">
           <app-base-button
             :theme="orderSide === 'buy' ? 'success' : 'error'"
-            :disabled="isSubmitting || !!orderError || !!leverageError"
+            :disabled="
+              isSubmitting ||
+              !!orderError ||
+              !!leverageError ||
+              limitPriceOutOfTolerance
+            "
             :is-loading="isSubmitting"
             class="flex-1"
             @click="$emit('confirm')"
@@ -152,6 +161,7 @@ defineProps<{
   orderError: string | null
   isSubmitting: boolean
   leverageError: string | null
+  limitPriceOutOfTolerance: boolean
 }>()
 
 defineEmits<{

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -430,11 +430,27 @@ export function usePerpsTradeForm() {
   })
 
   // ── Limit price validation ─────────────────────────────────
+  // Backend rejects orders whose price drifts more than 10% from mid; mirror
+  // that bound on the client so the order button disables before submit and
+  // again at confirm time if the live price moves while the modal is open.
+  const LIMIT_PRICE_TOLERANCE = 0.1
+
+  const limitPriceOutOfTolerance = computed(() => {
+    if (orderType.value !== 'limit' || !limitPrice.value) return false
+    const price = parseFloat(limitPrice.value)
+    if (isNaN(price) || price <= 0 || !currentPrice.value) return false
+    return (
+      Math.abs(price - currentPrice.value) / currentPrice.value >
+      LIMIT_PRICE_TOLERANCE
+    )
+  })
+
   const limitPriceHasError = computed(() => {
     if (orderType.value !== 'limit' || !limitPrice.value) return false
     const price = parseFloat(limitPrice.value)
     if (isNaN(price) || price <= 0 || price >= 10_000_000) return true
     if (limitPricePrecisionError.value) return true
+    if (limitPriceOutOfTolerance.value) return true
     return false
   })
 
@@ -1139,6 +1155,7 @@ export function usePerpsTradeForm() {
     submitDisabled,
     submitButtonLabel,
     limitPriceHasError,
+    limitPriceOutOfTolerance,
     limitPricePrecisionError,
     marginPrecisionError,
     closeAmountPrecisionError,


### PR DESCRIPTION
## What was wrong

On the Perps trade panel, when placing a **Limit** order whose price is more than 10% away from the current market price, the user could fill in the form and click the Long/Short button without seeing any warning. The error ("Price must be within +/- 10% tolerance") only surfaced after clicking **Confirm** in the modal — because that's when the backend rejected the order.

There was also a subtler case: a user could enter a price that was *almost* 10% off, open the Confirm modal, and have the live price move just enough during that window that the order now fell outside the tolerance. They'd hit Confirm, the backend would reject, and the same error showed up at the bottom of the dialog.

## What's fixed

- On the limit price input, if the user types a price more than 10% above or below the live market price, the input now shows **"Price must be within +/- 10% tolerance"** in red.
- The order button (Long / Short / Add to Position / close-position-limit) is **disabled** while the price is out of tolerance.
- The Confirm modal also re-checks the tolerance live, so if the market price moves while the modal is open, the **Confirm** button disables and a clear tolerance error appears inside the dialog.

## How to test

1. Open the Perps trade panel and pick any market (e.g. AAPL-USD).
2. Switch the order type to **Limit Order**.
3. Type a price that is **more than 10%** above or below the current price (e.g. if AAPL is ~$200, try $240 or $160).
4. Verify the red error "Price must be within +/- 10% tolerance" shows under the price input and the order button is disabled.
5. Type a price close to (but still inside) the ±10% band, click the order button to open the Confirm modal, and watch the live price — if it drifts past the threshold, the Confirm button should disable and the same error should appear in the modal.
6. Type a price *within* the ±10% band and confirm everything still works normally end-to-end.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added limit price validation for limit orders—limit price must remain within ±10% of the current market price
  * Error message displays when limit price exceeds the acceptable tolerance range
  * Order confirmation is blocked until limit price is adjusted within tolerance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyEtherWallet/MyEtherWallet/pull/5485)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->