### PR TITLE
fix: MEW-1856 restrict perps network dropdown to ETH only

### DIFF
--- a/src/components/core_layouts/wallet/TheCurrentNetwork.vue
+++ b/src/components/core_layouts/wallet/TheCurrentNetwork.vue
@@ -1,6 +1,6 @@
 <template>
   <!-- App Select Chain -->
-  <select-chain-for-app :has-label="false">
+  <select-chain-for-app :has-label="false" :passed-chains="restrictedChains">
     <template #network-button="{ openNetworkDialog, selectedChain }">
       <button
         class="hoverNoBG p-1 xs:py-2 xs:px-3 rounded-[24px] xs:rounded-full max-w-[178px] shadow-button shadow-button-elevated"
@@ -31,9 +31,29 @@
   </select-chain-for-app>
 </template>
 <script setup lang="ts">
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
+import { storeToRefs } from 'pinia'
 import SelectChainForApp from '@/components/select_chain/SelectChainForApp.vue'
 import { ChevronDownIcon } from '@heroicons/vue/24/solid'
 import { useAppBreakpoints } from '@/composables/useAppBreakpoints'
+import { useChainsStore } from '@/stores/chainsStore'
+import { ROUTES_MAIN, PERP_INFO_ROUTE_NAME } from '@/router/routeNames'
+import type { Chain } from '@/mew_api/types'
 
 const { isXS } = useAppBreakpoints()
+const route = useRoute()
+const { chains } = storeToRefs(useChainsStore())
+
+const isPerpsRoute = computed(
+  () =>
+    route.name === ROUTES_MAIN.PERPS.NAME ||
+    route.name === PERP_INFO_ROUTE_NAME,
+)
+
+const restrictedChains = computed<Chain[]>(() => {
+  if (!isPerpsRoute.value) return []
+  const eth = chains.value.find(c => c.name === 'ETHEREUM')
+  return eth ? [eth] : []
+})
 </script>

--- a/src/components/core_layouts/wallet/TheCurrentNetwork.vue
+++ b/src/components/core_layouts/wallet/TheCurrentNetwork.vue
@@ -33,17 +33,15 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useRoute } from 'vue-router'
-import { storeToRefs } from 'pinia'
 import SelectChainForApp from '@/components/select_chain/SelectChainForApp.vue'
 import { ChevronDownIcon } from '@heroicons/vue/24/solid'
 import { useAppBreakpoints } from '@/composables/useAppBreakpoints'
-import { useChainsStore } from '@/stores/chainsStore'
+import { useEthOnlyChains } from '@/composables/useEthOnlyChains'
 import { ROUTES_MAIN, PERP_INFO_ROUTE_NAME } from '@/router/routeNames'
-import type { Chain } from '@/mew_api/types'
 
 const { isXS } = useAppBreakpoints()
 const route = useRoute()
-const { chains } = storeToRefs(useChainsStore())
+const { ethOnlyChains } = useEthOnlyChains()
 
 const isPerpsRoute = computed(
   () =>
@@ -51,9 +49,7 @@ const isPerpsRoute = computed(
     route.name === PERP_INFO_ROUTE_NAME,
 )
 
-const restrictedChains = computed<Chain[]>(() => {
-  if (!isPerpsRoute.value) return []
-  const eth = chains.value.find(c => c.name === 'ETHEREUM')
-  return eth ? [eth] : []
-})
+const restrictedChains = computed(() =>
+  isPerpsRoute.value ? ethOnlyChains.value : [],
+)
 </script>

--- a/src/composables/useEthOnlyChains.ts
+++ b/src/composables/useEthOnlyChains.ts
@@ -1,0 +1,15 @@
+import { computed } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useChainsStore } from '@/stores/chainsStore'
+import type { Chain } from '@/mew_api/types'
+
+export function useEthOnlyChains() {
+  const { chains } = storeToRefs(useChainsStore())
+
+  const ethOnlyChains = computed<Chain[]>(() => {
+    const eth = chains.value.find(c => c.name === 'ETHEREUM')
+    return eth ? [eth] : []
+  })
+
+  return { ethOnlyChains }
+}

--- a/src/modules/perps/ModulePerpsTrade.vue
+++ b/src/modules/perps/ModulePerpsTrade.vue
@@ -614,7 +614,7 @@
           <p class="text-info text-s-14 mb-4">
             Perps is only available on Ethereum
           </p>
-          <select-chain-for-app>
+          <select-chain-for-app :passed-chains="ethOnlyChains">
             <template #network-button="{ openNetworkDialog }">
               <button
                 class="bg-primary text-white rounded-full px-6 py-2.5 text-s-14 font-medium hoverOpacity w-full"
@@ -787,6 +787,8 @@ import { useWalletStore } from '@/stores/walletStore'
 import { useAccessStore } from '@/stores/accessStore'
 import { useWalletMenuStore } from '@/stores/walletMenuStore'
 import { useGlobalStore } from '@/stores/globalStore'
+import { useChainsStore } from '@/stores/chainsStore'
+import type { Chain } from '@/mew_api/types'
 import { storeToRefs } from 'pinia'
 import { useI18n } from 'vue-i18n'
 
@@ -795,7 +797,12 @@ const { isWalletConnected, isWatchOnly } = storeToRefs(walletStore)
 const accessStore = useAccessStore()
 const globalStore = useGlobalStore()
 const { selectedNetwork } = storeToRefs(globalStore)
+const { chains } = storeToRefs(useChainsStore())
 const isSupportedNetwork = computed(() => selectedNetwork.value === 'ETHEREUM')
+const ethOnlyChains = computed<Chain[]>(() => {
+  const eth = chains.value.find(c => c.name === 'ETHEREUM')
+  return eth ? [eth] : []
+})
 const { t } = useI18n()
 
 const { setSelectedTradeManageMode } = useWalletMenuStore()

--- a/src/modules/perps/ModulePerpsTrade.vue
+++ b/src/modules/perps/ModulePerpsTrade.vue
@@ -787,8 +787,7 @@ import { useWalletStore } from '@/stores/walletStore'
 import { useAccessStore } from '@/stores/accessStore'
 import { useWalletMenuStore } from '@/stores/walletMenuStore'
 import { useGlobalStore } from '@/stores/globalStore'
-import { useChainsStore } from '@/stores/chainsStore'
-import type { Chain } from '@/mew_api/types'
+import { useEthOnlyChains } from '@/composables/useEthOnlyChains'
 import { storeToRefs } from 'pinia'
 import { useI18n } from 'vue-i18n'
 
@@ -797,12 +796,8 @@ const { isWalletConnected, isWatchOnly } = storeToRefs(walletStore)
 const accessStore = useAccessStore()
 const globalStore = useGlobalStore()
 const { selectedNetwork } = storeToRefs(globalStore)
-const { chains } = storeToRefs(useChainsStore())
+const { ethOnlyChains } = useEthOnlyChains()
 const isSupportedNetwork = computed(() => selectedNetwork.value === 'ETHEREUM')
-const ethOnlyChains = computed<Chain[]>(() => {
-  const eth = chains.value.find(c => c.name === 'ETHEREUM')
-  return eth ? [eth] : []
-})
 const { t } = useI18n()
 
 const { setSelectedTradeManageMode } = useWalletMenuStore()

--- a/src/views/ViewPerps.vue
+++ b/src/views/ViewPerps.vue
@@ -80,8 +80,7 @@ import { usePerpsAuth } from '@/modules/perps/composables/usePerpsAuth'
 import { useAppBreakpoints } from '@/composables/useAppBreakpoints'
 import { useGlobalStore } from '@/stores/globalStore'
 import { useAccessStore } from '@/stores/accessStore'
-import { useChainsStore } from '@/stores/chainsStore'
-import type { Chain } from '@/mew_api/types'
+import { useEthOnlyChains } from '@/composables/useEthOnlyChains'
 
 const router = useRouter()
 const walletMenu = useWalletMenuStore()
@@ -89,11 +88,7 @@ const walletStore = useWalletStore()
 const { isWatchOnly, wallet } = storeToRefs(walletStore)
 const { token, isAuthenticating, login, logout } = usePerpsAuth()
 const { isDesktopAndUp } = useAppBreakpoints()
-const { chains } = storeToRefs(useChainsStore())
-const ethOnlyChains = computed<Chain[]>(() => {
-  const eth = chains.value.find(c => c.name === 'ETHEREUM')
-  return eth ? [eth] : []
-})
+const { ethOnlyChains } = useEthOnlyChains()
 
 watch(
   () => wallet.value,

--- a/src/views/ViewPerps.vue
+++ b/src/views/ViewPerps.vue
@@ -4,7 +4,7 @@
       <p class="text-info text-s-14 mb-4">
         Perps is only available on Ethereum
       </p>
-      <select-chain-for-app>
+      <select-chain-for-app :passed-chains="ethOnlyChains">
         <template #network-button="{ openNetworkDialog }">
           <button
             class="bg-black text-white rounded-full px-6 py-2.5 text-s-14 font-medium hoverOpacity"
@@ -80,6 +80,8 @@ import { usePerpsAuth } from '@/modules/perps/composables/usePerpsAuth'
 import { useAppBreakpoints } from '@/composables/useAppBreakpoints'
 import { useGlobalStore } from '@/stores/globalStore'
 import { useAccessStore } from '@/stores/accessStore'
+import { useChainsStore } from '@/stores/chainsStore'
+import type { Chain } from '@/mew_api/types'
 
 const router = useRouter()
 const walletMenu = useWalletMenuStore()
@@ -87,6 +89,11 @@ const walletStore = useWalletStore()
 const { isWatchOnly, wallet } = storeToRefs(walletStore)
 const { token, isAuthenticating, login, logout } = usePerpsAuth()
 const { isDesktopAndUp } = useAppBreakpoints()
+const { chains } = storeToRefs(useChainsStore())
+const ethOnlyChains = computed<Chain[]>(() => {
+  const eth = chains.value.find(c => c.name === 'ETHEREUM')
+  return eth ? [eth] : []
+})
 
 watch(
   () => wallet.value,


### PR DESCRIPTION
## Summary
- When the user is on a perps route, the topbar `TheCurrentNetwork` chain dialog now lists only Ethereum (other routes are unaffected).
- The perps page (`ViewPerps`) and perps drawer (`ModulePerpsTrade`) "Switch to Ethereum" dialogs also only show Ethereum, removing the dead-end of selecting another non-ETH chain when the user is explicitly being told that perps requires ETH.

All three dropdowns reuse the existing `passedChains` filter that `SelectChainDialog` already supports — no new prop or composable was added.

## Test plan
- [x] `pnpm vue-tsc --noEmit` clean
- [x] `pnpm test:unit --run` — 56 / 56 pass
- [x] Topbar dropdown on `/perps` shows only Ethereum
- [x] Topbar dropdown on `/perps/perp/:market` shows only Ethereum
- [x] Topbar dropdown on `/` / `/crypto` still shows the full chain list (regression)
- [x] Perps page "Switch to Ethereum" dialog shows only Ethereum
- [x] Perps drawer "Switch to Ethereum" dialog shows only Ethereum


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Perps trading network selection now restricts available chains to Ethereum on Perps pages, preventing attempts on unsupported networks.

* **Chores**
  * Centralized Ethereum-only chain handling applied across Perps views and the app layout so the network selector behaves consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->