### PR TITLE
MEW-1857 fix(perps): refresh Target Price when switching markets

### DIFF
--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -1172,6 +1172,16 @@ export function usePerpsTradeForm() {
       closeError.value = ''
       takeProfitPrice.value = null
       stopLossPrice.value = null
+      // Reset the target price + re-apply the previously-selected pill against
+      // the new market's currentPrice. Without this the absolute USD value
+      // computed from the prior market (e.g. +10% of AAPL ~ $264) carried over
+      // to the new token, even though the label reads "Target <new symbol>".
+      const previousLimitPill = activeLimitPill.value
+      limitPrice.value = ''
+      activeLimitPill.value = null
+      if (previousLimitPill !== null) {
+        setLimitPricePct(previousLimitPill)
+      }
       // Reset leverage to the new market's open-position leverage if there is
       // one, otherwise to its per-token max. Prevents callsites reading the
       // singleton (sidepanel / order modal / leverage dialog) from showing a


### PR DESCRIPTION
## Summary

- On switching markets in the perps drawer, the limit-order "Target {symbol} price" was keeping the absolute USD value computed from the previous market (e.g. +10% of AAPL ≈ $264) even though the label flipped to the new symbol.
- Reset `limitPrice` + `activeLimitPill` inside the `activeMarket` watcher of `usePerpsTradeForm` and re-apply the previously-selected pill against the new market's `currentPrice`, so picking +10% on AAPL and then jumping to AMD now shows +10% of AMD's price.

## Test plan

- [ ] Open perps drawer on AAPL, switch order type to Limit, click a target-price pill (e.g. +10%), then change token to AMD. The Target price recomputes to the same pill relative to AMD's mid price (not the prior AAPL USD amount).
- [ ] If no pill was selected before switching, the Target price field is cleared so the user can re-pick.
- [ ] Switch back and forth between several markets; the limit price never carries over the prior market's absolute USD amount.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where limit prices would incorrectly persist when switching between trading markets, ensuring they are now properly recalculated based on your previous selection settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->