### PR TITLE
fix: [MEW-1835] remove redundant sign-in label above perps sign-in button

### DIFF
--- a/src/modules/perps/ModulePerpsTrade.vue
+++ b/src/modules/perps/ModulePerpsTrade.vue
@@ -634,7 +634,6 @@
         <div
           class="bg-mewBg rounded-20 px-4 pb-6 pt-6 mx-auto w-full text-center w-[calc(100%-2rem)] mt-4"
         >
-          <p class="text-info text-s-14 mb-4">Sign in to start trading</p>
           <button
             class="bg-primary text-white rounded-full px-6 py-2.5 text-s-14 font-medium hoverOpacity w-full"
             @click="login"


### PR DESCRIPTION
## Summary
- Drops the "Sign in to start trading" paragraph above the "Sign in to Perps" button in the trade panel, leaving only the button as designed (per QA in MEW-1835).

## Test plan
- [ ] Open Perps with a wallet that hasn't authenticated to Perps yet
- [ ] Confirm the right panel shows only the "Sign in to Perps" button — no text above it
- [ ] Click "Sign in to Perps" and confirm sign-in flow still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified the unauthenticated user sign-in interface by removing redundant text. The sign-in action is now represented solely by the "Sign in to Perps" button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->