### PR TITLE
[MEW-1821] gate perps fetches behind isPerpsActive

### DIFF
--- a/src/modules/perps/composables/usePerpsActive.ts
+++ b/src/modules/perps/composables/usePerpsActive.ts
@@ -1,0 +1,17 @@
+import { computed, type ComputedRef } from 'vue'
+import { useRoute } from 'vue-router'
+import { storeToRefs } from 'pinia'
+import { useWalletMenuStore } from '@/stores/walletMenuStore'
+
+let _isPerpsActive: ComputedRef<boolean> | null = null
+
+export function usePerpsActive() {
+  if (!_isPerpsActive) {
+    const route = useRoute()
+    const { walletPanel } = storeToRefs(useWalletMenuStore())
+    _isPerpsActive = computed(
+      () => route.path.startsWith('/perps') || walletPanel.value === 'perps',
+    )
+  }
+  return { isPerpsActive: _isPerpsActive }
+}

--- a/src/modules/perps/composables/usePerpsActive.ts
+++ b/src/modules/perps/composables/usePerpsActive.ts
@@ -1,4 +1,4 @@
-import { computed, type ComputedRef } from 'vue'
+import { computed, watch, type ComputedRef } from 'vue'
 import { useRoute } from 'vue-router'
 import { storeToRefs } from 'pinia'
 import { useWalletMenuStore } from '@/stores/walletMenuStore'
@@ -14,4 +14,14 @@ export function usePerpsActive() {
     )
   }
   return { isPerpsActive: _isPerpsActive }
+}
+
+export function gatedPoll(fn: () => void, intervalMs: number) {
+  const { isPerpsActive } = usePerpsActive()
+  setInterval(() => {
+    if (isPerpsActive.value) fn()
+  }, intervalMs)
+  watch(isPerpsActive, on => {
+    if (on) fn()
+  })
 }

--- a/src/modules/perps/composables/usePerpsActive.ts
+++ b/src/modules/perps/composables/usePerpsActive.ts
@@ -8,9 +8,11 @@ let _isPerpsActive: ComputedRef<boolean> | null = null
 export function usePerpsActive() {
   if (!_isPerpsActive) {
     const route = useRoute()
-    const { walletPanel } = storeToRefs(useWalletMenuStore())
+    const { walletPanel, isOpenSideMenu } = storeToRefs(useWalletMenuStore())
     _isPerpsActive = computed(
-      () => route.path.startsWith('/perps') || walletPanel.value === 'perps',
+      () =>
+        route.path.startsWith('/perps') ||
+        (walletPanel.value === 'perps' && isOpenSideMenu.value),
     )
   }
   return { isPerpsActive: _isPerpsActive }

--- a/src/modules/perps/composables/usePerpsActive.ts
+++ b/src/modules/perps/composables/usePerpsActive.ts
@@ -1,4 +1,4 @@
-import { computed, watch, type ComputedRef } from 'vue'
+import { computed, watch, effectScope, type ComputedRef } from 'vue'
 import { useRoute } from 'vue-router'
 import { storeToRefs } from 'pinia'
 import { useWalletMenuStore } from '@/stores/walletMenuStore'
@@ -23,7 +23,11 @@ export function gatedPoll(fn: () => void, intervalMs: number) {
   setInterval(() => {
     if (isPerpsActive.value) fn()
   }, intervalMs)
-  watch(isPerpsActive, on => {
-    if (on) fn()
+  // Detached scope so the watcher survives the unmount of whichever
+  // component happens to call gatedPoll first.
+  effectScope(true).run(() => {
+    watch(isPerpsActive, on => {
+      if (on) fn()
+    })
   })
 }

--- a/src/modules/perps/composables/usePerpsAuth.ts
+++ b/src/modules/perps/composables/usePerpsAuth.ts
@@ -4,6 +4,7 @@ import { useWalletStore } from '@/stores/walletStore'
 import { storeToRefs } from 'pinia'
 import type { PerpsBalance, PortfolioSummary } from '../sdk/types'
 import { usePerpsToasts } from '@/modules/perps/composables/usePerpsToasts'
+import { gatedPoll } from '@/modules/perps/composables/usePerpsActive'
 import { decrypt, encrypt } from '@/utils/crypto'
 
 const STORAGE_KEY_TOKEN = 'perps_auth_token'
@@ -216,7 +217,7 @@ export function usePerpsBalance() {
     }
 
     poll()
-    setInterval(poll, 1_000)
+    gatedPoll(poll, 1_000)
 
     let lastRefreshKey = refreshKey.value
     setInterval(() => {
@@ -286,7 +287,7 @@ export function usePerpsPortfolioSummary() {
     }
 
     poll()
-    setInterval(poll, 300_000) // refresh every 5 minutes
+    gatedPoll(poll, 300_000) // refresh every 5 minutes
 
     _sharedFetchSummary = fetchSummary
   }

--- a/src/modules/perps/composables/usePerpsMarkPrices.ts
+++ b/src/modules/perps/composables/usePerpsMarkPrices.ts
@@ -1,5 +1,6 @@
 import { ref } from 'vue'
 import { perpsClient } from '../configs'
+import { gatedPoll } from './usePerpsActive'
 
 const markPriceData = ref<Record<string, any>>({})
 let initialized = false
@@ -17,7 +18,7 @@ export function usePerpsMarkPrices() {
   if (!initialized) {
     initialized = true
     fetchMarkPrices()
-    setInterval(fetchMarkPrices, 5_000)
+    gatedPoll(fetchMarkPrices, 5_000)
   }
   return { markPriceData, refetch: fetchMarkPrices }
 }

--- a/src/modules/perps/composables/usePerpsMarkets.ts
+++ b/src/modules/perps/composables/usePerpsMarkets.ts
@@ -1,6 +1,7 @@
 import { ref } from 'vue'
 import type { Contract, TradingPair } from '../sdk/types'
 import { perpsClient } from '../configs'
+import { gatedPoll } from './usePerpsActive'
 
 // Singleton state for markets
 const markets = ref<TradingPair[]>([])
@@ -70,7 +71,7 @@ export function usePerpsContracts() {
   if (!contractsInitialized) {
     contractsInitialized = true
     fetchContracts()
-    setInterval(fetchContracts, 2500)
+    gatedPoll(fetchContracts, 2500)
   }
   return {
     contracts,

--- a/src/modules/perps/composables/usePerpsPositions.ts
+++ b/src/modules/perps/composables/usePerpsPositions.ts
@@ -1,5 +1,6 @@
 import { ref, watch } from 'vue'
 import { perpsClient } from '../configs'
+import { gatedPoll } from './usePerpsActive'
 import { usePerpsAuth } from './usePerpsAuth'
 import type { Position } from '../sdk/types'
 
@@ -44,7 +45,7 @@ function startPolling() {
   }
 
   poll()
-  setInterval(poll, 5_000)
+  gatedPoll(poll, 5_000)
 
   // The singleton is often initialised by PerpsMarketList (mounted before auth)
   // so the first poll() runs with no token and never sets loading=true. React

--- a/tests/unit/specs/modules/perps/composables/usePerpsActive.spec.ts
+++ b/tests/unit/specs/modules/perps/composables/usePerpsActive.spec.ts
@@ -50,28 +50,56 @@ describe('usePerpsActive', () => {
     expect(isPerpsActive.value).toBe(true)
   })
 
-  it('returns true when side panel is perps on any route', async () => {
+  it('returns true when side panel is perps AND drawer is open on any route', async () => {
     const { usePerpsActive } = await import(
       '@/modules/perps/composables/usePerpsActive'
     )
     const store = useWalletMenuStore()
     store.setWalletPanel('perps')
+    store.setIsOpenSideMenu(true)
     routePath.value = '/stocks'
     const { isPerpsActive } = usePerpsActive()
     expect(isPerpsActive.value).toBe(true)
   })
 
-  it('reacts to walletPanel changes', async () => {
+  it('returns false when perps panel is selected but drawer is closed', async () => {
+    const { usePerpsActive } = await import(
+      '@/modules/perps/composables/usePerpsActive'
+    )
+    const store = useWalletMenuStore()
+    store.setWalletPanel('perps')
+    store.setIsOpenSideMenu(false)
+    routePath.value = '/stocks'
+    const { isPerpsActive } = usePerpsActive()
+    expect(isPerpsActive.value).toBe(false)
+  })
+
+  it('reacts to walletPanel changes while drawer stays open', async () => {
     const { usePerpsActive } = await import(
       '@/modules/perps/composables/usePerpsActive'
     )
     const store = useWalletMenuStore()
     store.setWalletPanel('swap')
+    store.setIsOpenSideMenu(true)
     routePath.value = '/'
     const { isPerpsActive } = usePerpsActive()
     expect(isPerpsActive.value).toBe(false)
     store.setWalletPanel('perps')
     expect(isPerpsActive.value).toBe(true)
+  })
+
+  it('reacts to drawer close while perps panel remains selected', async () => {
+    const { usePerpsActive } = await import(
+      '@/modules/perps/composables/usePerpsActive'
+    )
+    const store = useWalletMenuStore()
+    store.setWalletPanel('perps')
+    store.setIsOpenSideMenu(true)
+    routePath.value = '/'
+    const { isPerpsActive } = usePerpsActive()
+    expect(isPerpsActive.value).toBe(true)
+    store.setIsOpenSideMenu(false)
+    expect(isPerpsActive.value).toBe(false)
   })
 })
 
@@ -117,12 +145,14 @@ describe('gatedPoll', () => {
     )
     const store = useWalletMenuStore()
     store.setWalletPanel('swap')
+    store.setIsOpenSideMenu(false)
     routePath.value = '/'
     const fn = vi.fn()
     gatedPoll(fn, 5000)
     vi.advanceTimersByTime(1000)
     expect(fn).not.toHaveBeenCalled()
     store.setWalletPanel('perps')
+    store.setIsOpenSideMenu(true)
     await vi.advanceTimersByTimeAsync(0)
     expect(fn).toHaveBeenCalledTimes(1)
   })

--- a/tests/unit/specs/modules/perps/composables/usePerpsActive.spec.ts
+++ b/tests/unit/specs/modules/perps/composables/usePerpsActive.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
 import { useWalletMenuStore } from '@/stores/walletMenuStore'
 
@@ -72,5 +72,58 @@ describe('usePerpsActive', () => {
     expect(isPerpsActive.value).toBe(false)
     store.setWalletPanel('perps')
     expect(isPerpsActive.value).toBe(true)
+  })
+})
+
+describe('gatedPoll', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    routePath.value = '/'
+    vi.useFakeTimers()
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does not call fn when inactive', async () => {
+    const { gatedPoll } = await import(
+      '@/modules/perps/composables/usePerpsActive'
+    )
+    const store = useWalletMenuStore()
+    store.setWalletPanel('swap')
+    routePath.value = '/'
+    const fn = vi.fn()
+    gatedPoll(fn, 1000)
+    vi.advanceTimersByTime(3500)
+    expect(fn).not.toHaveBeenCalled()
+  })
+
+  it('calls fn each tick while active', async () => {
+    const { gatedPoll } = await import(
+      '@/modules/perps/composables/usePerpsActive'
+    )
+    routePath.value = '/perps'
+    const fn = vi.fn()
+    gatedPoll(fn, 1000)
+    vi.advanceTimersByTime(3500)
+    expect(fn).toHaveBeenCalledTimes(3)
+  })
+
+  it('fires fn immediately on inactive→active transition', async () => {
+    const { gatedPoll } = await import(
+      '@/modules/perps/composables/usePerpsActive'
+    )
+    const store = useWalletMenuStore()
+    store.setWalletPanel('swap')
+    routePath.value = '/'
+    const fn = vi.fn()
+    gatedPoll(fn, 5000)
+    vi.advanceTimersByTime(1000)
+    expect(fn).not.toHaveBeenCalled()
+    store.setWalletPanel('perps')
+    await vi.advanceTimersByTimeAsync(0)
+    expect(fn).toHaveBeenCalledTimes(1)
   })
 })

--- a/tests/unit/specs/modules/perps/composables/usePerpsActive.spec.ts
+++ b/tests/unit/specs/modules/perps/composables/usePerpsActive.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { createPinia, setActivePinia } from 'pinia'
+import { useWalletMenuStore } from '@/stores/walletMenuStore'
+
+const { routePath } = vi.hoisted(() => ({
+  routePath: { value: '/' },
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({
+    get path() {
+      return routePath.value
+    },
+  }),
+}))
+
+describe('usePerpsActive', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    routePath.value = '/'
+    vi.resetModules()
+  })
+
+  it('returns false on a non-perps route with side panel != perps', async () => {
+    const { usePerpsActive } = await import(
+      '@/modules/perps/composables/usePerpsActive'
+    )
+    const store = useWalletMenuStore()
+    store.setWalletPanel('swap')
+    routePath.value = '/stocks'
+    const { isPerpsActive } = usePerpsActive()
+    expect(isPerpsActive.value).toBe(false)
+  })
+
+  it('returns true on /perps route', async () => {
+    const { usePerpsActive } = await import(
+      '@/modules/perps/composables/usePerpsActive'
+    )
+    routePath.value = '/perps'
+    const { isPerpsActive } = usePerpsActive()
+    expect(isPerpsActive.value).toBe(true)
+  })
+
+  it('returns true on /perps/perp/:market sub-route', async () => {
+    const { usePerpsActive } = await import(
+      '@/modules/perps/composables/usePerpsActive'
+    )
+    routePath.value = '/perps/perp/ETH-USD'
+    const { isPerpsActive } = usePerpsActive()
+    expect(isPerpsActive.value).toBe(true)
+  })
+
+  it('returns true when side panel is perps on any route', async () => {
+    const { usePerpsActive } = await import(
+      '@/modules/perps/composables/usePerpsActive'
+    )
+    const store = useWalletMenuStore()
+    store.setWalletPanel('perps')
+    routePath.value = '/stocks'
+    const { isPerpsActive } = usePerpsActive()
+    expect(isPerpsActive.value).toBe(true)
+  })
+
+  it('reacts to walletPanel changes', async () => {
+    const { usePerpsActive } = await import(
+      '@/modules/perps/composables/usePerpsActive'
+    )
+    const store = useWalletMenuStore()
+    store.setWalletPanel('swap')
+    routePath.value = '/'
+    const { isPerpsActive } = usePerpsActive()
+    expect(isPerpsActive.value).toBe(false)
+    store.setWalletPanel('perps')
+    expect(isPerpsActive.value).toBe(true)
+  })
+})

--- a/tests/unit/specs/modules/perps/composables/usePerpsActive.spec.ts
+++ b/tests/unit/specs/modules/perps/composables/usePerpsActive.spec.ts
@@ -2,9 +2,10 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
 import { useWalletMenuStore } from '@/stores/walletMenuStore'
 
-const { routePath } = vi.hoisted(() => ({
-  routePath: { value: '/' },
-}))
+const { routePath } = await vi.hoisted(async () => {
+  const { ref } = await import('vue')
+  return { routePath: ref('/') }
+})
 
 vi.mock('vue-router', () => ({
   useRoute: () => ({
@@ -101,6 +102,17 @@ describe('usePerpsActive', () => {
     store.setIsOpenSideMenu(false)
     expect(isPerpsActive.value).toBe(false)
   })
+
+  it('reacts to route navigation /stocks → /perps', async () => {
+    const { usePerpsActive } = await import(
+      '@/modules/perps/composables/usePerpsActive'
+    )
+    routePath.value = '/stocks'
+    const { isPerpsActive } = usePerpsActive()
+    expect(isPerpsActive.value).toBe(false)
+    routePath.value = '/perps'
+    expect(isPerpsActive.value).toBe(true)
+  })
 })
 
 describe('gatedPoll', () => {
@@ -153,6 +165,20 @@ describe('gatedPoll', () => {
     expect(fn).not.toHaveBeenCalled()
     store.setWalletPanel('perps')
     store.setIsOpenSideMenu(true)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires fn on route navigation into /perps', async () => {
+    const { gatedPoll } = await import(
+      '@/modules/perps/composables/usePerpsActive'
+    )
+    routePath.value = '/stocks'
+    const fn = vi.fn()
+    gatedPoll(fn, 5000)
+    vi.advanceTimersByTime(1000)
+    expect(fn).not.toHaveBeenCalled()
+    routePath.value = '/perps'
     await vi.advanceTimersByTimeAsync(0)
     expect(fn).toHaveBeenCalledTimes(1)
   })


### PR DESCRIPTION
## Summary
- Adds `usePerpsActive` composable: a reactive flag = `route.startsWith('/perps') || (walletPanel === 'perps' && isOpenSideMenu)`
- Adds `gatedPoll(fn, ms)` helper that wraps `setInterval` to skip ticks when inactive and refire on every false→true transition
- Wires the gate into the five leaking module-level singletons: `usePerpsContracts`, `usePerpsMarkPrices`, `usePerpsPositions`, `usePerpsBalance`, `usePerpsPortfolioSummary`

## What was leaking
| Composable | Interval |
|---|---|
| `usePerpsContracts` | 2.5s |
| `usePerpsMarkPrices` | 5s |
| `usePerpsPositions` | 5s |
| `usePerpsBalance` | 1s |
| `usePerpsPortfolioSummary` | 5min |

All five were module-level singletons that never stopped. Now they no-op when `isPerpsActive === false`.

## What was NOT touched
- `usePerpsAuth` token-restoration `watch(walletAddress)` — runs only on address change, not periodic
- `usePerpsHistory` (`usePerpsOrders`, `usePerpsFills`, `usePerpsDepositsWithdrawals`) — already use `onUnmounted` cleanup
- `usePerpsPortfolioGraph` cache-clear interval — clears cache, no network
- `refreshKey` watchers in `usePerpsPositions` / `usePerpsBalance` — only fire after user mutations, which are inherently inside perps

## Test plan
- [x] `pnpm test:unit run tests/unit/specs/modules/perps/composables/usePerpsActive.spec.ts` — 10/10 pass
- [x] `pnpm test:unit run` (full suite) — 64/64 pass
- [x] `pnpm type-check` — clean
- [x] `pnpm lint` — clean
- [x] Manual: opening then closing the perps side panel stops fetching; navigating to `/stocks` shows 0 perps requests; navigating into `/perps` triggers an immediate refetch and resumes intervals


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced gated polling for the perps module so balances, positions, mark prices, markets and portfolio summaries poll only when the perps view/panel is active; polling now starts/stops with UI context and triggers immediately on activation.

* **Tests**
  * Added unit tests covering perps-active detection and gated polling behavior across navigation and menu state changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->