### PR TITLE
fix: [MEW-1819] sync leverage per market, skeleton while loading

### DIFF
--- a/changelog/fix-5503.md
+++ b/changelog/fix-5503.md
@@ -1,0 +1,1 @@
+fix keep leverage in sync per market and show skeleton while loading

--- a/changelog/fix-5503.md
+++ b/changelog/fix-5503.md
@@ -1,1 +1,0 @@
-fix keep leverage in sync per market and show skeleton while loading

--- a/src/modules/perps/ModulePerpInfo.vue
+++ b/src/modules/perps/ModulePerpInfo.vue
@@ -1395,10 +1395,10 @@ watch(selectedManageAction, action => {
     setIsOpenSideMenu(true)
   } else if (action.value === 'leverage') {
     const parsedPosition = parseInt(marketPosition.value?.leverage ?? '')
-    const initial = Number.isFinite(parsedPosition) && parsedPosition > 0
-      ? parsedPosition
-      : leverage.value || marketMaxLeverage.value
-    tempLeverage.value = Math.min(initial, marketMaxLeverage.value)
+    tempLeverage.value =
+      Number.isFinite(parsedPosition) && parsedPosition > 0
+        ? Math.min(parsedPosition, marketMaxLeverage.value)
+        : marketMaxLeverage.value
     leverageError.value = ''
     showLeverageDialog.value = true
   }

--- a/src/modules/perps/ModulePerpsTrade.vue
+++ b/src/modules/perps/ModulePerpsTrade.vue
@@ -325,9 +325,14 @@
               </div>
               <button
                 class="flex items-center hoverNoBG gap-1 px-2 py-1 rounded-full bg-surface min-w-15"
-                @click="openLeverageModal"
+                :disabled="isLoadingLeverage"
+                @click="openLeverage"
               >
-                <p class="ml-auto font-semibold text-s-14">
+                <span
+                  v-if="isLoadingLeverage"
+                  class="ml-auto bg-grey-10 animate-pulse rounded-full h-4 w-8"
+                />
+                <p v-else class="ml-auto font-semibold text-s-14">
                   {{ manageMode === 'add' ? localLeverage : leverage }}&times;
                 </p>
                 <ChevronDownIcon class="w-3 h-3" />
@@ -730,7 +735,7 @@
       :is-saving="isSavingLeverage"
       :max-leverage="marketMaxLeverage"
       :mode="manageMode === 'add' ? 'add' : 'create'"
-      @save="manageMode === 'add' ? closeLeverageModal() : saveLeverage()"
+      @save="onSaveLeverage"
     />
 
     <!-- Take Profit / Stop Loss Dialog -->
@@ -942,6 +947,7 @@ const {
   showLeverageModal,
   tempLeverage,
   isSavingLeverage,
+  isLoadingLeverage,
   leverageError,
   openLeverageModal,
   saveLeverage,
@@ -959,10 +965,40 @@ watch(
   },
 )
 
+// 'add' mode doesn't persist via the API on save — it stages a leverage for
+// the next add order. Only commit to localLeverage on explicit save (never on
+// dismiss). Non-add modes go through saveLeverage(), which updates the
+// `leverage` singleton and the watcher above syncs localLeverage.
+const onSaveLeverage = () => {
+  if (manageMode.value === 'add') {
+    localLeverage.value = tempLeverage.value
+    closeLeverageModal()
+  } else {
+    saveLeverage()
+  }
+}
+
+// Seed tempLeverage from localLeverage in add mode (which tracks the open
+// position's leverage and any staged-but-unapplied change) instead of the
+// singleton. The composable's openLeverageModal seeds from the singleton,
+// which would jump the slider back to the user's preferred leverage and
+// drop a staged add-mode value.
+const openLeverage = () => {
+  if (manageMode.value === 'add') {
+    tempLeverage.value = Math.min(localLeverage.value, marketMaxLeverage.value)
+    leverageError.value = ''
+    showLeverageModal.value = true
+  } else {
+    openLeverageModal()
+  }
+}
+
+// Reset tempLeverage on dismiss so the confirm modal and submit-path leverage
+// check don't fire on an abandoned slider value.
 watch(
   () => showLeverageModal.value,
   val => {
-    if (!val) localLeverage.value = tempLeverage.value
+    if (!val) tempLeverage.value = localLeverage.value
   },
 )
 

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -33,15 +33,20 @@ const SL_TP_INVALID_PATTERN =
   /invalid\s+(stop[\s-]?loss|take[\s-]?profit|trigger)/i
 
 const leverage = ref(20)
+const isFetchingLeverage = ref(false)
 
 export function usePerpsTradeForm() {
   const walletMenuStore = useWalletMenuStore()
   const router = useRouter()
   const { token, login, triggerRefresh } = usePerpsAuth()
   const { balance } = usePerpsBalance()
-  const { markets } = usePerpsMarkets()
+  const { markets, isLoading: marketsLoading } = usePerpsMarkets()
   const { contracts } = usePerpsContracts()
-  const { positions, closePosition } = usePerpsPositions()
+  const {
+    positions,
+    hasLoaded: positionsHasLoaded,
+    closePosition,
+  } = usePerpsPositions()
   const { markPriceData } = usePerpsMarkPrices()
   const perpsToasts = usePerpsToasts()
 
@@ -70,7 +75,7 @@ export function usePerpsTradeForm() {
   const isSubmitting = ref(false)
   const maxOrderSize = ref<MaxOrderSizeResult | null>(null)
   const showLeverageModal = ref(false)
-  const tempLeverage = ref(1)
+  const tempLeverage = ref(leverage.value)
   const isSavingLeverage = ref(false)
   const leverageError = ref('')
   const showConfirmModal = ref(false)
@@ -133,6 +138,43 @@ export function usePerpsTradeForm() {
 
   const activePosition = computed(
     () => positions.value.find(p => p.market === fullMarketName.value) || null,
+  )
+
+  // Reset the singleton to match the current market synchronously on every
+  // composable instantiation. The leverage singleton is module-scope and
+  // persists across mounts; the activeMarket watcher only fires on subsequent
+  // market changes, so mounting in a market the store was already pointed at
+  // would otherwise render the leverage button with the previously-viewed
+  // market's value until something else triggers a re-sync.
+  {
+    const initialPos = positions.value.find(
+      p => p.market === fullMarketName.value,
+    )
+    const initialParsedPos = initialPos ? parseInt(initialPos.leverage) : NaN
+    leverage.value =
+      Number.isFinite(initialParsedPos) && initialParsedPos > 0
+        ? Math.min(initialParsedPos, marketMaxLeverage.value)
+        : marketMaxLeverage.value
+    // Flag loading when fetchLeverage is expected to fire on mount so consumers
+    // render a skeleton instead of the synced placeholder, avoiding a flash
+    // between the synced value and the user's saved preference.
+    if (token.value && markets.value.length) {
+      isFetchingLeverage.value = true
+    }
+  }
+
+  // Aggregate every async source that can mutate the leverage singleton:
+  // - fetchLeverage (saved preference)
+  // - markets list (drives marketMaxLeverage; can clamp leverage when it
+  //   arrives)
+  // - first positions load (activePosition watcher updates leverage)
+  // Consumers render a skeleton off this until everything has settled so the
+  // displayed value doesn't rotate as each source resolves.
+  const isLoadingLeverage = computed(
+    () =>
+      isFetchingLeverage.value ||
+      marketsLoading.value ||
+      (!!token.value && !positionsHasLoaded.value),
   )
 
   const positionNotionalValue = computed(() => {
@@ -766,7 +808,11 @@ export function usePerpsTradeForm() {
 
   // ── API fetchers ───────────────────────────────────────────
   async function fetchLeverage() {
-    if (!token.value || !markets.value.length) return
+    if (!token.value || !markets.value.length) {
+      isFetchingLeverage.value = false
+      return
+    }
+    isFetchingLeverage.value = true
     try {
       const res = await perpsClient.getLeverage(fullMarketName.value)
 
@@ -776,6 +822,8 @@ export function usePerpsTradeForm() {
       }
     } catch (e) {
       console.error('Failed to fetch leverage:', e)
+    } finally {
+      isFetchingLeverage.value = false
     }
   }
 
@@ -1084,6 +1132,25 @@ export function usePerpsTradeForm() {
     { immediate: true },
   )
 
+  // Sync the singleton to the position's leverage when the position appears
+  // or its leverage changes. The activeMarket watcher already covers market
+  // switches, but positions can arrive after that watcher runs, leaving the
+  // singleton on its default. Comparing prev/current leverage prevents
+  // routine positions polling from clobbering a leverage the user has staged
+  // (e.g., via Change Leverage) but not yet applied through an add order.
+  watch(
+    () => activePosition.value,
+    (pos, prev) => {
+      if (pos && pos.leverage !== prev?.leverage) {
+        const parsed = parseInt(pos.leverage)
+        if (Number.isFinite(parsed) && parsed > 0) {
+          leverage.value = Math.min(parsed, marketMaxLeverage.value)
+        }
+      }
+    },
+    { immediate: true },
+  )
+
   watch(
     () => walletMenuStore.selectedTradeOrderSide,
     side => {
@@ -1105,11 +1172,17 @@ export function usePerpsTradeForm() {
       closeError.value = ''
       takeProfitPrice.value = null
       stopLossPrice.value = null
-      // Seed leverage from the market's per-token max before the saved
-      // leverage resolves, so callsites reading the singleton (sidepanel /
-      // order modal) don't show a stale value from the previous market or
-      // the default 20 on a market capped lower.
-      leverage.value = Math.min(leverage.value, marketMaxLeverage.value)
+      // Reset leverage to the new market's open-position leverage if there is
+      // one, otherwise to its per-token max. Prevents callsites reading the
+      // singleton (sidepanel / order modal / leverage dialog) from showing a
+      // stale value carried over from the previous market until the async
+      // fetchLeverage resolves.
+      const pos = positions.value.find(p => p.market === fullMarketName.value)
+      const parsedPos = pos ? parseInt(pos.leverage) : NaN
+      leverage.value =
+        Number.isFinite(parsedPos) && parsedPos > 0
+          ? Math.min(parsedPos, marketMaxLeverage.value)
+          : marketMaxLeverage.value
       fetchLeverage()
       fetchMaxOrderSize()
     },
@@ -1121,6 +1194,16 @@ export function usePerpsTradeForm() {
     () => marketMaxLeverage.value,
     max => {
       if (leverage.value > max) leverage.value = max
+    },
+  )
+
+  // Keep tempLeverage tracking the saved leverage while the modal is closed
+  // so the order confirmation dialog displays the same value as the info
+  // drawer when the user opens it without ever interacting with the modal.
+  watch(
+    () => leverage.value,
+    val => {
+      if (!showLeverageModal.value) tempLeverage.value = val
     },
   )
 
@@ -1280,6 +1363,7 @@ export function usePerpsTradeForm() {
     showLeverageModal,
     tempLeverage,
     isSavingLeverage,
+    isLoadingLeverage,
     leverageError,
     openLeverageModal,
     closeLeverageModal,


### PR DESCRIPTION
## Summary
- Reset the module-scope `leverage` singleton on every `usePerpsTradeForm()` instantiation so the trade panel never renders with another token's leverage. The previous `activeMarket` watcher only fired on subsequent changes, leaving the singleton stale when the store already pointed at the newly-opened market.
- Sync the singleton to the active position's leverage when it appears or changes (`activePosition` watcher with `immediate: true`), clamped to the market's max so polling can't clobber a staged value.
- Drive the leverage button with a `isLoadingLeverage` computed that aggregates every async source that can mutate the singleton — `fetchLeverage` (saved preference), `marketsLoading` (drives `marketMaxLeverage` / clamp), and the first `usePerpsPositions().hasLoaded` cycle. The button renders a `bg-grey-10 animate-pulse` skeleton until all three settle, eliminating the "value rotates as each source resolves" flash.
- `ModulePerpsTrade.vue` add-mode opens the leverage dialog seeded from `localLeverage` (the staged add-mode value) instead of the singleton, so the slider doesn't snap to the user's saved preference and drop an unsaved staged change.
- `ModulePerpInfo.vue` "Change Leverage" now seeds `tempLeverage` from the position's leverage (or `marketMaxLeverage` when there's no open position), so the dialog starts at the value the drawer is actually showing.

## Test plan
- [ ] Open the trade panel on a token with no open position — leverage shows the token's max once everything loads, no flash from a previously-viewed token.
- [ ] Open the trade panel on a token with an open position — leverage shows the position's leverage; no flash.
- [ ] Switch markets back and forth (one with a position, one without) — leverage updates with the skeleton, never showing the previous market's value.
- [ ] Change leverage from the info drawer's "Change Leverage" action — dialog opens at the position's leverage (or token max), Save persists via `setLeverage`.
- [ ] In add mode (open position), open the leverage dialog from the trade panel — slider starts at the staged `localLeverage`, not the saved preference; Save updates `localLeverage` without firing the API.
- [ ] Click Long / Short from the drawer — the order confirmation dialog's `Leverage` field reflects the drawer's leverage.
- [ ] Confirm the slider can't exceed each token's `defaultLeverage` cap (tested at least one ≤10× market and one ≥20× market).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Staged leverage editing: changes in "add" mode are previewed locally and only persisted on save.
  * Loading indicators and disabled state for leverage controls to prevent UI flicker.

* **Bug Fixes**
  * More robust leverage computation with safer fallbacks and per-market sync.
  * Prevent abandoned modal edits from overwriting staged leverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->