### PR TITLE
feat: [MEW-1812] show estimated trading fee on order confirmation

### DIFF
--- a/src/modules/perps/ModulePerpsTrade.vue
+++ b/src/modules/perps/ModulePerpsTrade.vue
@@ -660,6 +660,8 @@
       :leverage-error="leverageError"
       :is-submitting="isSubmitting"
       :limit-price-out-of-tolerance="limitPriceOutOfTolerance"
+      :maker-fee="activeContract?.makerFee"
+      :taker-fee="activeContract?.takerFee"
       @confirm="confirmAndSubmitAndSetLeverage"
     />
 
@@ -898,6 +900,7 @@ const {
   marketFilterTabs,
   filteredMarketList,
   fullMarketName,
+  contracts,
   getMarketDisplayName,
   openTokenSelect,
   selectMarket,
@@ -926,6 +929,10 @@ watch(
   val => {
     if (!val) localLeverage.value = tempLeverage.value
   },
+)
+
+const activeContract = computed(() =>
+  contracts.value.find(c => c.market === fullMarketName.value),
 )
 
 const isLoading = computed(() => false)

--- a/src/modules/perps/components/PerpsOrderConfirmationDialog.vue
+++ b/src/modules/perps/components/PerpsOrderConfirmationDialog.vue
@@ -69,6 +69,12 @@
               estimatedLiquidation ? formatUsd(estimatedLiquidation) : '$0.00'
             }}</span>
           </div>
+          <div class="flex justify-between text-s-14">
+            <span class="text-info font-medium"
+              >Est. fee ({{ isMaker ? 'Maker' : 'Taker' }})</span
+            >
+            <span class="font-bold">{{ formatUsdc(estimatedFee) }}</span>
+          </div>
           <div
             v-if="takeProfitPrice !== null"
             class="flex justify-between text-s-14"
@@ -136,16 +142,17 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
 import AppDialog from '@/components/AppDialog.vue'
 import AppTokenLogo from '@/components/AppTokenLogo.vue'
 import AppBtnText from '@/components/AppBtnText.vue'
 import AppBaseButton from '@/components/AppBaseButton.vue'
-import { formatUsd } from '../utils/formatters'
+import { formatUsd, formatUsdc } from '../utils/formatters'
 import { getLogoUrl } from '../utils/market'
 
 const isOpen = defineModel<boolean>('isOpen', { default: false })
 
-defineProps<{
+const props = defineProps<{
   orderSide: 'buy' | 'sell'
   orderType: 'market' | 'limit'
   displaySymbol: string
@@ -162,9 +169,36 @@ defineProps<{
   isSubmitting: boolean
   leverageError: string | null
   limitPriceOutOfTolerance: boolean
+  makerFee?: string
+  takerFee?: string
 }>()
 
 defineEmits<{
   confirm: []
 }>()
+
+// Per-ticket maker/taker rules: market orders are always taker; limit orders
+// classify by whether they would rest on the book (maker) or cross it (taker).
+const isMaker = computed(() => {
+  if (props.orderType !== 'limit') return false
+  const limit = parseFloat(props.limitPrice)
+  if (!Number.isFinite(limit) || !props.currentPrice) return false
+  return props.orderSide === 'buy'
+    ? limit < props.currentPrice
+    : limit > props.currentPrice
+})
+
+const estimatedFee = computed(() => {
+  const rate = parseFloat(
+    (isMaker.value ? props.makerFee : props.takerFee) ?? '',
+  )
+  const size = parseFloat(props.orderSize)
+  const price =
+    props.orderType === 'limit'
+      ? parseFloat(props.limitPrice)
+      : props.currentPrice
+  if (!Number.isFinite(rate) || !Number.isFinite(size) || !Number.isFinite(price))
+    return 0
+  return size * price * rate
+})
 </script>

--- a/src/modules/perps/utils/formatters.ts
+++ b/src/modules/perps/utils/formatters.ts
@@ -39,6 +39,18 @@ export function formatUsd(val: string | number): string {
   })
 }
 
+// USDC-denominated values (e.g. fees) can be much smaller than $0.01 and would
+// round to "$0.00" with the standard 2-decimal USD formatter. Show up to 6
+// decimals (USDC's native precision) and suffix with "USDC".
+export function formatUsdc(val: string | number): string {
+  const n = typeof val === 'number' ? val : parseFloat(val)
+  if (isNaN(n)) return '0.00 USDC'
+  return `${n.toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 6,
+  })} USDC`
+}
+
 export function formatPrice(val?: string | number): string {
   if (val === undefined || val === null) return '—'
   const n = typeof val === 'number' ? val : parseFloat(val)


### PR DESCRIPTION
## What's new

The order confirmation dialog now shows an **estimated trading fee** before you submit a trade, so you know what the trade will cost before clicking confirm.

The row displays:

- the fee amount in USDC, with enough precision to show sub-cent fees (e.g. `0.000455 USDC` instead of rounding to `$0.00`)
- a `(Maker)` or `(Taker)` label so it's clear which rate is being applied

## How the maker/taker label is decided

The label follows the rules Ondo Perps documents:

- **Market orders** → always Taker (they cross the book immediately).
- **Limit Long (buy)** below the current market price → Maker. At or above → Taker.
- **Limit Short (sell)** above the current market price → Maker. At or below → Taker.

The maker and taker rates come from the per-market values returned by `/v1/markets` (so they automatically reflect whatever fee the API reports for that market, rather than being hardcoded).

## How to test

1. Open the perps trade screen.
2. Pick any market and start composing a **market** buy/sell.
3. Click the green/red action → confirmation dialog appears.
4. Verify the new `Est. fee (Taker)` row shows a non-zero USDC amount.
5. Cancel, switch to a **limit** order and try four combinations:
   - **Long, limit price below market** → row should read `Est. fee (Maker)`.
   - **Long, limit price at/above market** → `Est. fee (Taker)`.
   - **Short, limit price above market** → `Est. fee (Maker)`.
   - **Short, limit price at/below market** → `Est. fee (Taker)`.
6. Try a tiny order size to confirm fractional fees still render readable digits (not `$0.00`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Order confirmation dialog now displays estimated transaction fees with clear distinction between maker and taker fee rates, providing transparent cost information before order execution. This helps traders understand the full impact on their position.

* **Improvements**
  * Fee amounts formatted consistently in USDC denomination.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyEtherWallet/MyEtherWallet/pull/5490?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->