### PR TITLE
MEW-1869: update Target Price pct buttons to -5/-2.5/Mid/+2.5/+5

### DIFF
--- a/src/modules/perps/ModulePerpsTrade.vue
+++ b/src/modules/perps/ModulePerpsTrade.vue
@@ -276,7 +276,7 @@
 
           <div class="flex justify-start gap-2 mt-1">
             <button
-              v-for="pct in [-10, -5, 0, 5, 10]"
+              v-for="pct in [-5, -2.5, 0, 2.5, 5]"
               :key="pct"
               class="w-full px-[10px] py-1 text-s-11 leading-p-120 font-semibold bg-white hoverBGWhite rounded-full transition-all duration-150 shadow-button shadow-button-elevated"
               @click="setLimitPricePct(pct)"


### PR DESCRIPTION
## Summary

Per QA (MEW-1869), the Target Price percentage shortcut row in the Perps trade drawer changes from `[-10%, -5%, Mid, +5%, +10%]` to `[-5%, -2.5%, Mid, +2.5%, +5%]`.

## Implementation

- One-line change in `src/modules/perps/ModulePerpsTrade.vue:279` — swap the hardcoded `v-for` array.
- `setLimitPricePct(pct)` already accepts numeric inputs natively, so float values (`±2.5`) flow through the existing `currentPrice * (1 + pct/100)` calculation and quote-increment rounding without modification.
- The existing label expression `pct === 0 ? 'Mid' : (pct > 0 ? '+' : '') + pct + '%'` renders the new values correctly as `-5% / -2.5% / Mid / +2.5% / +5%`.

## Test plan

- [x] `pnpm vue-tsc --noEmit -p tsconfig.app.json` — exit 0
- [x] `pnpm vitest run` — 56/56 passing
- [x] Manual smoke: Perps drawer → Limit order type → Target Price row shows the 5 new buttons; each click writes the correct price relative to mid

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Updated Target price quick-set percentage buttons to provide finer adjustment increments and a more precise range for perpetuals trading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->