### PR TITLE
fix: [MEW-1813] show actual fee on filled orders in detail dialog

### DIFF
--- a/src/modules/perps/components/PerpsOrderDialog.vue
+++ b/src/modules/perps/components/PerpsOrderDialog.vue
@@ -73,7 +73,7 @@ import AppBtnText from '@/components/AppBtnText.vue'
 import type { ApiOrder } from '../sdk/types'
 import { perpsClient } from '../configs'
 import {
-  formatUsd,
+  formatUsdc,
   formatPrice,
   formatPnl,
   pnlColor,
@@ -187,7 +187,7 @@ const rows = computed(() => {
     },
     {
       label: 'Fee',
-      value: formatUsd(displayFee.value),
+      value: formatUsdc(displayFee.value),
     },
   ]
 

--- a/src/modules/perps/components/PerpsOrderDialog.vue
+++ b/src/modules/perps/components/PerpsOrderDialog.vue
@@ -66,11 +66,12 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref, watch } from 'vue'
 import AppDialog from '@/components/AppDialog.vue'
 import AppTokenLogo from '@/components/AppTokenLogo.vue'
 import AppBtnText from '@/components/AppBtnText.vue'
 import type { ApiOrder } from '../sdk/types'
+import { perpsClient } from '../configs'
 import {
   formatUsd,
   formatPrice,
@@ -118,6 +119,27 @@ const isCancellable = computed(() =>
   ['pending', 'untriggered', 'open'].includes(props.order.status),
 )
 
+const fetchedFee = ref<string | null>(null)
+
+watch(
+  () => [props.visible, props.order?.orderId] as const,
+  async ([visible, orderId]) => {
+    if (!visible || !orderId) {
+      fetchedFee.value = null
+      return
+    }
+    try {
+      const res = await perpsClient.getOrder(orderId)
+      if (res?.success) fetchedFee.value = res.result.fee
+    } catch {
+      fetchedFee.value = null
+    }
+  },
+  { immediate: true },
+)
+
+const displayFee = computed(() => fetchedFee.value ?? props.order.fee)
+
 const rows = computed(() => {
   const items = [
     {
@@ -157,7 +179,7 @@ const rows = computed(() => {
     },
     {
       label: 'Fee',
-      value: formatUsd(props.order.fee),
+      value: formatUsd(displayFee.value),
     },
   ]
 

--- a/src/modules/perps/components/PerpsOrderDialog.vue
+++ b/src/modules/perps/components/PerpsOrderDialog.vue
@@ -120,18 +120,26 @@ const isCancellable = computed(() =>
 )
 
 const fetchedFee = ref<string | null>(null)
+const currentFetchToken = ref(0)
 
 watch(
   () => [props.visible, props.order?.orderId] as const,
   async ([visible, orderId]) => {
+    const token = ++currentFetchToken.value
     if (!visible || !orderId) {
       fetchedFee.value = null
       return
     }
     try {
       const res = await perpsClient.getOrder(orderId)
-      if (res?.success) fetchedFee.value = res.result.fee
+      if (token !== currentFetchToken.value) return
+      if (res?.success) {
+        fetchedFee.value = res.result.fee
+      } else {
+        fetchedFee.value = null
+      }
     } catch {
+      if (token !== currentFetchToken.value) return
       fetchedFee.value = null
     }
   },

--- a/src/modules/perps/sdk/client.ts
+++ b/src/modules/perps/sdk/client.ts
@@ -316,6 +316,12 @@ export class PerpsClient {
     )
   }
 
+  async getOrder(orderId: string): Promise<GenericResponse<ApiOrder>> {
+    return this.authGet<GenericResponse<ApiOrder>>(
+      `/v1/perps/orders/${encodeURIComponent(orderId)}`,
+    )
+  }
+
   async getFills(opts?: {
     market?: string
     limit?: number

--- a/src/modules/perps/utils/formatters.ts
+++ b/src/modules/perps/utils/formatters.ts
@@ -39,6 +39,18 @@ export function formatUsd(val: string | number): string {
   })
 }
 
+// USDC-denominated values (e.g. fees) can be much smaller than $0.01 and would
+// round to "$0.00" with the standard 2-decimal USD formatter. Show up to 6
+// decimals (USDC's native precision) and suffix with "USDC".
+export function formatUsdc(val: string | number): string {
+  const n = typeof val === 'number' ? val : parseFloat(val)
+  if (isNaN(n)) return '0.00 USDC'
+  return `${n.toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 6,
+  })} USDC`
+}
+
 export function formatPrice(val?: string | number): string {
   if (val === undefined || val === null) return '—'
   const n = typeof val === 'number' ? val : parseFloat(val)


### PR DESCRIPTION
## What was wrong

In the Perps order detail dialog, the **Fee** row always showed `$0.00` — even for orders that had been fully or partially filled and clearly should have been charged a fee.

## Why it happened

The dialog uses the `fee` value the order was fetched with. Orders are loaded in bulk from the **list** endpoint (`GET /v1/perps/orders`), and that endpoint returns `fee: "0"` for every order, regardless of state. The real, cumulative fee is only populated on the **single-order** endpoint (`GET /v1/perps/orders/{orderId}`).

We confirmed this by validating both candidate sources during the investigation:

1. Refetching the order by id and reading its `fee` — returns the real value.
2. Pulling the order's fills (`/v1/perps/orders/{orderId}/fills`) and summing each fill's `fee` — also produces the real value, and was parked as a fallback option.

Option 1 is the smallest change and matches the data model best (the dialog already operates on a single order), so we went with that.

## What changes for the user

- Open a filled (or partially filled) order: the Fee row now shows the actual fee paid.
- Open a pending / open / untriggered order: the Fee row still shows `$0.00`. This is correct — no fill has occurred yet, so no fee has been charged.

## How to test

1. Place and let an order fill on Perps (sandbox is fine).
2. Open the order from the Orders table → click the row.
3. Confirm the Fee row reflects the actual fee (no longer `$0.00`).
4. Open a pending limit order and confirm the Fee row remains `$0.00` (expected).

## Implementation note

- Added a thin `getOrder(orderId)` method on the `PerpsClient` — there was no single-order fetch wired up before.
- Dialog fetches the order on open and uses its `fee` value; falls back to the list-cached value if the fetch fails so the UI never goes blank.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Perps order dialog now fetches and displays the latest order fee when opened and formats fees in USDC for clearer amounts.
* **Bug Fixes**
  * Stale or failed fee lookups are ignored; the dialog falls back to the existing displayed fee to prevent incorrect values.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyEtherWallet/MyEtherWallet/pull/5487?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->