### PR TITLE
MEW-1860 fix: perps sign-in button unresponsive after sign-out and 401

### DIFF
--- a/src/modules/perps/composables/usePerpsAuth.ts
+++ b/src/modules/perps/composables/usePerpsAuth.ts
@@ -26,6 +26,7 @@ const refreshKey = ref(0)
 
 let _authRestored = false
 let _currentAddress: string | null = null
+let _walletWatcherRegistered = false
 
 async function tryRestoreAuth(address: string) {
   const storedTokens: string[] = getStoredArray(STORAGE_KEY_TOKEN)
@@ -59,6 +60,11 @@ async function clearAuth() {
   token.value = null
   accountId.value = null
   perpsClient.setToken(null)
+  // Reset module-scope guards so a subsequent Sign In click is not silently
+  // blocked by a stale auth-restored flag from a previous session.
+  _authRestored = false
+  _currentAddress = null
+  isAuthenticating.value = false
 
   if (!wallet.value) return;
   const storedTokens = getStoredArray(STORAGE_KEY_TOKEN)
@@ -91,7 +97,13 @@ export function usePerpsAuth() {
   const store = useWalletStore()
   const { wallet, isWalletConnected, walletAddress } = storeToRefs(store)
 
-  if (!_authRestored) {
+  // Register the walletAddress watcher exactly once for the lifetime of the
+  // module. Re-registering after a sign-out would race with `clearAuth()`'s
+  // localStorage filtering — the fresh watcher's `immediate: true` fire would
+  // call `tryRestoreAuth` against the unfiltered localStorage and re-hydrate
+  // the token we just cleared.
+  if (!_walletWatcherRegistered) {
+    _walletWatcherRegistered = true
     watch(
       walletAddress,
       async address => {

--- a/src/views/ViewPerps.vue
+++ b/src/views/ViewPerps.vue
@@ -84,27 +84,27 @@ import { useAccessStore } from '@/stores/accessStore'
 const router = useRouter()
 const walletMenu = useWalletMenuStore()
 const walletStore = useWalletStore()
-const { isWatchOnly, wallet } = storeToRefs(walletStore)
+const { isWatchOnly, walletAddress } = storeToRefs(walletStore)
 const { token, isAuthenticating, login, logout } = usePerpsAuth()
 const { isDesktopAndUp } = useAppBreakpoints()
 
-watch(
-  () => wallet.value,
-  (newVal, oldVal) => {
-    if (
-      newVal &&
-      oldVal &&
-      !isWatchOnly.value &&
-      !isAuthenticating.value &&
-      !token.value
-    ) {
-      login()
-    }
-  },
-  {
-    deep: true,
-  },
-)
+// Trigger auto-login only when the connected wallet address actually changes
+// (wallet switch / account swap). Watching the wallet object with `deep: true`
+// re-fired on any internal provider mutation, which after a Sign Out would
+// silently re-auth the user and make the page flash back to the signed-in
+// view.
+watch(walletAddress, (newAddr, oldAddr) => {
+  if (
+    newAddr &&
+    oldAddr &&
+    newAddr !== oldAddr &&
+    !isWatchOnly.value &&
+    !isAuthenticating.value &&
+    !token.value
+  ) {
+    login()
+  }
+})
 
 const connectWallet = () => useAccessStore().openAccessDialog()
 

--- a/tests/unit/specs/modules/perps/composables/usePerpsAuth.spec.ts
+++ b/tests/unit/specs/modules/perps/composables/usePerpsAuth.spec.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ref, nextTick } from 'vue'
+
+const mockGetLoginChallenge = vi.fn()
+const mockCompleteLoginChallenge = vi.fn()
+const mockSetToken = vi.fn()
+const mockSetOnUnauthorized = vi.fn()
+const mockAcceptAgreement = vi.fn()
+const mockGetPerpsBalance = vi.fn()
+const mockGetPortfolioSummary = vi.fn()
+
+vi.mock('@/modules/perps/configs', () => ({
+  BUILDER_CODE: 'BC',
+  perpsClient: {
+    getLoginChallenge: mockGetLoginChallenge,
+    completeLoginChallenge: mockCompleteLoginChallenge,
+    setToken: mockSetToken,
+    setOnUnauthorized: mockSetOnUnauthorized,
+    acceptAgreement: mockAcceptAgreement,
+    getPerpsBalance: mockGetPerpsBalance,
+    getPortfolioSummary: mockGetPortfolioSummary,
+  },
+}))
+
+vi.mock('@/utils/crypto', () => ({
+  encrypt: vi.fn(async (value: string) => `enc:${value}`),
+  decrypt: vi.fn(async (value: string) => {
+    if (value.startsWith('enc:')) return value.slice(4)
+    throw new Error('decrypt failed')
+  }),
+}))
+
+const walletAddress = ref<string | null>('0xabc')
+const wallet = ref<{ getAddress: () => Promise<string>; SignMessage: (args: { message: string }) => Promise<string> } | null>({
+  getAddress: vi.fn(async () => '0xabc'),
+  SignMessage: vi.fn(async () => 'signature'),
+})
+const isWalletConnected = ref(true)
+
+vi.mock('pinia', async () => {
+  const actual = await vi.importActual<typeof import('pinia')>('pinia')
+  return {
+    ...actual,
+    storeToRefs: () => ({ wallet, walletAddress, isWalletConnected }),
+  }
+})
+
+vi.mock('@/stores/walletStore', () => ({
+  useWalletStore: () => ({ wallet, walletAddress, isWalletConnected }),
+}))
+
+vi.mock('@/modules/perps/composables/usePerpsToasts', () => ({
+  usePerpsToasts: () => ({
+    toastLiquidationInitiated: vi.fn(),
+  }),
+}))
+
+describe('usePerpsAuth — clearAuth state reset (MEW-1860)', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    localStorage.clear()
+    walletAddress.value = '0xabc'
+    wallet.value = {
+      getAddress: vi.fn(async () => '0xabc'),
+      SignMessage: vi.fn(async () => 'signature'),
+    }
+    isWalletConnected.value = true
+
+    mockGetLoginChallenge.mockResolvedValue({
+      result: { id: 'challenge-id', message: 'sign-me' },
+    })
+    mockCompleteLoginChallenge.mockResolvedValue({
+      result: { token: 'new-token', accountId: 'acc-1' },
+    })
+    mockAcceptAgreement.mockResolvedValue(undefined)
+  })
+
+  it('after logout, login() runs again instead of being silently blocked by the auth-restored guard', async () => {
+    // Seed localStorage with an encrypted token for the current wallet so that
+    // tryRestoreAuth() succeeds on first call and sets _authRestored = true.
+    localStorage.setItem(
+      'perps_auth_token',
+      JSON.stringify(['enc:restored-token']),
+    )
+    localStorage.setItem(
+      'perps_auth_account',
+      JSON.stringify(['enc:restored-account']),
+    )
+
+    const { usePerpsAuth } = await import(
+      '@/modules/perps/composables/usePerpsAuth'
+    )
+    const auth = usePerpsAuth()
+
+    // Allow the immediate walletAddress watcher to restore the token.
+    await nextTick()
+    await nextTick()
+    expect(auth.token.value).toBe('restored-token')
+
+    // User signs out.
+    auth.logout()
+    await nextTick()
+    expect(auth.token.value).toBeNull()
+
+    // User clicks "Sign in" again — login() must reach the challenge call,
+    // not bail out from the stale _authRestored guard.
+    await auth.login()
+    expect(mockGetLoginChallenge).toHaveBeenCalledTimes(1)
+    expect(auth.token.value).toBe('new-token')
+  })
+
+  it('after 401 unauthorized triggers clearAuth, login() can run again', async () => {
+    localStorage.setItem(
+      'perps_auth_token',
+      JSON.stringify(['enc:restored-token']),
+    )
+    localStorage.setItem(
+      'perps_auth_account',
+      JSON.stringify(['enc:restored-account']),
+    )
+
+    const { usePerpsAuth } = await import(
+      '@/modules/perps/composables/usePerpsAuth'
+    )
+    const auth = usePerpsAuth()
+    await nextTick()
+    await nextTick()
+    expect(auth.token.value).toBe('restored-token')
+
+    // Simulate perpsClient firing its onUnauthorized callback (e.g., 401 from
+    // a balance poll). The registered handler calls clearAuth() internally.
+    const onUnauthorizedCb = mockSetOnUnauthorized.mock.calls[0]?.[0]
+    expect(typeof onUnauthorizedCb).toBe('function')
+    await onUnauthorizedCb()
+    await nextTick()
+    expect(auth.token.value).toBeNull()
+
+    // Sign in should be reachable again.
+    await auth.login()
+    expect(mockGetLoginChallenge).toHaveBeenCalledTimes(1)
+    expect(auth.token.value).toBe('new-token')
+  })
+
+  it('clearAuth resets isAuthenticating so the loading state cannot get stuck', async () => {
+    localStorage.setItem(
+      'perps_auth_token',
+      JSON.stringify(['enc:restored-token']),
+    )
+
+    const { usePerpsAuth } = await import(
+      '@/modules/perps/composables/usePerpsAuth'
+    )
+    const auth = usePerpsAuth()
+    await nextTick()
+    await nextTick()
+
+    // Simulate an in-flight login that crashed before reaching the finally
+    // block (e.g., user closed the tab; the ref was left as `true`).
+    // We don't have a way to await the inner finally directly, so we mutate
+    // the flag and then call logout — clearAuth must drop it back to false.
+    ;(auth.isAuthenticating as { value: boolean }).value = true
+    auth.logout()
+    await nextTick()
+    expect(auth.isAuthenticating.value).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Fix the perps Sign in / Connect Wallet button becoming unresponsive after Sign Out or a 401 unauthorized event, and stop the post–Sign Out flash that bounced the user back to the signed-in view.

## Root causes

1. **Stale module-scope guards in `usePerpsAuth`.** `clearAuth()` cleared the reactive token but never reset `_authRestored`, `_currentAddress`, or `isAuthenticating`. The next click on Sign in hit the `if (_authRestored) return;` guard in `login()` and bailed silently — only a page refresh recovered.
2. **Watcher re-registration race after Sign Out.** When `PerpsMainBanner` re-mounted after sign-out, its `usePerpsAuth()` call re-registered the `walletAddress` watcher (guarded by `!_authRestored`). The new watcher's `immediate: true` fire ran `tryRestoreAuth` against the unfiltered `localStorage` in parallel with `clearAuth()`'s pending `await wallet.getAddress()` → encrypted-token filter, so the token we had just cleared got re-hydrated and the page flashed back to signed-in.
3. **`deep: true` wallet watcher in `ViewPerps`.** Watching the wallet object deeply re-fired auto-login on internal provider mutations (not just address changes), compounding the flash.

## Changes

- `src/modules/perps/composables/usePerpsAuth.ts`
  - `clearAuth()` now also resets `_authRestored`, `_currentAddress`, and `isAuthenticating`.
  - Added `_walletWatcherRegistered` flag; the `walletAddress` watcher registers exactly once per module lifetime so re-mounts cannot race with `clearAuth()`'s localStorage filter.
- `src/views/ViewPerps.vue`
  - Replaced `watch(() => wallet, { deep: true })` with `watch(walletAddress, …)` so auto-login only fires on a genuine address change.
- `tests/unit/specs/modules/perps/composables/usePerpsAuth.spec.ts` *(new)*
  - Covers: sign-out → re-login reaches the challenge call; 401 → re-login reaches the challenge call; `isAuthenticating` is reset by `clearAuth`.

## Test plan

- [x] `pnpm vitest run tests/unit/specs/modules/perps/composables/usePerpsAuth.spec.ts` — 3/3 green
- [x] `pnpm vue-tsc --noEmit -p tsconfig.app.json` — clean
- [x] Manual smoke (perps page): Sign Out → Sign in works on first click, no flash back to signed-in view
- [x] Manual smoke: trigger 401 (token expiry) → Sign in works without page refresh
- [x] Manual smoke: wallet switch / account swap → auto-login still fires once

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved wallet authentication flow to properly clear tokens on sign-out and prevent unintended re-authentication attempts.
  * Fixed sign-in trigger to activate only when wallet address changes, reducing unnecessary login attempts.
  * Resolved potential issue where authentication status could remain stuck during interrupted login sequences.

* **Tests**
  * Added comprehensive unit tests for authentication state management and wallet switching scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->