### PR TITLE
fix: 🐛 only call trade check once

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @kvhnuke @gamalielhere @olgakup @NickKelly1 @SemajaM8
+*   @kvhnuke @gamalielhere @olgakup @NickKelly1

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @kvhnuke @gamalielhere @olgakup @NickKelly1
+*   @kvhnuke @gamalielhere @olgakup @NickKelly1 @SemajaM8

--- a/src/App.vue
+++ b/src/App.vue
@@ -39,8 +39,6 @@ import { analytics } from '@/analytics'
 import { useRewardsStore } from '@/stores/rewardsStore'
 import Intercom from '@intercom/messenger-js-sdk'
 import { useMarketStatus } from './modules/trade/composables'
-
-// const { isTradingRestrictedInRegion, fetchMarketStatus } = useMarketStatus()
 const { fetchMarketStatus } = useMarketStatus()
 
 const dialogStore = useDialogStore()

--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -5,8 +5,9 @@ import { StoreConfigs } from '@/stores/configs'
 import type { AnalyticsState } from '@/stores/analyticsStore'
 import { captureException } from '@sentry/vue'
 import * as sessionReplay from '@amplitude/session-replay-browser'
+import configs from '@/configs';
 
-const __TMP_VERSION__ = 'v7'
+const __TMP_VERSION__ = configs.APP_VERSION
 const __TMP_HASHED_VERSION__ = `tmp_local_mew_web_${__TMP_VERSION__}`
 
 // Check initial consent state from localStorage

--- a/src/composables/useSwap.ts
+++ b/src/composables/useSwap.ts
@@ -24,8 +24,8 @@ import { parseUnits } from 'viem'
 import { useI18n } from 'vue-i18n'
 import { useToastStore } from '@/stores/toastStore'
 import { ToastType } from '@/types/notification'
+import { useMarketStatus } from '@/modules/trade/composables'
 import {
-  isTradingRestricted,
   getRestrictedTokenAddresses,
 } from '@/modules/trade/providers/ondoHelpers'
 import * as Sentry from '@sentry/vue'
@@ -68,6 +68,7 @@ export const useSwap = (): {
     quote: ProviderQuoteResponse,
   ) => Promise<ProviderSwapResponse | null>
 } => {
+  const { isTradingRestrictedInRegion } = useMarketStatus();
   const toastStore = useToastStore()
   const { t } = useI18n()
   const chainsStore = useChainsStore()
@@ -114,17 +115,14 @@ export const useSwap = (): {
       let swapToTokens = swapInstance.value.getToTokens()
 
       // Check if trading is restricted and filter out restricted token addresses
-      const [isRestricted, restrictedAddresses] = await Promise.all([
-        isTradingRestricted(),
-        getRestrictedTokenAddresses(),
-      ])
+      const restrictedAddresses = await getRestrictedTokenAddresses()
 
       const restrictedAddressesLower = restrictedAddresses.map(addr =>
         addr.toLowerCase(),
       )
 
       // Filter toTokens if trading is restricted
-      if (isRestricted && restrictedAddressesLower.length > 0) {
+      if (isTradingRestrictedInRegion.value && restrictedAddressesLower.length > 0) {
         const filterTokenArray = (tokens: TokenTypeTo[]) =>
           tokens.filter(
             token =>
@@ -209,7 +207,7 @@ export const useSwap = (): {
         ? fromAllTokensToWalletTokens
         : allFromTokensWithBalance
 
-      if (isRestricted && restrictedAddressesLower.length > 0) {
+      if (isTradingRestrictedInRegion.value && restrictedAddressesLower.length > 0) {
         finalFromTokens = finalFromTokens.filter(
           token =>
             !restrictedAddressesLower.includes(token.address.toLowerCase()),

--- a/src/modules/notifications/ModuleNotifications.vue
+++ b/src/modules/notifications/ModuleNotifications.vue
@@ -667,13 +667,9 @@ const updateNotificationStatus = (
 
 const consolidatedCall = async () => {
   await fetchBalances()
-  console.log('fetchBalances called')
   await fetchUserRewards()
-  console.log('fetchUserRewards called')
   await fetchEligibility()
-  console.log('fetchEligibility called')
   await checkRewards()
-  console.log('checkRewards called')
 }
 
 // Get the correct transaction status URL based on chain

--- a/src/modules/trade/composables/useMarketStatus.ts
+++ b/src/modules/trade/composables/useMarketStatus.ts
@@ -15,9 +15,10 @@ interface UseMarketStatusOptions {
   onMarketOpen?: () => void | Promise<void>
 }
 
+
 export function useMarketStatus(options: UseMarketStatusOptions = {}) {
   const { onMarketOpen } = options
-
+  const fetchedTradingThisSession = ref(false);
   const marketStatus = ref<GetWebSwapOndoMarketStatusResponse | null>(null)
   const isTradingRestrictedInRegion = ref<boolean>(false)
   const countdownText = ref<string>('')
@@ -72,8 +73,11 @@ export function useMarketStatus(options: UseMarketStatusOptions = {}) {
   }
 
   const fetchTradingRestriction = async () => {
+    // should only fetch this once in the session
+    if (fetchedTradingThisSession.value) return;
     try {
       isTradingRestrictedInRegion.value = await isTradingRestricted()
+      fetchedTradingThisSession.value = true;
     } catch (e) {
       if (isDevMode) {
         console.error('Failed to check trading restriction:', e)

--- a/src/modules/trade/composables/useMarketStatus.ts
+++ b/src/modules/trade/composables/useMarketStatus.ts
@@ -79,7 +79,8 @@ export function useMarketStatus(options: UseMarketStatusOptions = {}) {
       return fetchedTradingThisSession.value;
     }
     try {
-      isTradingRestrictedInRegion.value = await isTradingRestricted()
+      const res = await isTradingRestricted()
+      isTradingRestrictedInRegion.value = res
       fetchedTradingThisSession.value = true;
     } catch (e) {
       if (isDevMode) {

--- a/src/modules/trade/composables/useMarketStatus.ts
+++ b/src/modules/trade/composables/useMarketStatus.ts
@@ -94,7 +94,7 @@ export function useMarketStatus(options: UseMarketStatusOptions = {}) {
           },
         })
       }
-      isTradingRestrictedInRegion.value = false
+      isTradingRestrictedInRegion.value = true
     }
   }
 

--- a/src/modules/trade/composables/useMarketStatus.ts
+++ b/src/modules/trade/composables/useMarketStatus.ts
@@ -1,4 +1,5 @@
 import { ref, computed, onUnmounted } from 'vue'
+import { storeToRefs } from 'pinia'
 import type { GetWebSwapOndoMarketStatusResponse } from '@/mew_api/types'
 import {
   getMarketStatus,
@@ -8,6 +9,7 @@ import {
 import { captureException } from '@sentry/vue'
 import { SENTRY_MODULE_TAGS } from '@/sentry/constants'
 import Configs from '@/configs'
+import { useGlobalStore } from '@/stores/globalStore'
 
 const isDevMode = Configs.IS_DEV_MODE
 
@@ -18,9 +20,8 @@ interface UseMarketStatusOptions {
 
 export function useMarketStatus(options: UseMarketStatusOptions = {}) {
   const { onMarketOpen } = options
-  const fetchedTradingThisSession = ref(false);
+  const { fetchedTradingThisSession, isTradingRestrictedInRegion } = storeToRefs(useGlobalStore())
   const marketStatus = ref<GetWebSwapOndoMarketStatusResponse | null>(null)
-  const isTradingRestrictedInRegion = ref<boolean>(false)
   const countdownText = ref<string>('')
   let countdownInterval: ReturnType<typeof setInterval> | null = null
   let wasMarketClosed = false
@@ -74,7 +75,9 @@ export function useMarketStatus(options: UseMarketStatusOptions = {}) {
 
   const fetchTradingRestriction = async () => {
     // should only fetch this once in the session
-    if (fetchedTradingThisSession.value) return;
+    if (fetchedTradingThisSession.value) {
+      return fetchedTradingThisSession.value;
+    }
     try {
       isTradingRestrictedInRegion.value = await isTradingRestricted()
       fetchedTradingThisSession.value = true;

--- a/src/modules/trade/providers/ondoHelpers.ts
+++ b/src/modules/trade/providers/ondoHelpers.ts
@@ -31,13 +31,13 @@ const isTradingRestricted = async (): Promise<boolean> => {
   if (!configs.MEW_LIVE_URLS.includes(window.location.hostname)) return false
   return fetch(`https://partners.mewapi.io/o/ipcomply`)
     .then(async res => {
-      if (!res.ok) return false
+      if (!res.ok) return true
       else {
         const json: { isRWARestricted: boolean } = await res.json()
         return json.isRWARestricted
       }
     })
-    .catch(() => false
+    .catch(() => true
     )
 }
 

--- a/src/modules/trade/providers/ondoHelpers.ts
+++ b/src/modules/trade/providers/ondoHelpers.ts
@@ -1,4 +1,4 @@
-// import configs from '@/configs'
+import configs from '@/configs'
 import type { GetWebSwapOndoMarketStatusResponse } from '@/mew_api/types'
 import { getAPIPath } from '@/utils/constructAPIPath'
 import { throttle } from 'underscore'
@@ -28,7 +28,7 @@ const getRestrictedTokenAddresses = (): Promise<string[]> => {
 }
 
 const isTradingRestricted = async (): Promise<boolean> => {
-  // if (!configs.MEW_LIVE_URLS.includes(window.location.hostname)) return false
+  if (!configs.MEW_LIVE_URLS.includes(window.location.hostname)) return false
   return fetch(`https://partners.mewapi.io/o/ipcomply`)
     .then(async res => {
       if (!res.ok) return false

--- a/src/modules/trade/providers/ondoHelpers.ts
+++ b/src/modules/trade/providers/ondoHelpers.ts
@@ -1,4 +1,4 @@
-import configs from '@/configs'
+// import configs from '@/configs'
 import type { GetWebSwapOndoMarketStatusResponse } from '@/mew_api/types'
 import { getAPIPath } from '@/utils/constructAPIPath'
 import { throttle } from 'underscore'
@@ -28,7 +28,7 @@ const getRestrictedTokenAddresses = (): Promise<string[]> => {
 }
 
 const isTradingRestricted = async (): Promise<boolean> => {
-  if (!configs.MEW_LIVE_URLS.includes(window.location.hostname)) return false
+  // if (!configs.MEW_LIVE_URLS.includes(window.location.hostname)) return false
   return fetch(`https://partners.mewapi.io/o/ipcomply`)
     .then(async res => {
       if (!res.ok) return false
@@ -37,7 +37,8 @@ const isTradingRestricted = async (): Promise<boolean> => {
         return json.isRWARestricted
       }
     })
-    .catch(() => false)
+    .catch(() => false
+    )
 }
 
 const checkAddressRestriction = async (address: string): Promise<boolean> => {

--- a/src/stores/globalStore.ts
+++ b/src/stores/globalStore.ts
@@ -50,6 +50,12 @@ export const useGlobalStore = defineStore('global', () => {
     welcomeDialogDismissed.value = true
   }
 
+  /**--------------------
+   * TRADE
+   --------------------*/
+  const fetchedTradingThisSession = ref(false)
+  const isTradingRestrictedInRegion = ref(false)
+
   return {
     isEIP1559SupportedNetwork,
     eip1559,
@@ -58,5 +64,7 @@ export const useGlobalStore = defineStore('global', () => {
     setSelectedNetwork,
     welcomeDialogDismissed,
     dismissWelcomeDialog,
+    fetchedTradingThisSession,
+    isTradingRestrictedInRegion,
   }
 })

--- a/src/stores/walletStore.ts
+++ b/src/stores/walletStore.ts
@@ -14,7 +14,7 @@ import { useToastStore } from './toastStore'
 import { ToastType } from '@/types/notification'
 import type BaseEvmWallet from '@/providers/ethereum/baseEvmWallet'
 import type { WalletType } from '@/providers/types'
-import { checkAddressRestriction, isTradingRestricted } from '@/modules/trade/providers/ondoHelpers'
+import { checkAddressRestriction } from '@/modules/trade/providers/ondoHelpers'
 import {
   analytics,
   WalletStatus,
@@ -23,6 +23,7 @@ import {
 } from '@/analytics'
 import { type WalletConfigType } from '@/modules/access/common/walletConfigs'
 import * as Sentry from '@sentry/vue'
+import { useMarketStatus } from '@/modules/trade/composables'
 
 const PARTNER = 'ondo-finance'
 
@@ -39,6 +40,7 @@ export const useWalletStore = defineStore('walletStore', () => {
   const hasMissingBalances = ref(false)
   const walletName = ref<string>('')
   const userProperties = reactive<UserProperties>({})
+  const { isTradingRestrictedInRegion } = useMarketStatus()
 
   /** -------------------------------
   * The Wallet
@@ -50,7 +52,7 @@ export const useWalletStore = defineStore('walletStore', () => {
   ): Promise<void> => {
     const _address = await newWallet.getAddress()
     const isRestricted = await checkAddressRestriction(_address)
-    const tradingRestricted = await isTradingRestricted()
+    const tradingRestricted = isTradingRestrictedInRegion.value
     const canTrade = tradingRestricted && !isRestricted;
     userProperties.canTrade = tradingRestricted && !isRestricted
     analytics.setUserProperties({ ...userProperties, canTrade: canTrade });

--- a/src/stores/walletStore.ts
+++ b/src/stores/walletStore.ts
@@ -53,8 +53,8 @@ export const useWalletStore = defineStore('walletStore', () => {
     const _address = await newWallet.getAddress()
     const isRestricted = await checkAddressRestriction(_address)
     const tradingRestricted = isTradingRestrictedInRegion.value
-    const canTrade = tradingRestricted && !isRestricted;
-    userProperties.canTrade = tradingRestricted && !isRestricted
+    const canTrade = !tradingRestricted && !isRestricted;
+    userProperties.canTrade = canTrade
     analytics.setUserProperties({ ...userProperties, canTrade: canTrade });
     if (!isRestricted) {
       if (newWallet instanceof WatchOnlyWallet) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Market status is reliably fetched on startup; trading availability behaves consistently across the app.

* **Refactor**
  * Trading-restriction state centralized in global store and now drives swap and wallet eligibility logic.

* **Improvements**
  * Notifications now await reward/eligibility checks; debug logs removed.
  * App analytics now report the configured app version instead of a hardcoded value.

* **Chores**
  * Minor formatting tweaks with no functional changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyEtherWallet/MyEtherWallet/pull/5489?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->