### PR TITLE
fix: MEW-1863 use per-market defaultLeverage in select-market dialog

### DIFF
--- a/src/modules/perps/ModulePerpsTrade.vue
+++ b/src/modules/perps/ModulePerpsTrade.vue
@@ -721,6 +721,7 @@
       :contracts="filteredMarketList"
       :filter-tabs="marketFilterTabs"
       :get-market-display-name="getMarketDisplayName"
+      :get-market-leverage="getMarketLeverage"
       @set-sort="setMarketSort"
       @select="selectMarket"
     />
@@ -940,6 +941,7 @@ const {
   fullMarketName,
   contracts,
   getMarketDisplayName,
+  getMarketLeverage,
   openTokenSelect,
   selectMarket,
   // Leverage

--- a/src/modules/perps/components/PerpsSelectMarketDialog.vue
+++ b/src/modules/perps/components/PerpsSelectMarketDialog.vue
@@ -108,7 +108,7 @@
                     }}</span>
                     <span
                       class="shrink-0 bg-surface text-info font-bold rounded px-[6px] py-[1px] text-s-9"
-                      >20x</span
+                      >{{ getMarketLeverage(contract) }}x</span
                     >
                   </div>
                   <span class="text-info text-s-12">{{
@@ -197,6 +197,10 @@ const props = defineProps({
     default: '',
   },
   getMarketDisplayName: {
+    type: Function as PropType<(contract: Contract) => string>,
+    required: true,
+  },
+  getMarketLeverage: {
     type: Function as PropType<(contract: Contract) => string>,
     required: true,
   },

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -758,6 +758,11 @@ export function usePerpsTradeForm() {
     return match?.longName ?? match?.displayName ?? contract.baseCurrency
   }
 
+  function getMarketLeverage(contract: any): string {
+    const match = markets.value.find(m => m.market === contract.market)
+    return match?.defaultLeverage ?? ''
+  }
+
   function openTokenSelect() {
     marketSearch.value = ''
     marketFilter.value = 'all'
@@ -1357,6 +1362,7 @@ export function usePerpsTradeForm() {
     filteredMarketList,
     fullMarketName,
     getMarketDisplayName,
+    getMarketLeverage,
     openTokenSelect,
     selectMarket,
     // Leverage


### PR DESCRIPTION
## Summary
- Replace the hardcoded `20x` badge in `PerpsSelectMarketDialog` with each market's `defaultLeverage`, matching the badge shown in `PerpsMarketList`.
- Add `getMarketLeverage` to `usePerpsTradeForm` (parallel to the existing `getMarketDisplayName` lookup) and pass it through `ModulePerpsTrade` as a prop.

## Test plan
- [x] `pnpm vue-tsc --noEmit -p tsconfig.app.json` clean
- [x] `pnpm vitest run tests/unit/specs/modules/perps/` — 22/22 passing
- [x] Markets list badge value matches the select-market dialog badge for the same market
- [x] Filters / search / sort in the dialog still work; selecting a market updates the drawer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Market leverage is now displayed dynamically based on the selected market, replacing static leverage information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->