### PR TITLE
fix: 🐛 optimize swap init to avoid re-fetching on balance changes

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3686,7 +3686,7 @@ packages:
 
   '@paulmillr/qr@0.2.1':
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
-    deprecated: 'The package is now available as "qr": npm install qr'
+    deprecated: 'Switch to "qr" (new package name) for security updates: npm install qr'
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -4251,6 +4251,7 @@ packages:
   '@safe-global/safe-gateway-typescript-sdk@3.23.1':
     resolution: {integrity: sha512-6ORQfwtEJYpalCeVO21L4XXGSdbEMfyp2hEv6cP82afKXSwvse6d3sdelgaPWUxHIsFRkWvHDdzh8IyyKHZKxw==}
     engines: {node: '>=16'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@scure/base@1.1.9':
     resolution: {integrity: sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==}
@@ -14807,6 +14808,7 @@ packages:
 
   uuid@7.0.3:
     resolution: {integrity: sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@8.3.2:

--- a/src/App.vue
+++ b/src/App.vue
@@ -60,7 +60,7 @@ const {
   userProperties,
 } = storeToRefs(store)
 const chainStore = useChainsStore()
-const { initSwapper } = useSwap()
+useSwap()
 const { selectedChain } = storeToRefs(chainStore)
 const { setTokens, setIsLoadingBalances } = store
 const isLoadingComplete = ref(false)
@@ -183,7 +183,6 @@ onMounted(() => {
     const provider = customEvent.detail
     addProvider(provider)
   })
-  initSwapper()
   if (configs.INTERCOM_APP_ID) {
     Intercom({
       app_id: configs.INTERCOM_APP_ID,

--- a/src/composables/useSwap.ts
+++ b/src/composables/useSwap.ts
@@ -83,10 +83,74 @@ export const useSwap = (): {
   const toTokens = ref<ToTokenType | null>(null)
   const fromTokens = ref<NewTokenInfo[] | null>(null)
   const swapLoaded = ref<boolean>(false)
+  // Cached raw data used to update balances without re-fetching swaplists
+  const rawFromTokens = ref<TokenType[]>([])
+  const restrictedAddressesLower = ref<string[]>([])
+  // Per-instance guard: deduplicates concurrent initSwapper calls
+  let inflightInit: Promise<void> | null = null
+
+  // Updates fromTokens with current wallet balances without re-fetching swaplists.
+  // Called after init and when wallet tokens/native balance change reactively.
+  const applyTokenBalances = () => {
+    if (!swapInstance.value || !swapLoaded.value || !rawFromTokens.value.length) return
+
+    const allFromTokensWithBalance = rawFromTokens.value.map(token => {
+      let tokenBalance = '0'
+      let tokenPrice = token.price
+      if (tokens.value.length > 0 || balanceWei.value !== '0') {
+        if (token.address.toLowerCase() === MAIN_TOKEN_CONTRACT) {
+          tokenBalance = balanceWei.value
+          tokenPrice = tokenPrice || selectedChain.value?.price || 0
+        } else {
+          const found = tokens.value.find(
+            t => t.contract.toLowerCase() === token.address.toLowerCase(),
+          )
+          if (found) {
+            tokenBalance = found.balanceWei
+            tokenPrice = tokenPrice || (found as any).price || 0
+          }
+        }
+      }
+      return Object.freeze({
+        ...token,
+        balance: tokenBalance,
+        price: tokenPrice,
+      }) as NewTokenInfo
+    })
+
+    const fromAllTokensToWalletTokens = allFromTokensWithBalance.filter(
+      token => {
+        if (
+          tokens.value.find(
+            t => t.contract.toLowerCase() === token.address.toLowerCase(),
+          )
+        ) {
+          return true
+        }
+        if (token.address.toLowerCase() === MAIN_TOKEN_CONTRACT) {
+          return true
+        }
+        return false
+      },
+    )
+
+    let finalFromTokens = isWalletConnected.value
+      ? fromAllTokensToWalletTokens
+      : allFromTokensWithBalance
+
+    if (isTradingRestrictedInRegion.value && restrictedAddressesLower.value.length > 0) {
+      finalFromTokens = finalFromTokens.filter(
+        token =>
+          !restrictedAddressesLower.value.includes(token.address.toLowerCase()),
+      )
+    }
+
+    fromTokens.value = finalFromTokens
+  }
 
   // Initialize the Swapper instance
   // parses tokens and to networks available for swapping
-  const initSwapper = async () => {
+  const doInitSwapper = async () => {
     try {
       swapLoaded.value = false
       const rpc = selectedChain.value?.rpcUrls?.[0] || ''
@@ -112,40 +176,40 @@ export const useSwap = (): {
       await swapInstance.value.initPromise
       const allFromTokens = swapInstance.value.getFromTokens()
       supportedNetwork.value = allFromTokens.all.length > 0
+      rawFromTokens.value = allFromTokens.all
       let swapToTokens = swapInstance.value.getToTokens()
 
       // Check if trading is restricted and filter out restricted token addresses
-      const restrictedAddresses = await getRestrictedTokenAddresses()
-
-      const restrictedAddressesLower = restrictedAddresses.map(addr =>
+      const fetchedRestrictedAddresses = await getRestrictedTokenAddresses()
+      restrictedAddressesLower.value = fetchedRestrictedAddresses.map(addr =>
         addr.toLowerCase(),
       )
 
       // Filter toTokens if trading is restricted
-      if (isTradingRestrictedInRegion.value && restrictedAddressesLower.length > 0) {
-        const filterTokenArray = (tokens: TokenTypeTo[]) =>
-          tokens.filter(
+      if (isTradingRestrictedInRegion.value && restrictedAddressesLower.value.length > 0) {
+        const filterTokenArray = (tkns: TokenTypeTo[]) =>
+          tkns.filter(
             token =>
-              !restrictedAddressesLower.includes(token.address.toLowerCase()),
+              !restrictedAddressesLower.value.includes(token.address.toLowerCase()),
           )
 
         swapToTokens = {
           top: Object.fromEntries(
-            Object.entries(swapToTokens.top).map(([network, tokens]) => [
+            Object.entries(swapToTokens.top).map(([network, tkns]) => [
               network,
-              filterTokenArray(tokens as TokenTypeTo[]),
+              filterTokenArray(tkns as TokenTypeTo[]),
             ]),
           ) as typeof swapToTokens.top,
           trending: Object.fromEntries(
-            Object.entries(swapToTokens.trending).map(([network, tokens]) => [
+            Object.entries(swapToTokens.trending).map(([network, tkns]) => [
               network,
-              filterTokenArray(tokens as TokenTypeTo[]),
+              filterTokenArray(tkns as TokenTypeTo[]),
             ]),
           ) as typeof swapToTokens.trending,
           all: Object.fromEntries(
-            Object.entries(swapToTokens.all).map(([network, tokens]) => [
+            Object.entries(swapToTokens.all).map(([network, tkns]) => [
               network,
-              filterTokenArray(tokens as TokenTypeTo[]),
+              filterTokenArray(tkns as TokenTypeTo[]),
             ]),
           ) as typeof swapToTokens.all,
         }
@@ -162,60 +226,9 @@ export const useSwap = (): {
         })
         .filter((chain): chain is Chain => chain !== undefined)
       swapChains.value = toChains.value
-      const allFromTokensWithBalance = allFromTokens.all.map(token => {
-        let tokenBalance = '0'
-        let tokenPrice = token.price
-        if (tokens.value.length > 0 || balanceWei.value !== '0') {
-          if (token.address.toLowerCase() === MAIN_TOKEN_CONTRACT) {
-            tokenBalance = balanceWei.value
-            tokenPrice = tokenPrice || selectedChain.value?.price || 0
-          } else {
-            const found = tokens.value.find(
-              t => t.contract.toLowerCase() === token.address.toLowerCase(),
-            )
-            if (found) {
-              tokenBalance = found.balanceWei
-              tokenPrice = tokenPrice || (found as any).price || 0
-            }
-          }
-        }
-        return Object.freeze({
-          ...token,
-          balance: tokenBalance,
-          price: tokenPrice,
-        }) as NewTokenInfo
-      })
 
-      const fromAllTokensToWalletTokens = allFromTokensWithBalance.filter(
-        token => {
-          if (
-            tokens.value.find(
-              t => t.contract.toLowerCase() === token.address.toLowerCase(),
-            )
-          ) {
-            return true
-          }
-          if (token.address.toLowerCase() === MAIN_TOKEN_CONTRACT) {
-            return true
-          }
-          return false
-        },
-      )
-
-      // Filter out restricted addresses from fromTokens if trading is restricted
-      let finalFromTokens = isWalletConnected.value
-        ? fromAllTokensToWalletTokens
-        : allFromTokensWithBalance
-
-      if (isTradingRestrictedInRegion.value && restrictedAddressesLower.length > 0) {
-        finalFromTokens = finalFromTokens.filter(
-          token =>
-            !restrictedAddressesLower.includes(token.address.toLowerCase()),
-        )
-      }
-
-      fromTokens.value = finalFromTokens
       swapLoaded.value = true
+      applyTokenBalances()
       return Promise.resolve()
     } catch (e) {
       if (
@@ -285,14 +298,31 @@ export const useSwap = (): {
     }
   }
 
+  // Deduplicates concurrent calls — if initialization is already in progress,
+  // returns the same promise rather than starting a second fetch of swaplists.
+  const initSwapper = async (): Promise<void> => {
+    if (inflightInit) return inflightInit
+    inflightInit = doInitSwapper() as Promise<void>
+    inflightInit.finally(() => { inflightInit = null })
+    return inflightInit
+  }
+
+  // Re-initialize swapper only when the network changes, not on every token/balance update.
   watch(
-    () => [selectedChain.value?.name, tokens.value],
-    async newChainName => {
-      if (newChainName) {
+    () => selectedChain.value?.name,
+    async chainName => {
+      if (chainName) {
         await initSwapper()
       }
     },
     { immediate: true },
+  )
+
+  // Update fromTokens balances reactively when wallet tokens or native balance change,
+  // without re-fetching swaplists from the network.
+  watch(
+    () => [tokens.value, balanceWei.value] as const,
+    () => applyTokenBalances(),
   )
 
   return {


### PR DESCRIPTION
### Fix

## What
Refactors `useSwap` to separate swap list initialization (network fetch) from
balance updates (reactive computation), and adds in-flight deduplication for
concurrent `initSwapper` calls.

## Why
Previously, any change to wallet tokens or native balance triggered a full
re-initialization of the swapper, causing unnecessary network requests. This
reduces redundant fetches and improves swap loading performance.

## How
- Extracted `applyTokenBalances()` to update `fromTokens` using cached raw data
  without re-fetching swaplists
- Wrapped internal `doInitSwapper` with a new `initSwapper` that deduplicates
  concurrent calls via an `inflightInit` guard
- Split the single `watch([selectedChain, tokens])` into two separate watchers:
  one for chain changes (triggers re-init) and one for token/balance changes
  (calls `applyTokenBalances` only)
- Removed manual `initSwapper()` call from `App.vue` `onMounted`, now handled
  reactively by the watcher with `immediate: true`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Prevents overlapping swap initialization and improves when initialization runs.
  * Caches and updates token lists/balances more efficiently for snappier UI updates.
  * Applies trading-restricted token filtering during initialization for cleaner results.

* **Bug Fixes**
  * Improves reactivity to network and wallet changes to avoid redundant work.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MyEtherWallet/MyEtherWallet/pull/5501?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->