### PR TITLE
fix: [MEW-1820] keep limit-price tolerance band on -10% target preset

### DIFF
--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -195,6 +195,12 @@ export function usePerpsTradeForm() {
     return floored.toFixed(decimals)
   }
 
+  function ceilToIncrement(value: number, increment: number): string {
+    const ceiled = Math.ceil(value / increment) * increment
+    const decimals = Math.max(0, -Math.floor(Math.log10(increment)))
+    return ceiled.toFixed(decimals)
+  }
+
   const activeMarketIncrement = computed(() => {
     const market = markets.value.find(m => m.market === fullMarketName.value)
     return parseFloat(market?.baseIncrement || '0.0001')
@@ -566,7 +572,15 @@ export function usePerpsTradeForm() {
     if (!currentPrice.value) return
     activeLimitPill.value = pct
     const price = currentPrice.value * (1 + pct / 100)
-    limitPrice.value = formatQuotePrice(price)
+    // Round toward currentPrice so the snapped value stays inside the
+    // backend's +/-10% tolerance band: floor for non-negative pct, ceil for
+    // negative pct. Flooring a -10% raw value lands just outside the band on
+    // markets with non-trivial quoteIncrement.
+    const increment = activeMarketQuoteIncrement.value
+    limitPrice.value =
+      pct < 0
+        ? ceilToIncrement(price, increment)
+        : floorToIncrement(price, increment)
   }
 
   // ── Market selector ────────────────────────────────────────


### PR DESCRIPTION
## What was wrong

On the Perps trade screen, when placing a Limit order and clicking the **-10%** Target price preset, the input would land with the red error message:

> Price must be within +/- 10 % tolerance

…even though the user had not typed anything themselves. The Long/Short button stayed disabled, blocking the order.

## What's fixed

The -10% preset now lands the price *inside* the +/-10% tolerance band, just like the other presets. No error, button stays enabled. +10%, +5%, -5%, and Mid behave exactly as before.

## How to test

1. Open the Perps module and switch to a market with a small `quoteIncrement` (e.g. an Equities market priced in cents).
2. Toggle order type to **Limit**.
3. Click the **-10%** Target price button. The target price input should populate, no error should appear, and the Long/Short button should be enabled.
4. Click **+10%**, **-5%**, **+5%**, and **Mid** — they should all populate without errors, same as before.
5. Manually enter prices just inside and just outside the +/-10% band — the tolerance error should still appear when the price is genuinely out of range.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced precision for stop loss and take profit price calculations in perpetual futures trading, ensuring they align more accurately with market tolerance requirements when setting percentage-based offsets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyEtherWallet/MyEtherWallet/pull/5497?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->