### PR TITLE
fix: [MEW-1818] [MEW-1819] sync leverage modal with side panel and cap slider at token max

### DIFF
--- a/src/modules/perps/ModulePerpInfo.vue
+++ b/src/modules/perps/ModulePerpInfo.vue
@@ -886,6 +886,7 @@
     :symbol="baseCurrency"
     :leverage-error="leverageError"
     :is-saving="isSavingLeverage"
+    :max-leverage="marketMaxLeverage"
     mode="submit"
     @save="saveLeverage"
   />
@@ -1352,6 +1353,12 @@ const tempLeverage = ref(1)
 const isSavingLeverage = ref(false)
 const leverageError = ref('')
 
+const marketMaxLeverage = computed(() => {
+  const pair = markets.value.find(m => m.market === props.market)
+  const parsed = parseInt(pair?.defaultLeverage ?? '')
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 20
+})
+
 const saveLeverage = async () => {
   isSavingLeverage.value = true
   leverageError.value = ''
@@ -1376,7 +1383,11 @@ watch(selectedManageAction, action => {
     setWalletPanel('perps')
     setIsOpenSideMenu(true)
   } else if (action.value === 'leverage') {
-    tempLeverage.value = parseInt(marketPosition.value?.leverage ?? '1') || 1
+    const parsedPosition = parseInt(marketPosition.value?.leverage ?? '')
+    const initial = Number.isFinite(parsedPosition) && parsedPosition > 0
+      ? parsedPosition
+      : leverage.value || marketMaxLeverage.value
+    tempLeverage.value = Math.min(initial, marketMaxLeverage.value)
     leverageError.value = ''
     showLeverageDialog.value = true
   }

--- a/src/modules/perps/ModulePerpsTrade.vue
+++ b/src/modules/perps/ModulePerpsTrade.vue
@@ -713,6 +713,7 @@
       :symbol="displaySymbol"
       :leverage-error="leverageError"
       :is-saving="isSavingLeverage"
+      :max-leverage="marketMaxLeverage"
       :mode="manageMode === 'add' ? 'add' : 'create'"
       @save="manageMode === 'add' ? closeLeverageModal() : saveLeverage()"
     />
@@ -922,6 +923,7 @@ const {
   openLeverageModal,
   saveLeverage,
   closeLeverageModal,
+  marketMaxLeverage,
 } = usePerpsTradeForm()
 
 const localLeverage = ref(leverage.value)

--- a/src/modules/perps/components/PerpsMarketList.vue
+++ b/src/modules/perps/components/PerpsMarketList.vue
@@ -578,6 +578,7 @@
     :symbol="leverageSymbol"
     :leverage-error="leverageError"
     :is-saving="isSavingLeverage"
+    :max-leverage="leverageMaxLeverage"
     mode="submit"
     @save="saveLeverage"
   />
@@ -630,6 +631,7 @@ const isSavingLeverage = ref(false)
 const leverageError = ref('')
 const leverageMarket = ref('')
 const leverageSymbol = ref('')
+const leverageMaxLeverage = ref(20)
 const perpsToasts = usePerpsToasts()
 
 const openLeverage = (
@@ -639,7 +641,15 @@ const openLeverage = (
 ) => {
   leverageMarket.value = market
   leverageSymbol.value = symbol
-  tempLeverage.value = parseInt(currentLeverage) || 1
+  const tradingPair = markets.value.find(m => m.market === market)
+  const parsedMax = parseInt(tradingPair?.defaultLeverage ?? '')
+  const maxLev = Number.isFinite(parsedMax) && parsedMax > 0 ? parsedMax : 20
+  leverageMaxLeverage.value = maxLev
+  const parsedCurrent = parseInt(currentLeverage)
+  const initial = Number.isFinite(parsedCurrent) && parsedCurrent > 0
+    ? parsedCurrent
+    : maxLev
+  tempLeverage.value = Math.min(initial, maxLev)
   leverageError.value = ''
   showLeverageDialog.value = true
 }

--- a/src/modules/perps/components/PerpsPositionsTable.vue
+++ b/src/modules/perps/components/PerpsPositionsTable.vue
@@ -821,6 +821,7 @@
       :symbol="displaySymbol"
       :leverage-error="leverageError"
       :is-saving="isSavingLeverage"
+      :max-leverage="localMaxLeverage"
       mode="submit"
       @save="saveLeverage"
     />
@@ -876,6 +877,7 @@ import { usePaginate } from '@/composables/usePaginate'
 import type { Position, ApiOrder, ApiFill } from '../sdk/types'
 
 const localLeverage = ref(1)
+const localMaxLeverage = ref(20)
 const leverageError = ref('')
 const isSavingLeverage = ref(false)
 const fullMarketName = ref('')
@@ -898,9 +900,15 @@ const saveLeverage = async () => {
 const displaySymbol = computed(() => fullMarketName.value.split('-')[0])
 
 const openLeverage = (pos: Position) => {
-  showLeverageModal.value = true
-  localLeverage.value = Number(pos.leverage) // temp
+  const pair = markets.value.find(m => m.market === pos.market)
+  const parsedMax = parseInt(pair?.defaultLeverage ?? '')
+  const maxLev = Number.isFinite(parsedMax) && parsedMax > 0 ? parsedMax : 20
+  localMaxLeverage.value = maxLev
+  const parsedPos = Number(pos.leverage)
+  const initial = Number.isFinite(parsedPos) && parsedPos > 0 ? parsedPos : maxLev
+  localLeverage.value = Math.min(initial, maxLev)
   fullMarketName.value = pos.market
+  showLeverageModal.value = true
 }
 
 watch(
@@ -908,6 +916,7 @@ watch(
   val => {
     if (!val) {
       localLeverage.value = 1
+      localMaxLeverage.value = 20
       leverageError.value = ''
       isSavingLeverage.value = false
       fullMarketName.value = ''

--- a/src/modules/perps/components/PerpsSelectLeverageDialog.vue
+++ b/src/modules/perps/components/PerpsSelectLeverageDialog.vue
@@ -37,14 +37,14 @@
                 :value="modelValue"
                 type="number"
                 min="1"
-                max="20"
+                :max="maxLeverage"
                 step="1"
                 class="font-bold text-[40px] tracking-tight w-[50px] text-center bg-transparent outline-none appearance-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none [-moz-appearance:textfield]"
                 @change="
                   e => {
                     const val = Math.round(
                       Math.min(
-                        20,
+                        maxLeverage,
                         Math.max(
                           1,
                           Number((e.target as HTMLInputElement).value) || 1,
@@ -60,13 +60,15 @@
             </div>
             <button
               class="w-10 h-10 rounded-full bg-white hoverBGWhite flex items-center justify-center hover:bg-greyLight transition-colors text-s-20"
-              :disabled="modelValue >= 20"
+              :disabled="modelValue >= maxLeverage"
               :class="
-                modelValue >= 20
+                modelValue >= maxLeverage
                   ? '!bg-white/90'
                   : 'shadow-button shadow-button-elevated'
               "
-              @click="$emit('update:modelValue', Math.min(20, modelValue + 1))"
+              @click="
+                $emit('update:modelValue', Math.min(maxLeverage, modelValue + 1))
+              "
             >
               <PlusIcon class="w-5 h-5" />
             </button>
@@ -75,7 +77,7 @@
           <!-- Tick Labels -->
           <div class="flex justify-between px-1">
             <button
-              v-for="tick in [1, 5, 10, 15, 20]"
+              v-for="tick in tickValues"
               :key="tick"
               class="text-[11px] font-medium hoverNoBG rounded-full px-2 py-0.5"
               :class="modelValue > tick ? 'text-info' : ''"
@@ -91,11 +93,11 @@
               :value="modelValue"
               type="range"
               min="1"
-              max="20"
+              :max="maxLeverage"
               step="1"
               class="w-full h-2 rounded-full appearance-none cursor-pointer leverage-slider"
               :style="{
-                background: `linear-gradient(to right, #0052ff 0%, #0052ff ${((modelValue - 1) / 19) * 100}%, #e5e7eb ${((modelValue - 1) / 19) * 100}%, #e5e7eb 100%)`,
+                background: `linear-gradient(to right, #0052ff 0%, #0052ff ${sliderFillPct}%, #e5e7eb ${sliderFillPct}%, #e5e7eb 100%)`,
               }"
               @input="
                 $emit(
@@ -156,9 +158,12 @@ interface Props {
   leverageError: string
   isSaving: boolean
   mode: 'add' | 'create' | 'submit'
+  maxLeverage?: number
 }
 
-const props = defineProps<Props>()
+const props = withDefaults(defineProps<Props>(), {
+  maxLeverage: 20,
+})
 
 const isOpen = defineModel('isOpen', {
   type: Boolean,
@@ -175,6 +180,23 @@ const buttonText = computed(() => {
     return props.isSaving ? 'Submitting...' : 'Submit'
   }
   return props.isSaving ? 'Saving...' : 'Save'
+})
+
+const tickValues = computed(() => {
+  const max = Math.max(1, Math.floor(props.maxLeverage))
+  if (max <= 1) return [1]
+  const count = Math.min(5, max)
+  const ticks = new Set<number>()
+  for (let i = 0; i < count; i++) {
+    const v = Math.round(1 + ((max - 1) * i) / (count - 1))
+    ticks.add(v)
+  }
+  return Array.from(ticks).sort((a, b) => a - b)
+})
+
+const sliderFillPct = computed(() => {
+  const max = Math.max(2, props.maxLeverage)
+  return ((props.modelValue - 1) / (max - 1)) * 100
 })
 </script>
 

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -125,6 +125,12 @@ export function usePerpsTradeForm() {
     return match?.market || activeMarket.value
   })
 
+  const marketMaxLeverage = computed(() => {
+    const match = markets.value.find(m => m.market === fullMarketName.value)
+    const parsed = parseInt(match?.defaultLeverage ?? '')
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 20
+  })
+
   const activePosition = computed(
     () => positions.value.find(p => p.market === fullMarketName.value) || null,
   )
@@ -662,7 +668,7 @@ export function usePerpsTradeForm() {
 
   // ── Leverage modal ─────────────────────────────────────────
   function openLeverageModal() {
-    tempLeverage.value = leverage.value
+    tempLeverage.value = Math.min(leverage.value, marketMaxLeverage.value)
     leverageError.value = ''
     showLeverageModal.value = true
   }
@@ -700,7 +706,8 @@ export function usePerpsTradeForm() {
       const res = await perpsClient.getLeverage(fullMarketName.value)
 
       if (res.success && res.result?.length) {
-        leverage.value = parseInt(res.result[0].leverage) || 20
+        const parsed = parseInt(res.result[0].leverage) || marketMaxLeverage.value
+        leverage.value = Math.min(parsed, marketMaxLeverage.value)
       }
     } catch (e) {
       console.error('Failed to fetch leverage:', e)
@@ -1033,8 +1040,22 @@ export function usePerpsTradeForm() {
       closeError.value = ''
       takeProfitPrice.value = null
       stopLossPrice.value = null
+      // Seed leverage from the market's per-token max before the saved
+      // leverage resolves, so callsites reading the singleton (sidepanel /
+      // order modal) don't show a stale value from the previous market or
+      // the default 20 on a market capped lower.
+      leverage.value = Math.min(leverage.value, marketMaxLeverage.value)
       fetchLeverage()
       fetchMaxOrderSize()
+    },
+  )
+
+  // When markets list arrives, clamp the singleton to the active market's
+  // per-token max so the default 20 doesn't exceed a 10x-capped market.
+  watch(
+    () => marketMaxLeverage.value,
+    max => {
+      if (leverage.value > max) leverage.value = max
     },
   )
 
@@ -1198,5 +1219,6 @@ export function usePerpsTradeForm() {
     openLeverageModal,
     closeLeverageModal,
     saveLeverage,
+    marketMaxLeverage,
   }
 }


### PR DESCRIPTION
## What was wrong

Two related bugs on the Perps leverage picker:

- When opening the Long/Short modal from the markets list (or the "Change Leverage" menu on a position), the leverage slider opened at **1×**, even when the side panel was clearly showing something else (e.g. 10× or 20×). Changing it in the modal would then sync everything up — but the first impression was always wrong.
- The leverage slider could go up to **20×** on every market, including tokens that are capped lower (e.g. a market with a 10× max). Picking 20× on a 10× market looked fine in the UI but the order would be rejected by the API at submit time.

## What's fixed

- The leverage modal now opens at the same value the side panel shows. If you already have a position, it uses that position's leverage; otherwise it uses your saved leverage for that market.
- The slider's maximum is now the per-token leverage cap shown on the markets list (the `10x` / `20x` badge). The tick labels along the slider also rescale to that cap, and you can no longer drag past it.
- If a saved leverage from a previous session is higher than the current market's cap, it gets clamped down on open so the order can always be placed.

## How to test

- [ ] Open Perps and pick a market that shows a `10x` badge (e.g. one of the lower-cap tokens). Click **Long** or **Short** — the modal opens; the slider should top out at 10× and show ticks spread across 1–10.
- [ ] Pick a `20x` market and confirm the slider still goes up to 20× with the usual 1 / 5 / 10 / 15 / 20 ticks.
- [ ] Change the leverage in the side panel (e.g. set 8×), close the dialog, then click **Long** again — the modal should open at 8×, not 1×.
- [ ] With an existing position open, use the **Change Leverage** menu from the markets list, the position table, and the market detail page. Each should open the modal at the position's current leverage (clamped to the token cap if it was higher).
- [ ] Submit an order at the new max leverage on a 10× market and confirm it places without the "invalid leverage" rejection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Per-market leverage limits now enforced across all trading interfaces. Leverage controls and sliders dynamically adapt to market-specific maximum values.
  * Initial leverage values automatically clamped to applicable market maximums. Each market's leverage capabilities are now independently defined, replacing the previous global 20x limit.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyEtherWallet/MyEtherWallet/pull/5496?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->