### PR TITLE
feat: [MEW-1805] add tooltip to time in force order detail

### DIFF
--- a/src/modules/perps/components/PerpsOrderDialog.vue
+++ b/src/modules/perps/components/PerpsOrderDialog.vue
@@ -37,10 +37,17 @@
             :key="row.label"
             class="flex items-center justify-between px-5 py-4"
           >
-            <span
-              class="text-s-11 uppercase text-info tracking-sp-06 font-bold"
-              >{{ row.label }}</span
-            >
+            <div class="flex items-center gap-1">
+              <span
+                class="text-s-11 uppercase text-info tracking-sp-06 font-bold"
+                >{{ row.label }}</span
+              >
+              <app-tooltip
+                v-if="row.tooltip"
+                :text="row.tooltip"
+                position="top-right"
+              />
+            </div>
             <span class="text-s-14 font-medium" :class="row.colorClass ?? ''">
               {{ row.value }}
             </span>
@@ -70,6 +77,7 @@ import { computed } from 'vue'
 import AppDialog from '@/components/AppDialog.vue'
 import AppTokenLogo from '@/components/AppTokenLogo.vue'
 import AppBtnText from '@/components/AppBtnText.vue'
+import AppTooltip from '@/components/AppTooltip.vue'
 import type { ApiOrder } from '../sdk/types'
 import {
   formatUsd,
@@ -118,8 +126,15 @@ const isCancellable = computed(() =>
   ['pending', 'untriggered', 'open'].includes(props.order.status),
 )
 
+type Row = {
+  label: string
+  value: string
+  colorClass?: string
+  tooltip?: string
+}
+
 const rows = computed(() => {
-  const items = [
+  const items: Row[] = [
     {
       label: 'Market',
       value: base.value,
@@ -173,6 +188,8 @@ const rows = computed(() => {
     items.push({
       label: 'Time in Force',
       value: props.order.timeInForce,
+      tooltip:
+        'The order remains active until the order is completely filled or you manually cancel it',
     })
   }
 

--- a/src/modules/perps/components/PerpsOrderDialog.vue
+++ b/src/modules/perps/components/PerpsOrderDialog.vue
@@ -189,7 +189,7 @@ const rows = computed(() => {
       label: 'Time in Force',
       value: props.order.timeInForce,
       tooltip:
-        'The order remains active until the order is completely filled or you manually cancel it',
+        'The order remains active until the order is completely filled or you manually cancel it.',
     })
   }
 


### PR DESCRIPTION
## What's new

The perps order details dialog now shows a small info-icon next to the **Time in Force** label. Hovering it reveals a tooltip that explains what the field means:

> The order remains active until the order is completely filled or you manually cancel it.

This addresses the QA question — users could see the "Time in Force" value but had no in-app explanation of the underlying policy.

## How to test

1. Open MEW perps and place (or look up) any order that has a `Time in Force` value — currently the only order type where this field is shown.
2. Open the order detail dialog from the orders list.
3. Hover the small info icon next to "Time in Force".
4. Confirm the tooltip text reads exactly: *The order remains active until the order is completely filled or you manually cancel it*.
5. Other rows (Market, Side, Status, etc.) should not show the info icon.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* Order dialog fields now display contextual tooltips for additional guidance
* "Time in Force" field includes a tooltip explaining when orders remain active

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyEtherWallet/MyEtherWallet/pull/5486?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->