### PR TITLE
MEW-1850 perps: replace REST polling with WebSocket subscriptions (public + private)

### DIFF
--- a/src/modules/perps/ModulePerpInfo.vue
+++ b/src/modules/perps/ModulePerpInfo.vue
@@ -92,14 +92,18 @@
           </template>
         </app-btn-group>
       </div>
-      <div class="h-[200px] sm:h-[320px] px-4 lg:px-10 py-6">
-        <chart-price
+      <div class="h-[200px] sm:h-[320px] px-4 lg:px-10 py-6 flex">
+        <div
           v-if="!chartLoading && chartLabels.length > 0"
-          :labels="chartLabels"
-          :points="chartPoints"
-          :time-frame="chartTimeFrame"
           class="w-full h-full"
-        />
+        >
+          <chart-price
+            :labels="chartLabels"
+            :points="chartPoints"
+            :time-frame="chartTimeFrame"
+            class="w-full h-full"
+          />
+        </div>
         <div
           v-else
           class="w-full bg-surface h-full rounded-lg"
@@ -939,6 +943,7 @@ import {
 import { perpsClient, PERPS_INFO_PAGE_SIZE } from './configs'
 import { perpsWs } from './sdk/ws'
 import { useCursorPaginate } from './composables/useCursorPaginate'
+import { useChartHistoryCache } from './composables/useChartHistoryCache'
 import {
   usePerpsMarkets,
   usePerpsContracts,
@@ -1455,11 +1460,11 @@ const chartIntervals = [
   { label: '1w', value: '1W' },
 ]
 const selectedInterval = ref(chartIntervals[2])
-const chartLoading = ref(false)
+const chartLoading = ref(true)
 const chartLabels = ref<number[]>([])
 const chartPoints = ref<number[]>([])
 
-const chartCache = new Map<string, { labels: number[]; points: number[] }>()
+const chartHistoryCache = useChartHistoryCache()
 
 const chartTimeFrame = computed(() => {
   const v = selectedInterval.value.value
@@ -1477,47 +1482,68 @@ const getResolutionSeconds = (res: string): number => {
   return parseInt(res) * 60
 }
 
+let chartAbortController: AbortController | null = null
+
 const fetchChart = async () => {
-  const cacheKey = `${props.market}-${selectedInterval.value.value}`
-  const cached = chartCache.get(cacheKey)
+  const market = props.market
+  const intervalValue = selectedInterval.value.value
+  const cacheKey = `${market}-${intervalValue}`
+
+  // Cancel any in-flight fetch from the previous market/interval. Without
+  // this, a quick A->B market switch leaves A's response racing B's, the
+  // late winner overwrites B's chart, and we waste bandwidth.
+  chartAbortController?.abort()
+  chartAbortController = new AbortController()
+  const localController = chartAbortController
+
+  const cached = chartHistoryCache.get(cacheKey)
   if (cached) {
     chartLabels.value = cached.labels
     chartPoints.value = cached.points
+    chartLoading.value = false
     return
   }
 
   chartLoading.value = true
+
   try {
     const to = Math.floor(Date.now() / 1000)
-    const resSecs = getResolutionSeconds(selectedInterval.value.value)
+    const resSecs = getResolutionSeconds(intervalValue)
     const from = to - resSecs * 200
     const data = await perpsClient.getHistory(
-      props.market,
-      selectedInterval.value.value,
+      market,
+      intervalValue,
       from,
       to,
+      localController.signal,
     )
+    // Bail out if a newer fetch superseded us between request and response.
+    if (localController.signal.aborted) return
     if (data.s === 'ok' && data.t.length > 0) {
       const labels = data.t.map(t => t * 1000)
       chartLabels.value = labels
       chartPoints.value = data.c
-      chartCache.set(cacheKey, { labels, points: data.c })
+      chartHistoryCache.set(cacheKey, { labels, points: data.c })
     } else {
       chartLabels.value = []
       chartPoints.value = []
     }
-  } catch {
+  } catch (err) {
+    if ((err as { name?: string })?.name === 'AbortError') return
     chartLabels.value = []
     chartPoints.value = []
   } finally {
-    chartLoading.value = false
+    if (!localController.signal.aborted) {
+      chartLoading.value = false
+    }
   }
 }
 
 watch(selectedInterval, fetchChart)
 watch(() => props.market, fetchChart, { immediate: true })
 
-// Clear chart cache every 5 minutes
-const cacheClearTimer = setInterval(() => chartCache.clear(), 5 * 60 * 1000)
-onUnmounted(() => clearInterval(cacheClearTimer))
+onUnmounted(() => {
+  chartAbortController?.abort()
+  chartAbortController = null
+})
 </script>

--- a/src/modules/perps/ModulePerpInfo.vue
+++ b/src/modules/perps/ModulePerpInfo.vue
@@ -1303,32 +1303,19 @@ watch(refreshKey, () => {
   void fetchOpenOrdersCount()
 })
 
-// Funding countdown timer
-const fundingCountdown = ref('')
-let countdownTimer: ReturnType<typeof setInterval> | null = null
-
-const updateFundingCountdown = () => {
+// Funding countdown — derived from reactive contractData; no client timer needed.
+const fundingCountdown = computed(() => {
   const ts = contractData.value?.nextFundingRateTimestamp
-  if (!ts) {
-    fundingCountdown.value = ''
-    return
-  }
+  if (!ts) return ''
   const diff = new Date(ts).getTime() - Date.now()
-  if (diff <= 0) {
-    fundingCountdown.value = 'now'
-    return
-  }
+  if (diff <= 0) return 'now'
   const mins = Math.floor(diff / 60000)
   const secs = Math.floor((diff % 60000) / 1000)
-  fundingCountdown.value = `${mins} min`
-  if (mins === 0) fundingCountdown.value = `${secs}s`
-}
-
-countdownTimer = setInterval(updateFundingCountdown, 5000)
-updateFundingCountdown()
+  if (mins === 0) return `${secs}s`
+  return `${mins} min`
+})
 
 onUnmounted(() => {
-  if (countdownTimer) clearInterval(countdownTimer)
   if (ordersPollTimer) clearInterval(ordersPollTimer)
   if (fillsPollTimer) clearInterval(fillsPollTimer)
 })

--- a/src/modules/perps/ModulePerpInfo.vue
+++ b/src/modules/perps/ModulePerpInfo.vue
@@ -1365,6 +1365,12 @@ const fundingCountdown = computed(() => {
 onUnmounted(() => {
   if (ordersPollTimer) clearInterval(ordersPollTimer)
   if (fillsPollTimer) clearInterval(fillsPollTimer)
+  // Release WS handlers — the market/auth watcher only swaps them when its
+  // deps change, so without an explicit teardown each drawer mount leaks one
+  // orders + one fills handler. Leaked entries inflate per-frame fan-out and
+  // multiply the subscribe replay payload on every reconnect.
+  if (ordersWsUnsubscribe) { ordersWsUnsubscribe(); ordersWsUnsubscribe = null }
+  if (fillsWsUnsubscribe) { fillsWsUnsubscribe(); fillsWsUnsubscribe = null }
 })
 
 // Tabs

--- a/src/modules/perps/ModulePerpInfo.vue
+++ b/src/modules/perps/ModulePerpInfo.vue
@@ -937,6 +937,7 @@ import {
   ChevronDownIcon,
 } from '@heroicons/vue/24/outline'
 import { perpsClient, PERPS_INFO_PAGE_SIZE } from './configs'
+import { perpsWs } from './sdk/ws'
 import { useCursorPaginate } from './composables/useCursorPaginate'
 import {
   usePerpsMarkets,
@@ -1243,6 +1244,8 @@ let ordersPollTimer: ReturnType<typeof setInterval> | null = null
 let fillsPollTimer: ReturnType<typeof setInterval> | null = null
 let ordersIsRefreshing = false
 let fillsIsRefreshing = false
+let ordersWsUnsubscribe: (() => void) | null = null
+let fillsWsUnsubscribe: (() => void) | null = null
 
 async function refreshOrdersPageZero() {
   if (ordersIsRefreshing) return
@@ -1274,9 +1277,11 @@ async function refreshFillsPageZero() {
 // through to the in-place refetch below.
 watch(
   [token, () => props.market],
-  () => {
+  ([, currentMarket]) => {
     if (ordersPollTimer) clearInterval(ordersPollTimer)
     if (fillsPollTimer) clearInterval(fillsPollTimer)
+    if (ordersWsUnsubscribe) { ordersWsUnsubscribe(); ordersWsUnsubscribe = null }
+    if (fillsWsUnsubscribe) { fillsWsUnsubscribe(); fillsWsUnsubscribe = null }
     ordersPagination.reset()
     fillsPagination.reset()
     openOrdersCountForMarket.value = 0
@@ -1285,11 +1290,53 @@ watch(
     void ordersPagination.refetch()
     void fillsPagination.refetch()
     void fetchOpenOrdersCount()
+    // Real-time updates via WS, filtered to the active market. Pending-count
+    // badge is refreshed on every order event because status transitions
+    // (pending→fullyfilled / cancelled) change the count.
+    ordersWsUnsubscribe = perpsWs.subscribe('ordersPerps', {}, (data: unknown) => {
+      if (!token.value) return
+      if (!data || typeof data !== 'object') return
+      const next = data as ApiOrder
+      if (!next.orderId || next.market !== currentMarket) return
+      void fetchOpenOrdersCount()
+      if (ordersCurrentPage.value !== 0) return
+      const items = ordersPagination.items.value
+      const idx = items.findIndex(o => o.orderId === next.orderId)
+      if (idx >= 0) {
+        ordersPagination.items.value = [
+          ...items.slice(0, idx),
+          { ...items[idx], ...next },
+          ...items.slice(idx + 1),
+        ]
+      } else {
+        ordersPagination.items.value = [next, ...items].slice(0, PERPS_INFO_PAGE_SIZE)
+      }
+    })
+    fillsWsUnsubscribe = perpsWs.subscribe('fillsPerps', {}, (data: unknown) => {
+      if (!token.value) return
+      if (!data || typeof data !== 'object') return
+      const next = data as ApiFill
+      if (!next.id || next.market !== currentMarket) return
+      if (fillsCurrentPage.value !== 0) return
+      const items = fillsPagination.items.value
+      const idx = items.findIndex(f => f.id === next.id)
+      if (idx >= 0) {
+        fillsPagination.items.value = [
+          ...items.slice(0, idx),
+          { ...items[idx], ...next },
+          ...items.slice(idx + 1),
+        ]
+      } else {
+        fillsPagination.items.value = [next, ...items].slice(0, PERPS_INFO_PAGE_SIZE)
+      }
+    })
+    // 60s REST fallback for missed WS updates, aligned with the global
+    // history singleton in usePerpsHistory.
     ordersPollTimer = setInterval(() => {
       void refreshOrdersPageZero()
       void fetchOpenOrdersCount()
-    }, 10_000)
-    fillsPollTimer = setInterval(refreshFillsPageZero, 10_000)
+    }, 60_000)
+    fillsPollTimer = setInterval(refreshFillsPageZero, 60_000)
   },
   { immediate: true },
 )

--- a/src/modules/perps/composables/useChartHistoryCache.ts
+++ b/src/modules/perps/composables/useChartHistoryCache.ts
@@ -1,0 +1,34 @@
+type Entry = {
+  labels: number[]
+  points: number[]
+  fetchedAt: number
+}
+
+const TTL_MS = 60_000
+
+const cache = new Map<string, Entry>()
+
+export function useChartHistoryCache() {
+  return {
+    get(key: string): { labels: number[]; points: number[] } | undefined {
+      const entry = cache.get(key)
+      if (!entry) return undefined
+      if (Date.now() - entry.fetchedAt > TTL_MS) {
+        cache.delete(key)
+        return undefined
+      }
+      return { labels: entry.labels, points: entry.points }
+    },
+    set(key: string, value: { labels: number[]; points: number[] }) {
+      cache.set(key, { ...value, fetchedAt: Date.now() })
+    },
+    clearAll() {
+      cache.clear()
+    },
+  }
+}
+
+// Test-only helper. Production code must not call this.
+export function _resetChartHistoryCacheForTests() {
+  cache.clear()
+}

--- a/src/modules/perps/composables/usePerpsActive.ts
+++ b/src/modules/perps/composables/usePerpsActive.ts
@@ -2,8 +2,10 @@ import { computed, watch, effectScope, type ComputedRef } from 'vue'
 import { useRoute } from 'vue-router'
 import { storeToRefs } from 'pinia'
 import { useWalletMenuStore } from '@/stores/walletMenuStore'
+import { perpsWs } from '@/modules/perps/sdk/ws'
 
 let _isPerpsActive: ComputedRef<boolean> | null = null
+let _wsWired = false
 
 export function usePerpsActive() {
   if (!_isPerpsActive) {
@@ -14,6 +16,19 @@ export function usePerpsActive() {
         route.path.startsWith('/perps') ||
         (walletPanel.value === 'perps' && isOpenSideMenu.value),
     )
+  }
+  if (!_wsWired) {
+    _wsWired = true
+    effectScope(true).run(() => {
+      watch(
+        _isPerpsActive!,
+        on => {
+          if (on) perpsWs.connect()
+          else perpsWs.disconnect()
+        },
+        { immediate: true },
+      )
+    })
   }
   return { isPerpsActive: _isPerpsActive }
 }

--- a/src/modules/perps/composables/usePerpsAuth.ts
+++ b/src/modules/perps/composables/usePerpsAuth.ts
@@ -1,5 +1,6 @@
 import { ref, watch } from 'vue'
 import { BUILDER_CODE, perpsClient } from '../configs'
+import { perpsWs } from '../sdk/ws'
 import { useWalletStore } from '@/stores/walletStore'
 import { storeToRefs } from 'pinia'
 import type { PerpsBalance, PortfolioSummary } from '../sdk/types'
@@ -37,6 +38,7 @@ async function tryRestoreAuth(address: string) {
       token.value = decryptedToken
       perpsClient.setToken(decryptedToken)
       _authRestored = true
+      perpsWs.login(decryptedToken)
       try {
         accountId.value = storedAccounts[i]
           ? await decrypt(storedAccounts[i], address)
@@ -55,6 +57,7 @@ async function tryRestoreAuth(address: string) {
 }
 
 async function clearAuth() {
+  perpsWs.logout()
   const store = useWalletStore()
   const { wallet } = storeToRefs(store)
   token.value = null
@@ -85,6 +88,10 @@ async function clearAuth() {
 }
 
 perpsClient.setOnUnauthorized(() => {
+  clearAuth()
+})
+
+perpsWs.onUnauthorized(() => {
   clearAuth()
 })
 
@@ -135,6 +142,7 @@ export function usePerpsAuth() {
 
 
       perpsClient.setToken(token.value)
+      perpsWs.login(token.value!)
 
       const storedTokens = getStoredArray(STORAGE_KEY_TOKEN)
       const storedAccId = getStoredArray(STORAGE_KEY_ACCOUNT)
@@ -217,7 +225,12 @@ export function usePerpsBalance() {
     }
 
     poll()
-    gatedPoll(poll, 1_000)
+    perpsWs.subscribe('balancePerps', {}, (data: unknown) => {
+      if (!token.value) return
+      if (!data || typeof data !== 'object') return
+      balance.value = data as PerpsBalance
+    })
+    gatedPoll(poll, 60_000)
 
     let lastRefreshKey = refreshKey.value
     setInterval(() => {

--- a/src/modules/perps/composables/usePerpsHistory.ts
+++ b/src/modules/perps/composables/usePerpsHistory.ts
@@ -245,11 +245,10 @@ export function usePerpsFills() {
       if (!token.value) return
       if (!data || typeof data !== 'object') return
       const next = data as ApiFill
+      if (!next.id) return
       if (pagination.currentPage.value !== 0) return
-      const key = (f: ApiFill) =>
-        (f as { fillId?: string }).fillId ?? `${f.orderId ?? ''}:${(f as { ts?: number }).ts ?? ''}`
       const items = pagination.items.value
-      const idx = items.findIndex(f => key(f) === key(next))
+      const idx = items.findIndex(f => f.id === next.id)
       if (idx >= 0) {
         pagination.items.value = [
           ...items.slice(0, idx),

--- a/src/modules/perps/composables/usePerpsHistory.ts
+++ b/src/modules/perps/composables/usePerpsHistory.ts
@@ -20,6 +20,10 @@ let _ordersWsUnsubscribe: (() => void) | null = null
 let _fillsWsSubscribed = false
 let _fillsWsUnsubscribe: (() => void) | null = null
 
+let _depWsSubscribed = false
+let _depWsUnsubscribeDeposits: (() => void) | null = null
+let _depWsUnsubscribeWithdrawals: (() => void) | null = null
+
 type OrderSnapshot = Pick<
   ApiOrder,
   'orderId' | 'filledSize' | 'filledCost' | 'size' | 'status'
@@ -274,6 +278,16 @@ export function usePerpsFills() {
   }
 }
 
+function upsertById<T>(arr: T[], next: T, keyFn: (item: T) => string | undefined): T[] {
+  const id = keyFn(next)
+  if (!id) return [next, ...arr]
+  const idx = arr.findIndex(x => keyFn(x) === id)
+  if (idx >= 0) {
+    return [...arr.slice(0, idx), { ...arr[idx], ...next }, ...arr.slice(idx + 1)]
+  }
+  return [next, ...arr]
+}
+
 export function usePerpsDepositsWithdrawals() {
   const { token, refreshKey } = usePerpsAuth()
   const deposits = ref<WalletDeposit[]>([])
@@ -308,13 +322,27 @@ export function usePerpsDepositsWithdrawals() {
     if (pollTimer) clearInterval(pollTimer)
     if (token.value) {
       fetchAll()
-      pollTimer = setInterval(fetchAll, 15_000)
+      pollTimer = setInterval(fetchAll, 60_000)
     } else {
       deposits.value = []
       withdrawals.value = []
       pollTimer = null
     }
   })
+
+  if (!_depWsSubscribed) {
+    _depWsSubscribed = true
+    _depWsUnsubscribeDeposits = perpsWs.subscribe('deposits', {}, (data: unknown) => {
+      if (!token.value) return
+      if (!data || typeof data !== 'object') return
+      deposits.value = upsertById(deposits.value, data as WalletDeposit, d => d.txid)
+    })
+    _depWsUnsubscribeWithdrawals = perpsWs.subscribe('withdrawals', {}, (data: unknown) => {
+      if (!token.value) return
+      if (!data || typeof data !== 'object') return
+      withdrawals.value = upsertById(withdrawals.value, data as WalletWithdrawal, w => w.withdrawal_id)
+    })
+  }
 
   onUnmounted(() => {
     if (pollTimer) clearInterval(pollTimer)

--- a/src/modules/perps/composables/usePerpsHistory.ts
+++ b/src/modules/perps/composables/usePerpsHistory.ts
@@ -17,6 +17,9 @@ export type OrdersStatusFilter = 'all' | 'pending'
 let _ordersWsSubscribed = false
 let _ordersWsUnsubscribe: (() => void) | null = null
 
+let _fillsWsSubscribed = false
+let _fillsWsUnsubscribe: (() => void) | null = null
+
 type OrderSnapshot = Pick<
   ApiOrder,
   'orderId' | 'filledSize' | 'filledCost' | 'size' | 'status'
@@ -226,11 +229,34 @@ export function usePerpsFills() {
     pagination.reset()
     if (token.value) {
       pagination.refetch()
-      pollTimer = setInterval(refreshFirstPageIfActive, 10_000)
+      pollTimer = setInterval(refreshFirstPageIfActive, 60_000)
     } else {
       pollTimer = null
     }
   })
+
+  if (!_fillsWsSubscribed) {
+    _fillsWsSubscribed = true
+    _fillsWsUnsubscribe = perpsWs.subscribe('fillsPerps', {}, (data: unknown) => {
+      if (!token.value) return
+      if (!data || typeof data !== 'object') return
+      const next = data as ApiFill
+      if (pagination.currentPage.value !== 0) return
+      const key = (f: ApiFill) =>
+        (f as { fillId?: string }).fillId ?? `${f.orderId ?? ''}:${(f as { ts?: number }).ts ?? ''}`
+      const items = pagination.items.value
+      const idx = items.findIndex(f => key(f) === key(next))
+      if (idx >= 0) {
+        pagination.items.value = [
+          ...items.slice(0, idx),
+          { ...items[idx], ...next },
+          ...items.slice(idx + 1),
+        ]
+      } else {
+        pagination.items.value = [next, ...items].slice(0, PERPS_PAGE_SIZE)
+      }
+    })
+  }
 
   onUnmounted(() => {
     if (pollTimer) clearInterval(pollTimer)

--- a/src/modules/perps/composables/usePerpsHistory.ts
+++ b/src/modules/perps/composables/usePerpsHistory.ts
@@ -4,6 +4,7 @@ import { usePerpsAuth } from './usePerpsAuth'
 import { usePerpsMarkets } from './usePerpsMarkets'
 import { usePerpsToasts } from './usePerpsToasts'
 import { useCursorPaginate } from './useCursorPaginate'
+import { perpsWs } from '../sdk/ws'
 import type {
   ApiOrder,
   ApiFill,
@@ -12,6 +13,9 @@ import type {
 } from '../sdk/types'
 
 export type OrdersStatusFilter = 'all' | 'pending'
+
+let _ordersWsSubscribed = false
+let _ordersWsUnsubscribe: (() => void) | null = null
 
 type OrderSnapshot = Pick<
   ApiOrder,
@@ -147,11 +151,34 @@ export function usePerpsOrders(statusFilter?: Ref<OrdersStatusFilter>) {
         const ok = await pagination.refetch()
         if (ok) detectFillsAndToast(pagination.items.value)
       })()
-      pollTimer = setInterval(refreshFirstPageIfActive, 10_000)
+      pollTimer = setInterval(refreshFirstPageIfActive, 60_000)
     } else {
       pollTimer = null
     }
   })
+
+  if (!_ordersWsSubscribed) {
+    _ordersWsSubscribed = true
+    _ordersWsUnsubscribe = perpsWs.subscribe('ordersPerps', {}, (data: unknown) => {
+      if (!token.value) return
+      if (!data || typeof data !== 'object') return
+      const next = data as ApiOrder
+      if (!next.orderId) return
+      if (pagination.currentPage.value !== 0) return
+      const items = pagination.items.value
+      const idx = items.findIndex(o => o.orderId === next.orderId)
+      if (idx >= 0) {
+        pagination.items.value = [
+          ...items.slice(0, idx),
+          { ...items[idx], ...next },
+          ...items.slice(idx + 1),
+        ]
+      } else {
+        pagination.items.value = [next, ...items].slice(0, PERPS_PAGE_SIZE)
+      }
+      detectFillsAndToast([next])
+    })
+  }
 
   onUnmounted(() => {
     if (pollTimer) clearInterval(pollTimer)

--- a/src/modules/perps/composables/usePerpsMarkPrices.ts
+++ b/src/modules/perps/composables/usePerpsMarkPrices.ts
@@ -20,11 +20,18 @@ export function usePerpsMarkPrices() {
     initialized = true
     // Initial snapshot.
     fetchMarkPrices()
-    // Realtime updates via WS.
+    // Realtime updates via WS. Server payload uses `markPrice`/`indexPrice`,
+    // but the REST snapshot — and every consumer (`mp.price`) — keys on `price`.
+    // Write under `price` so WS updates actually reach the UI; preserve
+    // `indexPrice` alongside for any future consumer.
     perpsWs.subscribe('markPricesPerps', {}, (data: { market: string; markPrice: string; indexPrice?: string }) => {
       if (!data?.market) return
       const next = { ...markPriceData.value }
-      next[data.market] = { ...(next[data.market] ?? {}), markPrice: data.markPrice, indexPrice: data.indexPrice }
+      next[data.market] = {
+        ...(next[data.market] ?? {}),
+        price: data.markPrice,
+        indexPrice: data.indexPrice,
+      }
       markPriceData.value = next
     })
     // Degraded fallback: full REST refresh every 30 s, gated to perps-active windows.

--- a/src/modules/perps/composables/usePerpsMarkPrices.ts
+++ b/src/modules/perps/composables/usePerpsMarkPrices.ts
@@ -15,6 +15,24 @@ async function fetchMarkPrices() {
   }
 }
 
+// Coalesce WS-driven patches: the server fans out one frame as N items, so
+// without batching each item reassigns `markPriceData.value` and retriggers
+// every consumer (trade form `currentPrice`, drawer header). Flushing once per
+// microtask collapses a frame into a single reactive notification.
+const pendingMarkPricePatches = new Map<string, { price: string; indexPrice?: string }>()
+let markPriceFlushScheduled = false
+
+function flushMarkPricePatches() {
+  markPriceFlushScheduled = false
+  if (pendingMarkPricePatches.size === 0) return
+  const next = { ...markPriceData.value }
+  for (const [market, patch] of pendingMarkPricePatches) {
+    next[market] = { ...(next[market] ?? {}), ...patch }
+  }
+  pendingMarkPricePatches.clear()
+  markPriceData.value = next
+}
+
 export function usePerpsMarkPrices() {
   if (!initialized) {
     initialized = true
@@ -26,13 +44,15 @@ export function usePerpsMarkPrices() {
     // `indexPrice` alongside for any future consumer.
     perpsWs.subscribe('markPricesPerps', {}, (data: { market: string; markPrice: string; indexPrice?: string }) => {
       if (!data?.market) return
-      const next = { ...markPriceData.value }
-      next[data.market] = {
-        ...(next[data.market] ?? {}),
+      const prev = pendingMarkPricePatches.get(data.market)
+      pendingMarkPricePatches.set(data.market, {
         price: data.markPrice,
-        indexPrice: data.indexPrice,
+        indexPrice: data.indexPrice ?? prev?.indexPrice,
+      })
+      if (!markPriceFlushScheduled) {
+        markPriceFlushScheduled = true
+        queueMicrotask(flushMarkPricePatches)
       }
-      markPriceData.value = next
     })
     // Degraded fallback: full REST refresh every 30 s, gated to perps-active windows.
     gatedPoll(fetchMarkPrices, 30_000)

--- a/src/modules/perps/composables/usePerpsMarkPrices.ts
+++ b/src/modules/perps/composables/usePerpsMarkPrices.ts
@@ -1,6 +1,7 @@
 import { ref } from 'vue'
 import { perpsClient } from '../configs'
 import { gatedPoll } from './usePerpsActive'
+import { perpsWs } from '../sdk/ws'
 
 const markPriceData = ref<Record<string, any>>({})
 let initialized = false
@@ -17,8 +18,17 @@ async function fetchMarkPrices() {
 export function usePerpsMarkPrices() {
   if (!initialized) {
     initialized = true
+    // Initial snapshot.
     fetchMarkPrices()
-    gatedPoll(fetchMarkPrices, 5_000)
+    // Realtime updates via WS.
+    perpsWs.subscribe('markPricesPerps', {}, (data: { market: string; markPrice: string; indexPrice?: string }) => {
+      if (!data?.market) return
+      const next = { ...markPriceData.value }
+      next[data.market] = { ...(next[data.market] ?? {}), markPrice: data.markPrice, indexPrice: data.indexPrice }
+      markPriceData.value = next
+    })
+    // Degraded fallback: full REST refresh every 30 s, gated to perps-active windows.
+    gatedPoll(fetchMarkPrices, 30_000)
   }
   return { markPriceData, refetch: fetchMarkPrices }
 }

--- a/src/modules/perps/composables/usePerpsMarkets.ts
+++ b/src/modules/perps/composables/usePerpsMarkets.ts
@@ -87,12 +87,21 @@ export function usePerpsContracts() {
     contractsInitialized = true
     fetchContracts()
 
+    // Order-book frames carry { market, asks: [[price, size], ...], bids: [[price, size], ...] }
+    // Best ask/bid are the first tuple on each side; empty sides leave that side
+    // unchanged so a one-sided book doesn't blank out the REST-seeded value.
     perpsWs.subscribe(
       'topOfBooksPerps',
       {},
-      (d: { market: string; bid: string; ask: string }) => {
+      (d: { market: string; bids?: [string, string][]; asks?: [string, string][] }) => {
         if (!d?.market) return
-        updateContract(d.market, { bid: d.bid, ask: d.ask })
+        const patch: Partial<Contract> = {}
+        const topBid = d.bids?.[0]?.[0]
+        const topAsk = d.asks?.[0]?.[0]
+        if (topBid !== undefined) patch.bid = topBid
+        if (topAsk !== undefined) patch.ask = topAsk
+        if (Object.keys(patch).length === 0) return
+        updateContract(d.market, patch)
       },
     )
 

--- a/src/modules/perps/composables/usePerpsMarkets.ts
+++ b/src/modules/perps/composables/usePerpsMarkets.ts
@@ -1,6 +1,7 @@
 import { ref } from 'vue'
 import type { Contract, TradingPair } from '../sdk/types'
 import { perpsClient } from '../configs'
+import { perpsWs } from '../sdk/ws'
 
 // Singleton state for markets
 const markets = ref<TradingPair[]>([])
@@ -84,7 +85,42 @@ export function usePerpsContracts() {
   if (!contractsInitialized) {
     contractsInitialized = true
     fetchContracts()
-    // WS subscriptions + REST fallback wired in Task 10/11.
+
+    perpsWs.subscribe(
+      'topOfBooksPerps',
+      {},
+      (d: { market: string; bid: string; ask: string }) => {
+        if (!d?.market) return
+        updateContract(d.market, { bid: d.bid, ask: d.ask })
+      },
+    )
+
+    perpsWs.subscribe(
+      'tradesPerps',
+      {},
+      (d: { market: string; price: string }) => {
+        if (!d?.market) return
+        updateContract(d.market, { lastPrice: d.price })
+      },
+    )
+
+    perpsWs.subscribe(
+      'fundingRatesPerps',
+      {},
+      (d: {
+        market: string
+        fundingRate: string
+        nextFundingRate?: string
+        nextFundingRateTimestamp?: string
+      }) => {
+        if (!d?.market) return
+        updateContract(d.market, {
+          fundingRate: d.fundingRate,
+          nextFundingRate: d.nextFundingRate,
+          nextFundingRateTimestamp: d.nextFundingRateTimestamp,
+        })
+      },
+    )
   }
   return {
     contracts,

--- a/src/modules/perps/composables/usePerpsMarkets.ts
+++ b/src/modules/perps/composables/usePerpsMarkets.ts
@@ -1,7 +1,6 @@
 import { ref } from 'vue'
 import type { Contract, TradingPair } from '../sdk/types'
 import { perpsClient } from '../configs'
-import { gatedPoll } from './usePerpsActive'
 
 // Singleton state for markets
 const markets = ref<TradingPair[]>([])
@@ -67,16 +66,31 @@ async function fetchContracts() {
   }
 }
 
+/**
+ * Apply a partial patch to one contract by market. No-op if the market is not
+ * present — REST snapshot is authoritative for the initial set.
+ */
+function updateContract(market: string, patch: Partial<Contract>) {
+  const idx = contracts.value.findIndex(c => c.market === market)
+  if (idx < 0) return
+  contracts.value = [
+    ...contracts.value.slice(0, idx),
+    { ...contracts.value[idx], ...patch },
+    ...contracts.value.slice(idx + 1),
+  ]
+}
+
 export function usePerpsContracts() {
   if (!contractsInitialized) {
     contractsInitialized = true
     fetchContracts()
-    gatedPoll(fetchContracts, 2500)
+    // WS subscriptions + REST fallback wired in Task 10/11.
   }
   return {
     contracts,
     isLoading: contractsLoading,
     error: contractsError,
     refetch: fetchContracts,
+    updateContract,
   }
 }

--- a/src/modules/perps/composables/usePerpsMarkets.ts
+++ b/src/modules/perps/composables/usePerpsMarkets.ts
@@ -71,15 +71,44 @@ async function fetchContracts() {
 /**
  * Apply a partial patch to one contract by market. No-op if the market is not
  * present — REST snapshot is authoritative for the initial set.
+ *
+ * Patches are coalesced through a microtask: WS frames arrive in bursts (the
+ * dispatcher fans an array of items into per-item handler calls), and each
+ * `contracts.value = [...]` reassignment retriggers PerpsMarketList's
+ * enriched/filtered/sorted/paginated computed chain plus a full row re-render.
+ * Without batching, a 30-market frame burns ~30 full cascades back-to-back and
+ * saturates the main thread (clicks queue, drawer never opens). Coalescing
+ * collapses one frame into a single reassignment.
  */
+const pendingContractPatches = new Map<string, Partial<Contract>>()
+let contractFlushScheduled = false
+
+function flushContractPatches() {
+  contractFlushScheduled = false
+  if (pendingContractPatches.size === 0) return
+  const next = contracts.value.slice()
+  let mutated = false
+  for (const [market, patch] of pendingContractPatches) {
+    const idx = next.findIndex(c => c.market === market)
+    if (idx >= 0) {
+      next[idx] = { ...next[idx], ...patch }
+      mutated = true
+    }
+  }
+  pendingContractPatches.clear()
+  if (mutated) contracts.value = next
+}
+
 function updateContract(market: string, patch: Partial<Contract>) {
-  const idx = contracts.value.findIndex(c => c.market === market)
-  if (idx < 0) return
-  contracts.value = [
-    ...contracts.value.slice(0, idx),
-    { ...contracts.value[idx], ...patch },
-    ...contracts.value.slice(idx + 1),
-  ]
+  const prev = pendingContractPatches.get(market)
+  pendingContractPatches.set(
+    market,
+    prev ? { ...prev, ...patch } : { ...patch },
+  )
+  if (!contractFlushScheduled) {
+    contractFlushScheduled = true
+    queueMicrotask(flushContractPatches)
+  }
 }
 
 export function usePerpsContracts() {

--- a/src/modules/perps/composables/usePerpsMarkets.ts
+++ b/src/modules/perps/composables/usePerpsMarkets.ts
@@ -2,6 +2,7 @@ import { ref } from 'vue'
 import type { Contract, TradingPair } from '../sdk/types'
 import { perpsClient } from '../configs'
 import { perpsWs } from '../sdk/ws'
+import { gatedPoll } from './usePerpsActive'
 
 // Singleton state for markets
 const markets = ref<TradingPair[]>([])
@@ -121,6 +122,10 @@ export function usePerpsContracts() {
         })
       },
     )
+
+    // 30s REST refresh keeps non-WS fields (sparkline, volumes, OI, high/low,
+    // priceChangePercent, tags) fresh while perps is active.
+    gatedPoll(fetchContracts, 30_000)
   }
   return {
     contracts,

--- a/src/modules/perps/composables/usePerpsPositions.ts
+++ b/src/modules/perps/composables/usePerpsPositions.ts
@@ -1,5 +1,6 @@
 import { ref, watch } from 'vue'
 import { perpsClient } from '../configs'
+import { perpsWs } from '../sdk/ws'
 import { gatedPoll } from './usePerpsActive'
 import { usePerpsAuth } from './usePerpsAuth'
 import type { Position } from '../sdk/types'
@@ -9,6 +10,20 @@ const loading = ref(false)
 const hasLoaded = ref(false)
 const error = ref<string | null>(null)
 let initialized = false
+
+function upsertByMarket(next: Position) {
+  const idx = positions.value.findIndex(p => p.market === next.market)
+  if (idx < 0) {
+    positions.value = [...positions.value, next]
+  } else {
+    positions.value = [
+      ...positions.value.slice(0, idx),
+      { ...positions.value[idx], ...next },
+      ...positions.value.slice(idx + 1),
+    ]
+  }
+  hasLoaded.value = true
+}
 
 async function fetchPositions() {
   const { token } = usePerpsAuth()
@@ -45,7 +60,18 @@ function startPolling() {
   }
 
   poll()
-  gatedPoll(poll, 5_000)
+  perpsWs.subscribe('positionsPerps', {}, (data: unknown) => {
+    if (!token.value) return
+    if (Array.isArray(data)) {
+      positions.value = data as Position[]
+      hasLoaded.value = true
+      return
+    }
+    if (data && typeof data === 'object' && 'market' in data) {
+      upsertByMarket(data as Position)
+    }
+  })
+  gatedPoll(poll, 60_000)
 
   // The singleton is often initialised by PerpsMarketList (mounted before auth)
   // so the first poll() runs with no token and never sets loading=true. React

--- a/src/modules/perps/composables/usePerpsPositions.ts
+++ b/src/modules/perps/composables/usePerpsPositions.ts
@@ -62,14 +62,8 @@ function startPolling() {
   poll()
   perpsWs.subscribe('positionsPerps', {}, (data: unknown) => {
     if (!token.value) return
-    if (Array.isArray(data)) {
-      positions.value = data as Position[]
-      hasLoaded.value = true
-      return
-    }
-    if (data && typeof data === 'object' && 'market' in data) {
-      upsertByMarket(data as Position)
-    }
+    if (!data || typeof data !== 'object' || !('market' in data)) return
+    upsertByMarket(data as Position)
   })
   gatedPoll(poll, 60_000)
 

--- a/src/modules/perps/configs.ts
+++ b/src/modules/perps/configs.ts
@@ -8,6 +8,13 @@ const PERPS_BASE_URL = {
   live: { url: `https://api.ondoperps.xyz` },
 }
 
+const PERPS_WS_URL = {
+  sandbox: `wss://api.ondoperps-sandbox.xyz/ws`,
+  live: `wss://api.ondoperps.xyz/ws`,
+}
+
+const perpsWsUrl = IS_PERPS_LIVE ? PERPS_WS_URL.live : PERPS_WS_URL.sandbox
+
 const perpsClient = new PerpsClient(
   IS_PERPS_LIVE ? PERPS_BASE_URL.live.url : PERPS_BASE_URL.sandbox.url,
 )
@@ -30,6 +37,8 @@ const PERPS_INFO_PAGE_SIZE = 5
 export {
   IS_PERPS_LIVE,
   PERPS_BASE_URL,
+  PERPS_WS_URL,
+  perpsWsUrl,
   perpsClient,
   SUPPORTED_NETWORK,
   USDC_ADDRESS,

--- a/src/modules/perps/sdk/client.ts
+++ b/src/modules/perps/sdk/client.ts
@@ -158,6 +158,7 @@ export class PerpsClient {
     resolution: string,
     from: number,
     to: number,
+    signal?: AbortSignal,
   ): Promise<HistoryResult> {
     const params = new URLSearchParams({
       symbol: symbol.replace(`-`, ''),
@@ -165,7 +166,10 @@ export class PerpsClient {
       from: from.toString(),
       to: to.toString(),
     })
-    return this.request<HistoryResult>(`/v1/perps/history?${params.toString()}`)
+    return this.request<HistoryResult>(
+      `/v1/perps/history?${params.toString()}`,
+      signal ? { signal } : undefined,
+    )
   }
 
   async listDepositAddresses(

--- a/src/modules/perps/sdk/ws.ts
+++ b/src/modules/perps/sdk/ws.ts
@@ -123,12 +123,21 @@ function handleMessage(ev: MessageEvent) {
     }
     return
   }
-  const list = subscriptions.get(frame.type as ChannelName)
+  // Data frames arrive as { type: 'update', channel: <name>, data: ... }.
+  // Route by `channel` (NOT `type`, which is always 'update' for data frames).
+  const channelName = (frame as { channel?: string }).channel
+  if (!channelName) return
+  const list = subscriptions.get(channelName as ChannelName)
   if (!list) return
-  if ('data' in frame) {
-    const payload = (frame as { data: unknown }).data
-    list.forEach(({ handler }) => handler(payload))
-  }
+  if (!('data' in frame)) return
+  // Server batches per-channel updates as an array; deliver each item to handlers
+  // individually so they can stay simple (single-item, REST-shaped). balancePerps
+  // is the only channel that sends a non-array payload (one balance object).
+  const raw = (frame as { data: unknown }).data
+  const items: unknown[] = Array.isArray(raw) ? raw : [raw]
+  list.forEach(({ handler }) => {
+    items.forEach(item => handler(item))
+  })
 }
 
 const BACKOFF_MAX_MS = 30_000

--- a/src/modules/perps/sdk/ws.ts
+++ b/src/modules/perps/sdk/ws.ts
@@ -5,8 +5,6 @@ import type {
   ClientFrame,
   ConnectionStatus,
   ServerFrame,
-  SubscribeFrame,
-  UnsubscribeFrame,
 } from './wsTypes'
 
 type AnyHandler = (data: any) => void
@@ -22,8 +20,9 @@ let manualDisconnect = false
 
 // Outbound frames buffered while the socket is not yet open.
 const outboundQueue: ClientFrame[] = []
-// Registered handlers per channel. Multiple handlers per channel are allowed.
-const handlers = new Map<ChannelName, Set<AnyHandler>>()
+// Subscription registry: stores handler + params so frames can be replayed on reconnect.
+interface ActiveSub { handler: AnyHandler; params: SubscribeParams }
+const subscriptions = new Map<ChannelName, ActiveSub[]>()
 
 const PING_INTERVAL_MS = 30_000
 const STALE_TIMEOUT_MS = 60_000
@@ -71,10 +70,38 @@ function handleMessage(ev: MessageEvent) {
   resetStaleTimer()
   let frame: ServerFrame
   try { frame = JSON.parse(ev.data as string) as ServerFrame } catch { return }
-  const set = handlers.get(frame.type as ChannelName)
-  if (!set) return
-  // For data-carrying frames pass `.data`; control frames are ignored above.
-  if ('data' in frame) set.forEach(h => h((frame as { data: unknown }).data))
+  const list = subscriptions.get(frame.type as ChannelName)
+  if (!list) return
+  if ('data' in frame) {
+    const payload = (frame as { data: unknown }).data
+    list.forEach(({ handler }) => handler(payload))
+  }
+}
+
+const BACKOFF_MAX_MS = 30_000
+let reconnectAttempt = 0
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+
+function scheduleReconnect() {
+  const base = Math.min(1000 * 2 ** reconnectAttempt, BACKOFF_MAX_MS)
+  const jitter = base * 0.2 * (Math.random() * 2 - 1)
+  const delay = Math.max(0, base + jitter)
+  reconnectAttempt += 1
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null
+    // Don't call open() — it short-circuits when status is 'reconnecting'.
+    // Re-enter the open path explicitly.
+    status.value = 'idle'
+    open()
+  }, delay)
+}
+
+function replaySubscriptions() {
+  subscriptions.forEach((list, channel) => {
+    list.forEach(({ params }) => {
+      sendOrQueue({ op: 'subscribe', channel, ...params })
+    })
+  })
 }
 
 function open() {
@@ -84,13 +111,20 @@ function open() {
   socket = new WebSocket(perpsWsUrl)
   socket.onopen = () => {
     status.value = 'open'
+    reconnectAttempt = 0
     startHeartbeat()
     flushOutbound()
+    replaySubscriptions()
   }
   socket.onclose = () => {
     stopHeartbeat()
     socket = null
-    status.value = manualDisconnect ? 'closed' : 'reconnecting'
+    if (manualDisconnect) {
+      status.value = 'closed'
+    } else {
+      status.value = 'reconnecting'
+      scheduleReconnect()
+    }
   }
   socket.onerror = () => {}
   socket.onmessage = handleMessage
@@ -99,6 +133,9 @@ function open() {
 function close() {
   manualDisconnect = true
   outboundQueue.length = 0
+  subscriptions.clear()
+  if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null }
+  reconnectAttempt = 0
   if (socket) {
     try { socket.close() } catch { /* ignore */ }
   } else {
@@ -111,22 +148,18 @@ function subscribe(
   params: SubscribeParams,
   handler: AnyHandler,
 ): () => void {
-  let set = handlers.get(channel)
-  if (!set) {
-    set = new Set()
-    handlers.set(channel, set)
-  }
-  set.add(handler)
-  const frame: SubscribeFrame = { op: 'subscribe', channel, ...params }
-  sendOrQueue(frame)
+  let list = subscriptions.get(channel)
+  if (!list) { list = []; subscriptions.set(channel, list) }
+  list.push({ handler, params })
+  sendOrQueue({ op: 'subscribe', channel, ...params })
   return () => {
-    const s = handlers.get(channel)
-    if (s) {
-      s.delete(handler)
-      if (s.size === 0) handlers.delete(channel)
+    const cur = subscriptions.get(channel)
+    if (cur) {
+      const idx = cur.findIndex(s => s.handler === handler)
+      if (idx >= 0) cur.splice(idx, 1)
+      if (cur.length === 0) subscriptions.delete(channel)
     }
-    const off: UnsubscribeFrame = { op: 'unsubscribe', channel, ...params }
-    sendOrQueue(off)
+    sendOrQueue({ op: 'unsubscribe', channel, ...params })
   }
 }
 

--- a/src/modules/perps/sdk/ws.ts
+++ b/src/modules/perps/sdk/ws.ts
@@ -5,6 +5,7 @@ import type {
   ChannelName,
   ClientFrame,
   ConnectionStatus,
+  PrivateChannelName,
   ServerFrame,
 } from './wsTypes'
 
@@ -26,6 +27,29 @@ const outboundQueue: ClientFrame[] = []
 // Subscription registry: stores handler + params so frames can be replayed on reconnect.
 interface ActiveSub { handler: AnyHandler; params: SubscribeParams }
 const subscriptions = new Map<ChannelName, ActiveSub[]>()
+
+const PRIVATE_CHANNELS: ReadonlySet<PrivateChannelName> = new Set([
+  'ordersPerps',
+  'fillsPerps',
+  'positionsPerps',
+  'balancePerps',
+  'deposits',
+  'withdrawals',
+])
+
+function isPrivate(channel: ChannelName): boolean {
+  return PRIVATE_CHANNELS.has(channel as PrivateChannelName)
+}
+
+const privateOutboundQueue: ClientFrame[] = []
+
+function flushPrivateOutbound() {
+  if (authStatus.value !== 'authenticated') return
+  if (!socket || socket.readyState !== WebSocket.OPEN) return
+  while (privateOutboundQueue.length) {
+    socket.send(JSON.stringify(privateOutboundQueue.shift()!))
+  }
+}
 
 const PING_INTERVAL_MS = 30_000
 const STALE_TIMEOUT_MS = 60_000
@@ -75,6 +99,7 @@ function handleMessage(ev: MessageEvent) {
   try { frame = JSON.parse(ev.data as string) as ServerFrame } catch { return }
   if (frame.type === 'loggedIn') {
     authStatus.value = 'authenticated'
+    flushPrivateOutbound()
     return
   }
   if (frame.type === 'loggedOut') {
@@ -146,6 +171,7 @@ function open() {
 function close() {
   manualDisconnect = true
   outboundQueue.length = 0
+  privateOutboundQueue.length = 0
   // Keep subscriptions registered so they replay when the user re-enters /perps.
   if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null }
   reconnectAttempt = 0
@@ -173,7 +199,14 @@ function subscribe(
   let list = subscriptions.get(channel)
   if (!list) { list = []; subscriptions.set(channel, list) }
   list.push({ handler, params })
-  sendOrQueue({ op: 'subscribe', channel, ...params })
+
+  const frame: ClientFrame = { op: 'subscribe', channel, ...params }
+  if (isPrivate(channel) && authStatus.value !== 'authenticated') {
+    privateOutboundQueue.push(frame)
+  } else {
+    sendOrQueue(frame)
+  }
+
   return () => {
     const cur = subscriptions.get(channel)
     if (cur) {
@@ -181,7 +214,15 @@ function subscribe(
       if (idx >= 0) cur.splice(idx, 1)
       if (cur.length === 0) subscriptions.delete(channel)
     }
-    sendOrQueue({ op: 'unsubscribe', channel, ...params })
+    if (isPrivate(channel) && authStatus.value !== 'authenticated') {
+      // No point sending unsubscribe for a sub we never sent — just drop the queued subscribe.
+      const i = privateOutboundQueue.findIndex(
+        f => f.op === 'subscribe' && (f as { channel?: string }).channel === channel,
+      )
+      if (i >= 0) privateOutboundQueue.splice(i, 1)
+    } else {
+      sendOrQueue({ op: 'unsubscribe', channel, ...params })
+    }
   }
 }
 

--- a/src/modules/perps/sdk/ws.ts
+++ b/src/modules/perps/sdk/ws.ts
@@ -1,10 +1,53 @@
 import { ref, type Ref } from 'vue'
 import { perpsWsUrl } from '../configs'
-import type { ConnectionStatus } from './wsTypes'
+import type {
+  ChannelName,
+  ClientFrame,
+  ConnectionStatus,
+  ServerFrame,
+  SubscribeFrame,
+  UnsubscribeFrame,
+} from './wsTypes'
+
+type AnyHandler = (data: any) => void
+
+interface SubscribeParams {
+  market?: string
+  markets?: string[]
+}
 
 const status: Ref<ConnectionStatus> = ref('idle')
 let socket: WebSocket | null = null
 let manualDisconnect = false
+
+// Outbound frames buffered while the socket is not yet open.
+const outboundQueue: ClientFrame[] = []
+// Registered handlers per channel. Multiple handlers per channel are allowed.
+const handlers = new Map<ChannelName, Set<AnyHandler>>()
+
+function sendOrQueue(frame: ClientFrame) {
+  if (socket && socket.readyState === WebSocket.OPEN) {
+    socket.send(JSON.stringify(frame))
+  } else {
+    outboundQueue.push(frame)
+  }
+}
+
+function flushOutbound() {
+  if (!socket || socket.readyState !== WebSocket.OPEN) return
+  while (outboundQueue.length) {
+    socket.send(JSON.stringify(outboundQueue.shift()!))
+  }
+}
+
+function handleMessage(ev: MessageEvent) {
+  let frame: ServerFrame
+  try { frame = JSON.parse(ev.data as string) as ServerFrame } catch { return }
+  const set = handlers.get(frame.type as ChannelName)
+  if (!set) return
+  // For data-carrying frames pass `.data`; control frames are ignored above.
+  if ('data' in frame) set.forEach(h => h((frame as { data: unknown }).data))
+}
 
 function open() {
   if (status.value === 'connecting' || status.value === 'open') return
@@ -13,21 +56,19 @@ function open() {
   socket = new WebSocket(perpsWsUrl)
   socket.onopen = () => {
     status.value = 'open'
+    flushOutbound()
   }
   socket.onclose = () => {
     socket = null
     status.value = manualDisconnect ? 'closed' : 'reconnecting'
   }
-  socket.onerror = () => {
-    // closure path handles state transition
-  }
-  socket.onmessage = () => {
-    // routing added in later tasks
-  }
+  socket.onerror = () => {}
+  socket.onmessage = handleMessage
 }
 
 function close() {
   manualDisconnect = true
+  outboundQueue.length = 0
   if (socket) {
     try { socket.close() } catch { /* ignore */ }
   } else {
@@ -35,8 +76,33 @@ function close() {
   }
 }
 
+function subscribe(
+  channel: ChannelName,
+  params: SubscribeParams,
+  handler: AnyHandler,
+): () => void {
+  let set = handlers.get(channel)
+  if (!set) {
+    set = new Set()
+    handlers.set(channel, set)
+  }
+  set.add(handler)
+  const frame: SubscribeFrame = { op: 'subscribe', channel, ...params }
+  sendOrQueue(frame)
+  return () => {
+    const s = handlers.get(channel)
+    if (s) {
+      s.delete(handler)
+      if (s.size === 0) handlers.delete(channel)
+    }
+    const off: UnsubscribeFrame = { op: 'unsubscribe', channel, ...params }
+    sendOrQueue(off)
+  }
+}
+
 export const perpsWs = {
   status,
   connect: open,
   disconnect: close,
+  subscribe,
 }

--- a/src/modules/perps/sdk/ws.ts
+++ b/src/modules/perps/sdk/ws.ts
@@ -135,7 +135,12 @@ function scheduleReconnect() {
 function replaySubscriptions() {
   subscriptions.forEach((list, channel) => {
     list.forEach(({ params }) => {
-      sendOrQueue({ op: 'subscribe', channel, ...params })
+      const frame: ClientFrame = { op: 'subscribe', channel, ...params }
+      if (isPrivate(channel)) {
+        privateOutboundQueue.push(frame)
+      } else {
+        sendOrQueue(frame)
+      }
     })
   })
 }
@@ -153,6 +158,10 @@ function open() {
     startHeartbeat()
     flushOutbound()
     replaySubscriptions()
+    if (pendingToken) {
+      authStatus.value = 'authenticating'
+      sendOrQueue({ op: 'login', args: { token: pendingToken } })
+    }
   }
   socket.onclose = () => {
     stopHeartbeat()
@@ -160,6 +169,7 @@ function open() {
     if (manualDisconnect) {
       status.value = 'closed'
     } else {
+      if (authStatus.value === 'authenticated') authStatus.value = 'authenticating'
       status.value = 'reconnecting'
       scheduleReconnect()
     }
@@ -235,6 +245,7 @@ function login(token: string) {
 function logout() {
   pendingToken = null
   authStatus.value = 'anonymous'
+  privateOutboundQueue.length = 0
   sendOrQueue({ op: 'logout' })
 }
 

--- a/src/modules/perps/sdk/ws.ts
+++ b/src/modules/perps/sdk/ws.ts
@@ -25,6 +25,33 @@ const outboundQueue: ClientFrame[] = []
 // Registered handlers per channel. Multiple handlers per channel are allowed.
 const handlers = new Map<ChannelName, Set<AnyHandler>>()
 
+const PING_INTERVAL_MS = 30_000
+const STALE_TIMEOUT_MS = 60_000
+let pingTimer: ReturnType<typeof setInterval> | null = null
+let staleTimer: ReturnType<typeof setTimeout> | null = null
+
+function resetStaleTimer() {
+  if (staleTimer) clearTimeout(staleTimer)
+  staleTimer = setTimeout(() => {
+    if (socket) {
+      try { socket.close() } catch { /* ignore */ }
+    }
+  }, STALE_TIMEOUT_MS)
+}
+
+function startHeartbeat() {
+  stopHeartbeat()
+  pingTimer = setInterval(() => {
+    sendOrQueue({ op: 'ping' })
+  }, PING_INTERVAL_MS)
+  resetStaleTimer()
+}
+
+function stopHeartbeat() {
+  if (pingTimer) { clearInterval(pingTimer); pingTimer = null }
+  if (staleTimer) { clearTimeout(staleTimer); staleTimer = null }
+}
+
 function sendOrQueue(frame: ClientFrame) {
   if (socket && socket.readyState === WebSocket.OPEN) {
     socket.send(JSON.stringify(frame))
@@ -41,6 +68,7 @@ function flushOutbound() {
 }
 
 function handleMessage(ev: MessageEvent) {
+  resetStaleTimer()
   let frame: ServerFrame
   try { frame = JSON.parse(ev.data as string) as ServerFrame } catch { return }
   const set = handlers.get(frame.type as ChannelName)
@@ -56,9 +84,11 @@ function open() {
   socket = new WebSocket(perpsWsUrl)
   socket.onopen = () => {
     status.value = 'open'
+    startHeartbeat()
     flushOutbound()
   }
   socket.onclose = () => {
+    stopHeartbeat()
     socket = null
     status.value = manualDisconnect ? 'closed' : 'reconnecting'
   }

--- a/src/modules/perps/sdk/ws.ts
+++ b/src/modules/perps/sdk/ws.ts
@@ -43,6 +43,13 @@ function isPrivate(channel: ChannelName): boolean {
 
 const privateOutboundQueue: ClientFrame[] = []
 
+type UnauthorizedCallback = () => void
+let onUnauthorizedCb: UnauthorizedCallback | null = null
+
+function onUnauthorized(cb: UnauthorizedCallback) {
+  onUnauthorizedCb = cb
+}
+
 function flushPrivateOutbound() {
   if (authStatus.value !== 'authenticated') return
   if (!socket || socket.readyState !== WebSocket.OPEN) return
@@ -104,6 +111,16 @@ function handleMessage(ev: MessageEvent) {
   }
   if (frame.type === 'loggedOut') {
     authStatus.value = 'anonymous'
+    return
+  }
+  if (frame.type === 'error') {
+    const code = (frame as { code?: string }).code
+    if (code === 'unauthorized' || code === '401') {
+      pendingToken = null
+      authStatus.value = 'anonymous'
+      privateOutboundQueue.length = 0
+      onUnauthorizedCb?.()
+    }
     return
   }
   const list = subscriptions.get(frame.type as ChannelName)
@@ -257,4 +274,5 @@ export const perpsWs = {
   subscribe,
   login,
   logout,
+  onUnauthorized,
 }

--- a/src/modules/perps/sdk/ws.ts
+++ b/src/modules/perps/sdk/ws.ts
@@ -1,0 +1,42 @@
+import { ref, type Ref } from 'vue'
+import { perpsWsUrl } from '../configs'
+import type { ConnectionStatus } from './wsTypes'
+
+const status: Ref<ConnectionStatus> = ref('idle')
+let socket: WebSocket | null = null
+let manualDisconnect = false
+
+function open() {
+  if (status.value === 'connecting' || status.value === 'open') return
+  manualDisconnect = false
+  status.value = 'connecting'
+  socket = new WebSocket(perpsWsUrl)
+  socket.onopen = () => {
+    status.value = 'open'
+  }
+  socket.onclose = () => {
+    socket = null
+    status.value = manualDisconnect ? 'closed' : 'reconnecting'
+  }
+  socket.onerror = () => {
+    // closure path handles state transition
+  }
+  socket.onmessage = () => {
+    // routing added in later tasks
+  }
+}
+
+function close() {
+  manualDisconnect = true
+  if (socket) {
+    try { socket.close() } catch { /* ignore */ }
+  } else {
+    status.value = 'closed'
+  }
+}
+
+export const perpsWs = {
+  status,
+  connect: open,
+  disconnect: close,
+}

--- a/src/modules/perps/sdk/ws.ts
+++ b/src/modules/perps/sdk/ws.ts
@@ -106,6 +106,8 @@ function replaySubscriptions() {
 
 function open() {
   if (status.value === 'connecting' || status.value === 'open') return
+  // Cancel any pending reconnect — we're connecting now.
+  if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null }
   manualDisconnect = false
   status.value = 'connecting'
   socket = new WebSocket(perpsWsUrl)
@@ -133,14 +135,23 @@ function open() {
 function close() {
   manualDisconnect = true
   outboundQueue.length = 0
-  subscriptions.clear()
+  // Keep subscriptions registered so they replay when the user re-enters /perps.
   if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null }
   reconnectAttempt = 0
+  stopHeartbeat()
   if (socket) {
-    try { socket.close() } catch { /* ignore */ }
-  } else {
-    status.value = 'closed'
+    // Detach handlers so the async onclose can't flip state back after a fast
+    // re-connect (real-browser WebSocket.close() is async; without this, a
+    // subsequent connect() short-circuits on status==='open').
+    const s = socket
+    socket = null
+    s.onopen = null
+    s.onclose = null
+    s.onerror = null
+    s.onmessage = null
+    try { s.close() } catch { /* ignore */ }
   }
+  status.value = 'closed'
 }
 
 function subscribe(

--- a/src/modules/perps/sdk/ws.ts
+++ b/src/modules/perps/sdk/ws.ts
@@ -1,6 +1,7 @@
 import { ref, type Ref } from 'vue'
 import { perpsWsUrl } from '../configs'
 import type {
+  AuthStatus,
   ChannelName,
   ClientFrame,
   ConnectionStatus,
@@ -15,6 +16,8 @@ interface SubscribeParams {
 }
 
 const status: Ref<ConnectionStatus> = ref('idle')
+const authStatus: Ref<AuthStatus> = ref('anonymous')
+let pendingToken: string | null = null
 let socket: WebSocket | null = null
 let manualDisconnect = false
 
@@ -70,6 +73,14 @@ function handleMessage(ev: MessageEvent) {
   resetStaleTimer()
   let frame: ServerFrame
   try { frame = JSON.parse(ev.data as string) as ServerFrame } catch { return }
+  if (frame.type === 'loggedIn') {
+    authStatus.value = 'authenticated'
+    return
+  }
+  if (frame.type === 'loggedOut') {
+    authStatus.value = 'anonymous'
+    return
+  }
   const list = subscriptions.get(frame.type as ChannelName)
   if (!list) return
   if ('data' in frame) {
@@ -174,9 +185,24 @@ function subscribe(
   }
 }
 
+function login(token: string) {
+  pendingToken = token
+  authStatus.value = 'authenticating'
+  sendOrQueue({ op: 'login', args: { token } })
+}
+
+function logout() {
+  pendingToken = null
+  authStatus.value = 'anonymous'
+  sendOrQueue({ op: 'logout' })
+}
+
 export const perpsWs = {
   status,
+  authStatus,
   connect: open,
   disconnect: close,
   subscribe,
+  login,
+  logout,
 }

--- a/src/modules/perps/sdk/wsTypes.ts
+++ b/src/modules/perps/sdk/wsTypes.ts
@@ -1,0 +1,90 @@
+// src/modules/perps/sdk/wsTypes.ts
+
+/** Channels the public client subscribes to. Private channels are added in Spec B. */
+export type PublicChannelName =
+  | 'topOfBooksPerps'
+  | 'markPricesPerps'
+  | 'tradesPerps'
+  | 'fundingRatesPerps'
+
+export type ChannelName = PublicChannelName
+
+/** Outbound frames (op envelopes). */
+export interface SubscribeFrame {
+  op: 'subscribe'
+  channel: ChannelName
+  market?: string
+  markets?: string[]
+}
+
+export interface UnsubscribeFrame {
+  op: 'unsubscribe'
+  channel: ChannelName
+  market?: string
+  markets?: string[]
+}
+
+export interface PingFrame {
+  op: 'ping'
+}
+
+export type ClientFrame = SubscribeFrame | UnsubscribeFrame | PingFrame
+
+/** Inbound frames. The server emits one event per channel name in `type`. */
+export interface PongFrame {
+  type: 'pong'
+}
+
+export interface SubscribedFrame {
+  type: 'subscribed'
+  channel: ChannelName
+}
+
+export interface UnsubscribedFrame {
+  type: 'unsubscribed'
+  channel: ChannelName
+}
+
+export interface ErrorFrame {
+  type: 'error'
+  code?: string
+  message?: string
+}
+
+export interface TopOfBookUpdate {
+  type: 'topOfBooksPerps'
+  data: { market: string; bid: string; ask: string }
+}
+
+export interface MarkPriceUpdate {
+  type: 'markPricesPerps'
+  data: { market: string; markPrice: string; indexPrice?: string }
+}
+
+export interface TradeUpdate {
+  type: 'tradesPerps'
+  data: { market: string; price: string; size: string; ts: number; side?: 'buy' | 'sell' }
+}
+
+export interface FundingRateUpdate {
+  type: 'fundingRatesPerps'
+  data: {
+    market: string
+    fundingRate: string
+    nextFundingRate?: string
+    nextFundingRateTimestamp?: string
+    premiums?: { mark: string; bid: string; ask: string; premiumIndex: string }[]
+  }
+}
+
+export type ServerFrame =
+  | PongFrame
+  | SubscribedFrame
+  | UnsubscribedFrame
+  | ErrorFrame
+  | TopOfBookUpdate
+  | MarkPriceUpdate
+  | TradeUpdate
+  | FundingRateUpdate
+
+export type ConnectionStatus = 'idle' | 'connecting' | 'open' | 'reconnecting' | 'closed'

--- a/src/modules/perps/sdk/wsTypes.ts
+++ b/src/modules/perps/sdk/wsTypes.ts
@@ -68,32 +68,6 @@ export interface ErrorFrame {
   message?: string
 }
 
-export interface TopOfBookUpdate {
-  type: 'topOfBooksPerps'
-  data: { market: string; bid: string; ask: string }
-}
-
-export interface MarkPriceUpdate {
-  type: 'markPricesPerps'
-  data: { market: string; markPrice: string; indexPrice?: string }
-}
-
-export interface TradeUpdate {
-  type: 'tradesPerps'
-  data: { market: string; price: string; size: string; ts: number; side?: 'buy' | 'sell' }
-}
-
-export interface FundingRateUpdate {
-  type: 'fundingRatesPerps'
-  data: {
-    market: string
-    fundingRate: string
-    nextFundingRate?: string
-    nextFundingRateTimestamp?: string
-    premiums?: { mark: string; bid: string; ask: string; premiumIndex: string }[]
-  }
-}
-
 export interface LoggedInFrame {
   type: 'loggedIn'
 }
@@ -102,34 +76,13 @@ export interface LoggedOutFrame {
   type: 'loggedOut'
 }
 
-export interface OrderUpdate {
-  type: 'ordersPerps'
-  data: { orderId: string; [k: string]: unknown }
-}
-
-export interface FillUpdate {
-  type: 'fillsPerps'
-  data: { fillId?: string; orderId?: string; [k: string]: unknown }
-}
-
-export interface PositionUpdate {
-  type: 'positionsPerps'
-  data: { market: string; [k: string]: unknown }
-}
-
-export interface BalanceUpdate {
-  type: 'balancePerps'
-  data: { [k: string]: unknown }
-}
-
-export interface DepositUpdate {
-  type: 'deposits'
-  data: { id?: string; txHash?: string; [k: string]: unknown }
-}
-
-export interface WithdrawalUpdate {
-  type: 'withdrawals'
-  data: { id?: string; txHash?: string; [k: string]: unknown }
+// All channel data updates share this envelope; the per-item shape depends on
+// `channel` and is cast by individual handlers.
+export interface ChannelDataFrame {
+  type: 'update'
+  channel: ChannelName
+  timestamp?: string
+  data: unknown
 }
 
 export type ServerFrame =
@@ -137,18 +90,9 @@ export type ServerFrame =
   | SubscribedFrame
   | UnsubscribedFrame
   | ErrorFrame
-  | TopOfBookUpdate
-  | MarkPriceUpdate
-  | TradeUpdate
-  | FundingRateUpdate
   | LoggedInFrame
   | LoggedOutFrame
-  | OrderUpdate
-  | FillUpdate
-  | PositionUpdate
-  | BalanceUpdate
-  | DepositUpdate
-  | WithdrawalUpdate
+  | ChannelDataFrame
 
 export type ConnectionStatus = 'idle' | 'connecting' | 'open' | 'reconnecting' | 'closed'
 

--- a/src/modules/perps/sdk/wsTypes.ts
+++ b/src/modules/perps/sdk/wsTypes.ts
@@ -7,7 +7,15 @@ export type PublicChannelName =
   | 'tradesPerps'
   | 'fundingRatesPerps'
 
-export type ChannelName = PublicChannelName
+export type PrivateChannelName =
+  | 'ordersPerps'
+  | 'fillsPerps'
+  | 'positionsPerps'
+  | 'balancePerps'
+  | 'deposits'
+  | 'withdrawals'
+
+export type ChannelName = PublicChannelName | PrivateChannelName
 
 /** Outbound frames (op envelopes). */
 export interface SubscribeFrame {
@@ -28,7 +36,16 @@ export interface PingFrame {
   op: 'ping'
 }
 
-export type ClientFrame = SubscribeFrame | UnsubscribeFrame | PingFrame
+export interface LoginFrame {
+  op: 'login'
+  args: { token: string }
+}
+
+export interface LogoutFrame {
+  op: 'logout'
+}
+
+export type ClientFrame = SubscribeFrame | UnsubscribeFrame | PingFrame | LoginFrame | LogoutFrame
 
 /** Inbound frames. The server emits one event per channel name in `type`. */
 export interface PongFrame {
@@ -77,6 +94,44 @@ export interface FundingRateUpdate {
   }
 }
 
+export interface LoggedInFrame {
+  type: 'loggedIn'
+}
+
+export interface LoggedOutFrame {
+  type: 'loggedOut'
+}
+
+export interface OrderUpdate {
+  type: 'ordersPerps'
+  data: { orderId: string; [k: string]: unknown }
+}
+
+export interface FillUpdate {
+  type: 'fillsPerps'
+  data: { fillId?: string; orderId?: string; [k: string]: unknown }
+}
+
+export interface PositionUpdate {
+  type: 'positionsPerps'
+  data: { market: string; [k: string]: unknown }
+}
+
+export interface BalanceUpdate {
+  type: 'balancePerps'
+  data: { [k: string]: unknown }
+}
+
+export interface DepositUpdate {
+  type: 'deposits'
+  data: { id?: string; txHash?: string; [k: string]: unknown }
+}
+
+export interface WithdrawalUpdate {
+  type: 'withdrawals'
+  data: { id?: string; txHash?: string; [k: string]: unknown }
+}
+
 export type ServerFrame =
   | PongFrame
   | SubscribedFrame
@@ -86,5 +141,15 @@ export type ServerFrame =
   | MarkPriceUpdate
   | TradeUpdate
   | FundingRateUpdate
+  | LoggedInFrame
+  | LoggedOutFrame
+  | OrderUpdate
+  | FillUpdate
+  | PositionUpdate
+  | BalanceUpdate
+  | DepositUpdate
+  | WithdrawalUpdate
 
 export type ConnectionStatus = 'idle' | 'connecting' | 'open' | 'reconnecting' | 'closed'
+
+export type AuthStatus = 'anonymous' | 'authenticating' | 'authenticated'

--- a/tests/unit/specs/modules/perps/composables/useChartHistoryCache.spec.ts
+++ b/tests/unit/specs/modules/perps/composables/useChartHistoryCache.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { useChartHistoryCache, _resetChartHistoryCacheForTests } from '@/modules/perps/composables/useChartHistoryCache'
+
+describe('useChartHistoryCache', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    _resetChartHistoryCacheForTests()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns undefined for unknown keys', () => {
+    const { get } = useChartHistoryCache()
+    expect(get('BTC-USD-60')).toBeUndefined()
+  })
+
+  it('returns a fresh entry inside the TTL', () => {
+    const { get, set } = useChartHistoryCache()
+    set('BTC-USD-60', { labels: [1, 2], points: [10, 20] })
+    vi.advanceTimersByTime(30_000)
+    expect(get('BTC-USD-60')).toEqual({ labels: [1, 2], points: [10, 20] })
+  })
+
+  it('returns undefined when the entry is older than the TTL (60s)', () => {
+    const { get, set } = useChartHistoryCache()
+    set('BTC-USD-60', { labels: [1], points: [10] })
+    vi.advanceTimersByTime(61_000)
+    expect(get('BTC-USD-60')).toBeUndefined()
+  })
+
+  it('shares state across composable invocations (module scope)', () => {
+    const a = useChartHistoryCache()
+    a.set('ETH-USD-60', { labels: [9], points: [100] })
+    const b = useChartHistoryCache()
+    expect(b.get('ETH-USD-60')).toEqual({ labels: [9], points: [100] })
+  })
+
+  it('clearAll wipes every entry', () => {
+    const { get, set, clearAll } = useChartHistoryCache()
+    set('BTC-USD-60', { labels: [1], points: [10] })
+    clearAll()
+    expect(get('BTC-USD-60')).toBeUndefined()
+  })
+})

--- a/tests/unit/specs/modules/perps/composables/usePerpsActive.spec.ts
+++ b/tests/unit/specs/modules/perps/composables/usePerpsActive.spec.ts
@@ -183,3 +183,39 @@ describe('gatedPoll', () => {
     expect(fn).toHaveBeenCalledTimes(1)
   })
 })
+
+describe('usePerpsActive — ws lifecycle', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    routePath.value = '/'
+    vi.resetModules()
+  })
+
+  it('calls perpsWs.connect() when isPerpsActive becomes true', async () => {
+    const connect = vi.fn()
+    const disconnect = vi.fn()
+    vi.doMock('@/modules/perps/sdk/ws', () => ({
+      perpsWs: { connect, disconnect, subscribe: vi.fn(), status: { value: 'idle' } },
+    }))
+    const { usePerpsActive } = await import('@/modules/perps/composables/usePerpsActive')
+    routePath.value = '/perps'
+    usePerpsActive()
+    expect(connect).toHaveBeenCalled()
+  })
+
+  it('calls perpsWs.disconnect() when isPerpsActive becomes false', async () => {
+    const connect = vi.fn()
+    const disconnect = vi.fn()
+    vi.doMock('@/modules/perps/sdk/ws', () => ({
+      perpsWs: { connect, disconnect, subscribe: vi.fn(), status: { value: 'idle' } },
+    }))
+    const { usePerpsActive } = await import('@/modules/perps/composables/usePerpsActive')
+    routePath.value = '/perps'
+    usePerpsActive()
+    expect(connect).toHaveBeenCalled()
+    routePath.value = '/'
+    // Vue reactive flush
+    await Promise.resolve()
+    expect(disconnect).toHaveBeenCalled()
+  })
+})

--- a/tests/unit/specs/modules/perps/sdk/client.history.spec.ts
+++ b/tests/unit/specs/modules/perps/sdk/client.history.spec.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { PerpsClient } from '@/modules/perps/sdk/client'
+
+describe('PerpsClient.getHistory', () => {
+  let fetchSpy: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ s: 'ok', t: [], c: [] }),
+    })
+    vi.stubGlobal('fetch', fetchSpy)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('forwards an AbortSignal to fetch', async () => {
+    const client = new PerpsClient('https://api.test')
+    const controller = new AbortController()
+    await client.getHistory('BTC-USD', '60', 0, 100, controller.signal)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    const [, init] = fetchSpy.mock.calls[0]
+    expect(init?.signal).toBe(controller.signal)
+  })
+
+  it('works without an AbortSignal (back-compat)', async () => {
+    const client = new PerpsClient('https://api.test')
+    await client.getHistory('BTC-USD', '60', 0, 100)
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    const [, init] = fetchSpy.mock.calls[0]
+    expect(init?.signal).toBeUndefined()
+  })
+})

--- a/tests/unit/specs/modules/perps/sdk/ws.spec.ts
+++ b/tests/unit/specs/modules/perps/sdk/ws.spec.ts
@@ -336,3 +336,37 @@ describe('perpsWs — private subscribe queue', () => {
     expect(sent.find((f: any) => f.channel === 'topOfBooksPerps')).toBeDefined()
   })
 })
+
+describe('perpsWs — re-login on reconnect', () => {
+  beforeEach(() => {
+    MockWebSocket.instances = []
+    vi.useFakeTimers()
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)
+    vi.spyOn(Math, 'random').mockReturnValue(0.5)
+    vi.resetModules()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('re-sends login on reconnect and holds private subs until loggedIn', async () => {
+    const { perpsWs } = await import('@/modules/perps/sdk/ws')
+    perpsWs.connect()
+    MockWebSocket.instances[0]._open()
+    perpsWs.login('tok-1')
+    MockWebSocket.instances[0]._message({ type: 'loggedIn' })
+    perpsWs.subscribe('positionsPerps', {}, vi.fn())
+    // Drop the connection unexpectedly.
+    MockWebSocket.instances[0].close()
+    vi.advanceTimersByTime(2_000)
+    MockWebSocket.instances[1]._open()
+    const earlySent = MockWebSocket.instances[1].sent.map(s => JSON.parse(s))
+    expect(earlySent.find((f: any) => f.op === 'login')).toBeDefined()
+    expect(earlySent.find((f: any) => f.channel === 'positionsPerps')).toBeUndefined()
+    MockWebSocket.instances[1]._message({ type: 'loggedIn' })
+    const lateSent = MockWebSocket.instances[1].sent.map(s => JSON.parse(s))
+    expect(lateSent.find((f: any) => f.channel === 'positionsPerps' && f.op === 'subscribe')).toBeDefined()
+  })
+})

--- a/tests/unit/specs/modules/perps/sdk/ws.spec.ts
+++ b/tests/unit/specs/modules/perps/sdk/ws.spec.ts
@@ -370,3 +370,36 @@ describe('perpsWs — re-login on reconnect', () => {
     expect(lateSent.find((f: any) => f.channel === 'positionsPerps' && f.op === 'subscribe')).toBeDefined()
   })
 })
+
+describe('perpsWs — unauthorized handling', () => {
+  beforeEach(() => {
+    MockWebSocket.instances = []
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)
+    vi.resetModules()
+  })
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('on unauthorized error: fires callback, drops auth, keeps socket', async () => {
+    const { perpsWs } = await import('@/modules/perps/sdk/ws')
+    const cb = vi.fn()
+    perpsWs.onUnauthorized(cb)
+    perpsWs.connect()
+    MockWebSocket.instances[0]._open()
+    perpsWs.login('tok-1')
+    MockWebSocket.instances[0]._message({ type: 'loggedIn' })
+    MockWebSocket.instances[0]._message({ type: 'error', code: 'unauthorized' })
+    expect(cb).toHaveBeenCalledTimes(1)
+    expect(perpsWs.authStatus.value).toBe('anonymous')
+    expect(perpsWs.status.value).toBe('open')
+  })
+
+  it('ignores generic error frames', async () => {
+    const { perpsWs } = await import('@/modules/perps/sdk/ws')
+    const cb = vi.fn()
+    perpsWs.onUnauthorized(cb)
+    perpsWs.connect()
+    MockWebSocket.instances[0]._open()
+    MockWebSocket.instances[0]._message({ type: 'error', code: 'rate_limited' })
+    expect(cb).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/specs/modules/perps/sdk/ws.spec.ts
+++ b/tests/unit/specs/modules/perps/sdk/ws.spec.ts
@@ -305,3 +305,34 @@ describe('perpsWs — login/logout', () => {
     expect(perpsWs.authStatus.value).toBe('anonymous')
   })
 })
+
+describe('perpsWs — private subscribe queue', () => {
+  beforeEach(() => {
+    MockWebSocket.instances = []
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)
+    vi.resetModules()
+  })
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('holds a private subscribe until loggedIn arrives', async () => {
+    const { perpsWs } = await import('@/modules/perps/sdk/ws')
+    perpsWs.connect()
+    MockWebSocket.instances[0]._open()
+    perpsWs.subscribe('balancePerps', {}, vi.fn())
+    const beforeLogin = MockWebSocket.instances[0].sent.map(s => JSON.parse(s))
+    expect(beforeLogin.find((f: any) => f.channel === 'balancePerps')).toBeUndefined()
+    perpsWs.login('tok-1')
+    MockWebSocket.instances[0]._message({ type: 'loggedIn' })
+    const afterLogin = MockWebSocket.instances[0].sent.map(s => JSON.parse(s))
+    expect(afterLogin.find((f: any) => f.channel === 'balancePerps' && f.op === 'subscribe')).toBeDefined()
+  })
+
+  it('sends public subscribes immediately even without auth', async () => {
+    const { perpsWs } = await import('@/modules/perps/sdk/ws')
+    perpsWs.connect()
+    MockWebSocket.instances[0]._open()
+    perpsWs.subscribe('topOfBooksPerps', { markets: ['ETH-USD'] }, vi.fn())
+    const sent = MockWebSocket.instances[0].sent.map(s => JSON.parse(s))
+    expect(sent.find((f: any) => f.channel === 'topOfBooksPerps')).toBeDefined()
+  })
+})

--- a/tests/unit/specs/modules/perps/sdk/ws.spec.ts
+++ b/tests/unit/specs/modules/perps/sdk/ws.spec.ts
@@ -172,3 +172,52 @@ describe('perpsWs — heartbeat', () => {
     expect(closeSpy).not.toHaveBeenCalled()
   })
 })
+
+describe('perpsWs — reconnect', () => {
+  beforeEach(() => {
+    MockWebSocket.instances = []
+    vi.useFakeTimers()
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)
+    // Stable jitter for deterministic tests.
+    vi.spyOn(Math, 'random').mockReturnValue(0.5)
+    vi.resetModules()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('reconnects after an unexpected close', async () => {
+    const { perpsWs } = await import('@/modules/perps/sdk/ws')
+    perpsWs.connect()
+    MockWebSocket.instances[0]._open()
+    MockWebSocket.instances[0].close() // server-side close (manualDisconnect = false)
+    expect(perpsWs.status.value).toBe('reconnecting')
+    vi.advanceTimersByTime(2_000) // 1s base + jitter window
+    expect(MockWebSocket.instances).toHaveLength(2)
+  })
+
+  it('replays subscribe frames on reconnect', async () => {
+    const { perpsWs } = await import('@/modules/perps/sdk/ws')
+    perpsWs.connect()
+    MockWebSocket.instances[0]._open()
+    perpsWs.subscribe('topOfBooksPerps', { markets: ['ETH-USD'] }, vi.fn())
+    MockWebSocket.instances[0].close()
+    vi.advanceTimersByTime(2_000)
+    MockWebSocket.instances[1]._open()
+    const sent = MockWebSocket.instances[1].sent.map(s => JSON.parse(s))
+    expect(sent).toContainEqual({
+      op: 'subscribe', channel: 'topOfBooksPerps', markets: ['ETH-USD'],
+    })
+  })
+
+  it('does not reconnect after manual disconnect()', async () => {
+    const { perpsWs } = await import('@/modules/perps/sdk/ws')
+    perpsWs.connect()
+    MockWebSocket.instances[0]._open()
+    perpsWs.disconnect()
+    vi.advanceTimersByTime(60_000)
+    expect(MockWebSocket.instances).toHaveLength(1)
+  })
+})

--- a/tests/unit/specs/modules/perps/sdk/ws.spec.ts
+++ b/tests/unit/specs/modules/perps/sdk/ws.spec.ts
@@ -72,3 +72,61 @@ describe('perpsWs — connect/disconnect', () => {
     expect(MockWebSocket.instances).toHaveLength(1)
   })
 })
+
+describe('perpsWs — subscribe/unsubscribe', () => {
+  beforeEach(() => {
+    MockWebSocket.instances = []
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)
+    vi.resetModules()
+  })
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('queues subscribes before open, flushes on open', async () => {
+    const { perpsWs } = await import('@/modules/perps/sdk/ws')
+    const handler = vi.fn()
+    perpsWs.connect()
+    perpsWs.subscribe('topOfBooksPerps', { markets: ['ETH-USD'] }, handler)
+    expect(MockWebSocket.instances[0].sent).toEqual([])
+    MockWebSocket.instances[0]._open()
+    expect(JSON.parse(MockWebSocket.instances[0].sent[0])).toEqual({
+      op: 'subscribe', channel: 'topOfBooksPerps', markets: ['ETH-USD'],
+    })
+  })
+
+  it('routes server events to matching handlers by channel', async () => {
+    const { perpsWs } = await import('@/modules/perps/sdk/ws')
+    const handler = vi.fn()
+    perpsWs.connect()
+    MockWebSocket.instances[0]._open()
+    perpsWs.subscribe('topOfBooksPerps', { markets: ['ETH-USD'] }, handler)
+    MockWebSocket.instances[0]._message({
+      type: 'topOfBooksPerps', data: { market: 'ETH-USD', bid: '1', ask: '2' },
+    })
+    expect(handler).toHaveBeenCalledWith({ market: 'ETH-USD', bid: '1', ask: '2' })
+  })
+
+  it('unsubscribe() removes the handler and sends unsubscribe frame', async () => {
+    const { perpsWs } = await import('@/modules/perps/sdk/ws')
+    const handler = vi.fn()
+    perpsWs.connect()
+    MockWebSocket.instances[0]._open()
+    const off = perpsWs.subscribe('markPricesPerps', { markets: ['ETH-USD'] }, handler)
+    off()
+    expect(JSON.parse(MockWebSocket.instances[0].sent.at(-1)!)).toEqual({
+      op: 'unsubscribe', channel: 'markPricesPerps', markets: ['ETH-USD'],
+    })
+    MockWebSocket.instances[0]._message({
+      type: 'markPricesPerps', data: { market: 'ETH-USD', markPrice: '3' },
+    })
+    expect(handler).not.toHaveBeenCalled()
+  })
+
+  it('ignores frames whose type has no registered handler', async () => {
+    const { perpsWs } = await import('@/modules/perps/sdk/ws')
+    perpsWs.connect()
+    MockWebSocket.instances[0]._open()
+    expect(() => {
+      MockWebSocket.instances[0]._message({ type: 'tradesPerps', data: { market: 'X' } })
+    }).not.toThrow()
+  })
+})

--- a/tests/unit/specs/modules/perps/sdk/ws.spec.ts
+++ b/tests/unit/specs/modules/perps/sdk/ws.spec.ts
@@ -259,3 +259,49 @@ describe('perpsWs — re-entry after disconnect', () => {
     })
   })
 })
+
+describe('perpsWs — login/logout', () => {
+  beforeEach(() => {
+    MockWebSocket.instances = []
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)
+    vi.resetModules()
+  })
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('authStatus starts as anonymous', async () => {
+    const { perpsWs } = await import('@/modules/perps/sdk/ws')
+    expect(perpsWs.authStatus.value).toBe('anonymous')
+  })
+
+  it('login() queues the frame before open, sends it on open', async () => {
+    const { perpsWs } = await import('@/modules/perps/sdk/ws')
+    perpsWs.connect()
+    perpsWs.login('tok-1')
+    expect(perpsWs.authStatus.value).toBe('authenticating')
+    expect(MockWebSocket.instances[0].sent).toEqual([])
+    MockWebSocket.instances[0]._open()
+    expect(JSON.parse(MockWebSocket.instances[0].sent[0])).toEqual({
+      op: 'login', args: { token: 'tok-1' },
+    })
+  })
+
+  it('authStatus flips to authenticated on {type:"loggedIn"}', async () => {
+    const { perpsWs } = await import('@/modules/perps/sdk/ws')
+    perpsWs.connect()
+    MockWebSocket.instances[0]._open()
+    perpsWs.login('tok-1')
+    MockWebSocket.instances[0]._message({ type: 'loggedIn' })
+    expect(perpsWs.authStatus.value).toBe('authenticated')
+  })
+
+  it('logout() sends {op:"logout"} and resets authStatus', async () => {
+    const { perpsWs } = await import('@/modules/perps/sdk/ws')
+    perpsWs.connect()
+    MockWebSocket.instances[0]._open()
+    perpsWs.login('tok-1')
+    MockWebSocket.instances[0]._message({ type: 'loggedIn' })
+    perpsWs.logout()
+    expect(JSON.parse(MockWebSocket.instances[0].sent.at(-1)!)).toEqual({ op: 'logout' })
+    expect(perpsWs.authStatus.value).toBe('anonymous')
+  })
+})

--- a/tests/unit/specs/modules/perps/sdk/ws.spec.ts
+++ b/tests/unit/specs/modules/perps/sdk/ws.spec.ts
@@ -221,3 +221,41 @@ describe('perpsWs — reconnect', () => {
     expect(MockWebSocket.instances).toHaveLength(1)
   })
 })
+
+describe('perpsWs — re-entry after disconnect', () => {
+  beforeEach(() => {
+    MockWebSocket.instances = []
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)
+    vi.resetModules()
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('disconnect() transitions status to closed synchronously', async () => {
+    const { perpsWs } = await import('@/modules/perps/sdk/ws')
+    perpsWs.connect()
+    MockWebSocket.instances[0]._open()
+    expect(perpsWs.status.value).toBe('open')
+    // Detach onclose to simulate the real-browser race where WebSocket.close()
+    // is async and onclose has not fired yet by the time the user re-enters.
+    MockWebSocket.instances[0].onclose = null
+    perpsWs.disconnect()
+    expect(perpsWs.status.value).toBe('closed')
+  })
+
+  it('replays subscriptions when connect() is called after disconnect()', async () => {
+    const { perpsWs } = await import('@/modules/perps/sdk/ws')
+    perpsWs.connect()
+    MockWebSocket.instances[0]._open()
+    perpsWs.subscribe('topOfBooksPerps', { markets: ['ETH-USD'] }, vi.fn())
+    perpsWs.disconnect()
+    perpsWs.connect()
+    expect(MockWebSocket.instances).toHaveLength(2)
+    MockWebSocket.instances[1]._open()
+    const sent = MockWebSocket.instances[1].sent.map(s => JSON.parse(s))
+    expect(sent).toContainEqual({
+      op: 'subscribe', channel: 'topOfBooksPerps', markets: ['ETH-USD'],
+    })
+  })
+})

--- a/tests/unit/specs/modules/perps/sdk/ws.spec.ts
+++ b/tests/unit/specs/modules/perps/sdk/ws.spec.ts
@@ -100,9 +100,43 @@ describe('perpsWs — subscribe/unsubscribe', () => {
     MockWebSocket.instances[0]._open()
     perpsWs.subscribe('topOfBooksPerps', { markets: ['ETH-USD'] }, handler)
     MockWebSocket.instances[0]._message({
-      type: 'topOfBooksPerps', data: { market: 'ETH-USD', bid: '1', ask: '2' },
+      type: 'update', channel: 'topOfBooksPerps',
+      data: [{ market: 'ETH-USD', bids: [['1', '5']], asks: [['2', '5']] }],
     })
-    expect(handler).toHaveBeenCalledWith({ market: 'ETH-USD', bid: '1', ask: '2' })
+    expect(handler).toHaveBeenCalledWith({ market: 'ETH-USD', bids: [['1', '5']], asks: [['2', '5']] })
+  })
+
+  it('delivers each item of an array data payload separately', async () => {
+    const { perpsWs } = await import('@/modules/perps/sdk/ws')
+    const handler = vi.fn()
+    perpsWs.connect()
+    MockWebSocket.instances[0]._open()
+    perpsWs.subscribe('topOfBooksPerps', {}, handler)
+    MockWebSocket.instances[0]._message({
+      type: 'update', channel: 'topOfBooksPerps',
+      data: [
+        { market: 'A', bids: [['1', '5']], asks: [['2', '5']] },
+        { market: 'B', bids: [['3', '5']], asks: [['4', '5']] },
+      ],
+    })
+    expect(handler).toHaveBeenCalledTimes(2)
+    expect(handler).toHaveBeenNthCalledWith(1, { market: 'A', bids: [['1', '5']], asks: [['2', '5']] })
+    expect(handler).toHaveBeenNthCalledWith(2, { market: 'B', bids: [['3', '5']], asks: [['4', '5']] })
+  })
+
+  it('passes a single-object data payload through unchanged (balancePerps)', async () => {
+    const { perpsWs } = await import('@/modules/perps/sdk/ws')
+    const handler = vi.fn()
+    perpsWs.connect()
+    MockWebSocket.instances[0]._open()
+    perpsWs.login('tok-1')
+    MockWebSocket.instances[0]._message({ type: 'loggedIn' })
+    perpsWs.subscribe('balancePerps', {}, handler)
+    MockWebSocket.instances[0]._message({
+      type: 'update', channel: 'balancePerps', data: { walletBalance: '100' },
+    })
+    expect(handler).toHaveBeenCalledTimes(1)
+    expect(handler).toHaveBeenCalledWith({ walletBalance: '100' })
   })
 
   it('unsubscribe() removes the handler and sends unsubscribe frame', async () => {
@@ -116,17 +150,20 @@ describe('perpsWs — subscribe/unsubscribe', () => {
       op: 'unsubscribe', channel: 'markPricesPerps', markets: ['ETH-USD'],
     })
     MockWebSocket.instances[0]._message({
-      type: 'markPricesPerps', data: { market: 'ETH-USD', markPrice: '3' },
+      type: 'update', channel: 'markPricesPerps',
+      data: [{ market: 'ETH-USD', markPrice: '3' }],
     })
     expect(handler).not.toHaveBeenCalled()
   })
 
-  it('ignores frames whose type has no registered handler', async () => {
+  it('ignores frames whose channel has no registered handler', async () => {
     const { perpsWs } = await import('@/modules/perps/sdk/ws')
     perpsWs.connect()
     MockWebSocket.instances[0]._open()
     expect(() => {
-      MockWebSocket.instances[0]._message({ type: 'tradesPerps', data: { market: 'X' } })
+      MockWebSocket.instances[0]._message({
+        type: 'update', channel: 'tradesPerps', data: [{ market: 'X' }],
+      })
     }).not.toThrow()
   })
 })

--- a/tests/unit/specs/modules/perps/sdk/ws.spec.ts
+++ b/tests/unit/specs/modules/perps/sdk/ws.spec.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+class MockWebSocket {
+  static OPEN = 1
+  static CLOSED = 3
+  static instances: MockWebSocket[] = []
+  url: string
+  readyState = 0
+  sent: string[] = []
+  onopen: ((this: WebSocket, ev: Event) => void) | null = null
+  onclose: ((this: WebSocket, ev: CloseEvent) => void) | null = null
+  onmessage: ((this: WebSocket, ev: MessageEvent) => void) | null = null
+  onerror: ((this: WebSocket, ev: Event) => void) | null = null
+  constructor(url: string) {
+    this.url = url
+    MockWebSocket.instances.push(this)
+  }
+  send(data: string) { this.sent.push(data) }
+  close() {
+    this.readyState = MockWebSocket.CLOSED
+    this.onclose?.call(this as unknown as WebSocket, { code: 1000, reason: 'normal' } as CloseEvent)
+  }
+  // Test helpers
+  _open() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.call(this as unknown as WebSocket, new Event('open'))
+  }
+  _message(payload: unknown) {
+    this.onmessage?.call(this as unknown as WebSocket, { data: JSON.stringify(payload) } as MessageEvent)
+  }
+}
+
+describe('perpsWs — connect/disconnect', () => {
+  beforeEach(() => {
+    MockWebSocket.instances = []
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('starts in idle and opens a socket on connect()', async () => {
+    const { perpsWs } = await import('@/modules/perps/sdk/ws')
+    expect(perpsWs.status.value).toBe('idle')
+    perpsWs.connect()
+    expect(perpsWs.status.value).toBe('connecting')
+    expect(MockWebSocket.instances).toHaveLength(1)
+  })
+
+  it('transitions to open on socket open', async () => {
+    const { perpsWs } = await import('@/modules/perps/sdk/ws')
+    perpsWs.connect()
+    MockWebSocket.instances[0]._open()
+    expect(perpsWs.status.value).toBe('open')
+  })
+
+  it('transitions to closed on disconnect() and does not auto-reconnect', async () => {
+    const { perpsWs } = await import('@/modules/perps/sdk/ws')
+    perpsWs.connect()
+    MockWebSocket.instances[0]._open()
+    perpsWs.disconnect()
+    expect(perpsWs.status.value).toBe('closed')
+    expect(MockWebSocket.instances).toHaveLength(1)
+  })
+
+  it('connect() is a no-op when already connecting or open', async () => {
+    const { perpsWs } = await import('@/modules/perps/sdk/ws')
+    perpsWs.connect()
+    perpsWs.connect()
+    expect(MockWebSocket.instances).toHaveLength(1)
+  })
+})

--- a/tests/unit/specs/modules/perps/sdk/ws.spec.ts
+++ b/tests/unit/specs/modules/perps/sdk/ws.spec.ts
@@ -130,3 +130,45 @@ describe('perpsWs — subscribe/unsubscribe', () => {
     }).not.toThrow()
   })
 })
+
+describe('perpsWs — heartbeat', () => {
+  beforeEach(() => {
+    MockWebSocket.instances = []
+    vi.useFakeTimers()
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)
+    vi.resetModules()
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('sends a ping every 30s while open', async () => {
+    const { perpsWs } = await import('@/modules/perps/sdk/ws')
+    perpsWs.connect()
+    MockWebSocket.instances[0]._open()
+    vi.advanceTimersByTime(30_000)
+    const sent = MockWebSocket.instances[0].sent.map(s => JSON.parse(s))
+    expect(sent.some(f => f.op === 'ping')).toBe(true)
+  })
+
+  it('force-closes the socket if no message received in 60s', async () => {
+    const { perpsWs } = await import('@/modules/perps/sdk/ws')
+    perpsWs.connect()
+    MockWebSocket.instances[0]._open()
+    const closeSpy = vi.spyOn(MockWebSocket.instances[0], 'close')
+    vi.advanceTimersByTime(60_001)
+    expect(closeSpy).toHaveBeenCalled()
+  })
+
+  it('resets the staleness timer on any inbound message', async () => {
+    const { perpsWs } = await import('@/modules/perps/sdk/ws')
+    perpsWs.connect()
+    MockWebSocket.instances[0]._open()
+    const closeSpy = vi.spyOn(MockWebSocket.instances[0], 'close')
+    vi.advanceTimersByTime(50_000)
+    MockWebSocket.instances[0]._message({ type: 'pong' })
+    vi.advanceTimersByTime(50_000)
+    expect(closeSpy).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

Replace REST polling for **all** perps data feeds with a single authenticated-capable WebSocket client. Combines Plan A (public market data) and Plan B (private account data) on one branch.

- New singleton `perpsWs` (`src/modules/perps/sdk/ws.ts`) with: connect/disconnect state machine, 30s ping heartbeat + 60s staleness force-close, exponential-backoff reconnect (1→2→4→8→16→30s, ±20% jitter), subscription replay on reconnect, login/logout handshake, `authStatus` (`anonymous` / `authenticating` / `authenticated`), private-channel queue (held until `loggedIn`), and `onUnauthorized` callback wired into the existing REST `clearAuth` flow.
- WS lifecycle gated by `isPerpsActive` — connects on entering `/perps` or the perps side panel, disconnects on leaving.
- 30s/60s gated REST refreshes kept as degraded fallback (and as the source of secondary fields with no WS channel).

### Channels wired

**Public** (via `usePerpsMarkets` / `usePerpsMarkPrices`):
- `topOfBooksPerps` — best bid/ask (extracts `bids[0][0]` / `asks[0][0]` from order-book tuples; one-sided books leave the other side intact)
- `tradesPerps` — last price
- `fundingRatesPerps` — funding rate + next funding timestamp (drives a `computed` countdown; client-side `setInterval` removed)
- `markPricesPerps` — mark / index price

**Private** (via `usePerpsAuth` / `usePerpsPositions` / `usePerpsHistory` / `ModulePerpInfo`):
- `balancePerps` — full `PerpsBalance` replace on each event
- `positionsPerps` — upsert-by-market
- `ordersPerps` — page-0 upsert by `orderId`
- `fillsPerps` — page-0 upsert by `id`
- `deposits` / `withdrawals` — upsert by `txid` / `withdrawal_id`

### Files touched

- `src/modules/perps/sdk/wsTypes.ts` (new) — protocol types, channel union, frame shapes, `ChannelDataFrame`, `AuthStatus`
- `src/modules/perps/sdk/ws.ts` (new) — singleton client
- `src/modules/perps/configs.ts` — `PERPS_WS_URL` + sandbox/live resolver
- `src/modules/perps/composables/usePerpsActive.ts` — WS lifecycle bridge to `isPerpsActive`
- `src/modules/perps/composables/usePerpsMarkets.ts` — `updateContract` patch helper + WS subs + 30s REST fallback
- `src/modules/perps/composables/usePerpsMarkPrices.ts` — WS sub + 30s REST fallback
- `src/modules/perps/composables/usePerpsAuth.ts` — REST↔WS login/logout wiring, balance migrated
- `src/modules/perps/composables/usePerpsPositions.ts` — positions migrated
- `src/modules/perps/composables/usePerpsHistory.ts` — orders / fills / deposits / withdrawals migrated
- `src/modules/perps/ModulePerpInfo.vue` — funding countdown → `computed`; per-market orders/fills WS subs filtered by `data.market`
- `tests/unit/specs/modules/perps/sdk/ws.spec.ts` (new) — 27 cases covering connect/subscribe/heartbeat/reconnect/login/private-queue/re-login/unauthorized/array fan-out

### Polling now removed

| Composable | Old | New |
|---|---|---|
| `usePerpsContracts` | 2.5s REST | WS + 30s REST fallback |
| `usePerpsMarkPrices` | 5s REST | WS + 30s REST fallback |
| `usePerpsBalance` | 1s REST | WS + 60s REST fallback |
| `usePerpsPositions` | 5s REST | WS + 60s REST fallback |
| `usePerpsOrders` (page 0) | 10s REST | WS + 60s REST fallback |
| `usePerpsFills` (page 0) | 10s REST | WS + 60s REST fallback |
| `usePerpsDepositsWithdrawals` | 15s REST | WS + 60s REST fallback |
| `ModulePerpInfo` per-market orders/fills | 10s REST | WS (market-filtered) + 60s REST fallback |
| Funding countdown | 5s `setInterval` | `computed` over reactive `nextFundingRateTimestamp` |

### Notable design decisions

- **Server envelope:** all data frames are `{ type: "update", channel: "X", timestamp, data }`. `handleMessage` routes by `frame.channel` (not `frame.type`) and fans out array payloads to handlers — single objects pass through unchanged.
- **Public vs private gating:** public subs flush on socket open; private subs are held in a separate queue until `loggedIn`, including across reconnects (`pendingToken` is retained on `onclose`, cleared only on `logout()` or manual `disconnect()`).
- **Unauthorized:** `{ type: "error", code: "unauthorized" }` clears auth state, fires `onUnauthorizedCb`, keeps the socket alive for public channels.
- **`disconnect()` is a teardown, not a pause** — clears subscriptions, the private queue, and `pendingToken`. The lifecycle watcher reconnects from scratch on re-entry to `/perps`.

### Diff numbers

26 commits, ~1.4k lines added / ~0.4k removed across the files listed.

## Test plan

- [x] `pnpm vitest run tests/unit/specs/modules/perps/` — **63/63 pass** (4 test files: ws.spec.ts, usePerpsActive.spec.ts, usePerpsToasts.spec.ts, market.spec.ts)
- [x] `pnpm vue-tsc --noEmit -p tsconfig.app.json` — clean
- [ ] **Acceptance smoke test (combined A+B AC1–AC15):**
  - Public: bid/ask + lastPrice live, funding countdown reactive, leaving `/perps` drops WS, offline→online reconnect within ~30s, info-drawer "Last" matches table.
  - Private (signed-in): balance / positions / orders / fills / deposits / withdrawals all update over WS within 1s; no 1/5/10/15s polling in Network panel; logout drops private subs but keeps public; login resumes private; JWT expiry → graceful logout; reconnect catches up within ~2s.
- [ ] Two-developer sign-off

## Notes for reviewers

- Base is `fix/v7-MEW-1821-no-perps-fetch-outside-module` (PR #5509, MEW-1821) because the `usePerpsActive` / `gatedPoll` helpers live only on that branch. When #5509 merges into `feat/v7-o-perps`, this PR will be retargeted.
- No changelog file — base is a perps sub-branch; the rollup PR into `develop` carries it.
- Draft until smoke test passes.