### PR TITLE
fix: [MEW-1827] withdraw amount no longer shows Infinity on overflow

### DIFF
--- a/src/modules/perps/components/PerpsAmount.vue
+++ b/src/modules/perps/components/PerpsAmount.vue
@@ -103,13 +103,21 @@ onClickOutside(targetValue, () => {
 })
 
 const handleInput = (e: Event) => {
-  const raw = (e.target as HTMLInputElement).value
+  const input = e.target as HTMLInputElement
+  const raw = input.value
   if (raw === '') {
     amount.value = null
-  } else {
-    const num = parseFloat(raw)
-    amount.value = isNaN(num) ? null : num
+    return
   }
+  const num = parseFloat(raw)
+  // Reject non-finite parses (e.g. very long inputs that overflow Number.MAX_VALUE
+  // to Infinity) — otherwise Vue would stringify amount back into the input as
+  // the literal "Infinity" and downstream consumers would submit it.
+  if (!Number.isFinite(num)) {
+    input.value = amount.value === null ? '' : String(amount.value)
+    return
+  }
+  amount.value = num
 }
 
 const checkIfNumber = (e: KeyboardEvent) => {

--- a/src/modules/perps/components/PerpsWithdrawDialog.vue
+++ b/src/modules/perps/components/PerpsWithdrawDialog.vue
@@ -153,6 +153,10 @@ const withdrawableMargin = computed(
 
 const isValidAmount = computed(() => {
   if (amount.value === null || amount.value <= 0) return false
+  // Don't trust amountError alone — its watcher is debounced 500ms, so a fast
+  // submit could otherwise sneak past a stale-but-empty error string.
+  if (!Number.isFinite(amount.value)) return false
+  if (hasInvalidPrecision(amount.value, USDC_DECIMALS[mainnet.id])) return false
   if (amountError.value) return false
   return amount.value <= parseFloat(withdrawableMargin.value)
 })
@@ -160,6 +164,10 @@ const isValidAmount = computed(() => {
 const validateAmount = () => {
   if (amount.value === null) {
     amountError.value = ''
+    return
+  }
+  if (!Number.isFinite(amount.value)) {
+    amountError.value = 'Amount is too large'
     return
   }
   if (hasInvalidPrecision(amount.value, USDC_DECIMALS[mainnet.id])) {


### PR DESCRIPTION
## What was wrong
In the Perps **Withdraw USDC** dialog, typing or pasting a very long number into the amount field could push the parsed value past JavaScript's largest representable number. When that happened, the field would show the literal word **"Infinity"** instead of the digits the user entered, and a "too many decimals" precision error would briefly fail to appear because validation was running on a short delay.

## What the user will now see
- Typing a number that's too long to represent simply stops accepting more digits — the field never displays "Infinity".
- Trying to withdraw with an amount that has more than 6 decimal places still shows the existing "Amount supports up to 6 decimal places" message, and the **Withdraw** button stays disabled while the value is invalid (no more half-second window where it briefly looks clickable).
- Valid amounts (e.g. `1.5`, `12.345678`) behave exactly the same as before.

## How to test
1. Open the Perps page and click **Withdraw**.
2. Try entering `0.1234567` — confirm the error "Amount supports up to 6 decimal places" appears and **Withdraw** is disabled.
3. Hold down a digit key to flood the field with many digits — confirm the field never shows the word "Infinity" and the button never enables.
4. Enter a normal value like `1.5` — confirm everything still works as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Enhanced validation for perpetual futures amount inputs to reject invalid numeric values and enforce proper decimal precision.
* Improved error handling and messaging when amounts exceed valid limits.
* Strengthened validation checks to prevent submission of malformed or out-of-range amounts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyEtherWallet/MyEtherWallet/pull/5500?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->