### PR TITLE
MEW-1856: switch-to-ethereum buttons replace connect/deposit on non-ETH

### DIFF
--- a/src/modules/perps/ModulePerpsTrade.vue
+++ b/src/modules/perps/ModulePerpsTrade.vue
@@ -614,16 +614,12 @@
           <p class="text-info text-s-14 mb-4">
             Perps is only available on Ethereum
           </p>
-          <select-chain-for-app>
-            <template #network-button="{ openNetworkDialog }">
-              <button
-                class="bg-primary text-white rounded-full px-6 py-2.5 text-s-14 font-medium hoverOpacity w-full"
-                @click="openNetworkDialog(true)"
-              >
-                Switch to Ethereum
-              </button>
-            </template>
-          </select-chain-for-app>
+          <button
+            class="bg-primary text-white rounded-full px-6 py-2.5 text-s-14 font-medium hoverOpacity w-full"
+            @click="onSwitchToEthereum"
+          >
+            Switch to Ethereum
+          </button>
         </div>
       </template>
       <template v-else-if="isWatchOnly">
@@ -782,11 +778,12 @@ import PerpsSelectMarketDialog from './components/PerpsSelectMarketDialog.vue'
 import PerpsOrderConfirmationDialog from './components/PerpsOrderConfirmationDialog.vue'
 import PerpsCloseConfirmationDialog from './components/PerpsCloseConfirmationDialog.vue'
 import PerpsTakeProfitStopLossDialog from './components/PerpsTakeProfitStopLossDialog.vue'
-import SelectChainForApp from '@/components/select_chain/SelectChainForApp.vue'
 import { useWalletStore } from '@/stores/walletStore'
 import { useAccessStore } from '@/stores/accessStore'
 import { useWalletMenuStore } from '@/stores/walletMenuStore'
 import { useGlobalStore } from '@/stores/globalStore'
+import { useToastStore } from '@/stores/toastStore'
+import { ToastType } from '@/types/notification'
 import { storeToRefs } from 'pinia'
 import { useI18n } from 'vue-i18n'
 
@@ -795,8 +792,18 @@ const { isWalletConnected, isWatchOnly } = storeToRefs(walletStore)
 const accessStore = useAccessStore()
 const globalStore = useGlobalStore()
 const { selectedNetwork } = storeToRefs(globalStore)
+const toastStore = useToastStore()
 const isSupportedNetwork = computed(() => selectedNetwork.value === 'ETHEREUM')
 const { t } = useI18n()
+
+const onSwitchToEthereum = () => {
+  globalStore.setSelectedNetwork('ETHEREUM')
+  toastStore.addToastMessage({
+    text: 'Switched to Ethereum',
+    textSecondary: 'Perpetuals are only available on Ethereum.',
+    type: ToastType.Info,
+  })
+}
 
 const { setSelectedTradeManageMode } = useWalletMenuStore()
 const connectWallet = () => {

--- a/src/modules/perps/components/PerpsMainBanner.vue
+++ b/src/modules/perps/components/PerpsMainBanner.vue
@@ -94,17 +94,7 @@
       </p>
 
       <div class="flex justify-center">
-        <template v-if="!isWalletConnected || isWatchOnly">
-          <app-base-button
-            class="w-full lg:w-auto lg:px-10"
-            @click="onConnectWallet"
-            @mouseenter="isHoveringCta = true"
-            @mouseleave="isHoveringCta = false"
-          >
-            Connect Wallet
-          </app-base-button>
-        </template>
-        <template v-else-if="isBitcoinChain && isUnisatWallet">
+        <template v-if="!isOnEthereum && isUnisatWallet">
           <app-base-button
             class="w-full lg:w-auto lg:px-10"
             @click="onDownloadEnkrypt"
@@ -114,7 +104,7 @@
             Download Enkrypt
           </app-base-button>
         </template>
-        <template v-else-if="isBitcoinChain">
+        <template v-else-if="!isOnEthereum">
           <app-base-button
             class="w-full lg:w-auto lg:px-10"
             @click="onSwitchToEthereum"
@@ -122,6 +112,16 @@
             @mouseleave="isHoveringCta = false"
           >
             Switch to Ethereum
+          </app-base-button>
+        </template>
+        <template v-else-if="!isWalletConnected || isWatchOnly">
+          <app-base-button
+            class="w-full lg:w-auto lg:px-10"
+            @click="onConnectWallet"
+            @mouseenter="isHoveringCta = true"
+            @mouseleave="isHoveringCta = false"
+          >
+            Connect Wallet
           </app-base-button>
         </template>
         <template v-else>
@@ -138,14 +138,14 @@
       </div>
 
       <p
-        v-if="isBitcoinChain && isUnisatWallet"
+        v-if="!isOnEthereum && isUnisatWallet"
         class="text-info text-s-12 mt-3"
       >
         UniSat doesn't support Perpetuals. Install Enkrypt or connect a
         different wallet to continue.
       </p>
-      <p v-else-if="isBitcoinChain" class="text-info text-s-12 mt-3">
-        Perpetuals are available on Ethereum. Switch network to continue.
+      <p v-else-if="!isOnEthereum" class="text-info text-s-13 mt-3">
+        Perpetuals feature is only available on the Ethereum network
       </p>
     </div>
   </div>
@@ -162,7 +162,6 @@ import coinbaseLogo from '@/assets/icons/perps-banner/coinbase.svg'
 import googleLogo from '@/assets/icons/perps-banner/google.svg'
 import hoodLogo from '@/assets/icons/perps-banner/hood.svg'
 import { useWalletStore } from '@/stores/walletStore'
-import { useChainsStore } from '@/stores/chainsStore'
 import { useAccessStore } from '@/stores/accessStore'
 import { useGlobalStore } from '@/stores/globalStore'
 import { useToastStore } from '@/stores/toastStore'
@@ -171,12 +170,13 @@ import { usePerpsAuth } from '../composables/usePerpsAuth'
 
 const walletStore = useWalletStore()
 const { isWalletConnected, isWatchOnly, walletName } = storeToRefs(walletStore)
-const chainsStore = useChainsStore()
-const { isBitcoinChain } = storeToRefs(chainsStore)
 const accessStore = useAccessStore()
 const globalStore = useGlobalStore()
+const { selectedNetwork } = storeToRefs(globalStore)
 const toastStore = useToastStore()
 const { login, isAuthenticating } = usePerpsAuth()
+
+const isOnEthereum = computed(() => selectedNetwork.value === 'ETHEREUM')
 
 const isHoveringCta = ref(false)
 

--- a/src/modules/perps/components/PerpsPortfolioSummary.vue
+++ b/src/modules/perps/components/PerpsPortfolioSummary.vue
@@ -18,8 +18,20 @@
           <span class="text-s-13 ml-2 leading-[16px]">({{ pnlPercent }})</span>
         </p>
         <div
+          v-if="!isOnEthereum"
           class="flex items-center gap-3 justify-start mt-5 -mx-1"
-          v-if="!watchOnly"
+        >
+          <AppBaseButton
+            @click="onSwitchToEthereum"
+            class="w-full"
+            size="medium"
+          >
+            Switch to Ethereum
+          </AppBaseButton>
+        </div>
+        <div
+          v-else-if="!watchOnly"
+          class="flex items-center gap-3 justify-start mt-5 -mx-1"
         >
           <AppBaseButton @click="$emit('deposit')" class="w-full" size="medium">
             Deposit
@@ -33,7 +45,7 @@
             Withdraw
           </AppBaseButton>
         </div>
-        <div class="flex items-center gap-3 justify-start mt-5 -mx-1" v-else>
+        <div v-else class="flex items-center gap-3 justify-start mt-5 -mx-1">
           <AppBaseButton @click="$emit('access')" class="w-full" size="medium">
             Connect your wallet
           </AppBaseButton>
@@ -100,6 +112,7 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
+import { storeToRefs } from 'pinia'
 import AppBaseButton from '@/components/AppBaseButton.vue'
 import AppBtnText from '@/components/AppBtnText.vue'
 import AppSheet from '@/components/AppSheet.vue'
@@ -112,6 +125,9 @@ import {
   formatPnl,
 } from '../utils/formatters'
 import { formatFiatValue } from '@/utils/numberFormatHelper'
+import { useGlobalStore } from '@/stores/globalStore'
+import { useToastStore } from '@/stores/toastStore'
+import { ToastType } from '@/types/notification'
 
 defineProps({
   watchOnly: {
@@ -125,6 +141,21 @@ defineEmits<{
   withdraw: []
   access: []
 }>()
+
+const globalStore = useGlobalStore()
+const { selectedNetwork } = storeToRefs(globalStore)
+const toastStore = useToastStore()
+
+const isOnEthereum = computed(() => selectedNetwork.value === 'ETHEREUM')
+
+const onSwitchToEthereum = () => {
+  globalStore.setSelectedNetwork('ETHEREUM')
+  toastStore.addToastMessage({
+    text: 'Switched to Ethereum',
+    textSecondary: 'Perpetuals are only available on Ethereum.',
+    type: ToastType.Info,
+  })
+}
 
 const showBalanceDialog = ref(false)
 

--- a/src/views/ViewPerps.vue
+++ b/src/views/ViewPerps.vue
@@ -1,20 +1,5 @@
 <template>
   <div class="flex flex-col gap-6">
-    <div v-if="!isSupportedNetwork" class="text-center py-8 bg-white">
-      <p class="text-info text-s-14 mb-4">
-        Perps is only available on Ethereum
-      </p>
-      <select-chain-for-app>
-        <template #network-button="{ openNetworkDialog }">
-          <button
-            class="bg-black text-white rounded-full px-6 py-2.5 text-s-14 font-medium hoverOpacity"
-            @click="openNetworkDialog(true)"
-          >
-            Switch to Ethereum
-          </button>
-        </template>
-      </select-chain-for-app>
-    </div>
     <!-- Not authenticated -->
     <perps-main-banner v-if="!token" />
 
@@ -62,7 +47,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue'
+import { ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { storeToRefs } from 'pinia'
 import { PERP_INFO_ROUTE_NAME } from '@/router/routeNames'
@@ -72,13 +57,11 @@ import PerpsPositionsTable from '@/modules/perps/components/PerpsPositionsTable.
 import PerpsMarketList from '@/modules/perps/components/PerpsMarketList.vue'
 import PerpsDepositDialog from '@/modules/perps/components/PerpsDepositDialog.vue'
 import PerpsWithdrawDialog from '@/modules/perps/components/PerpsWithdrawDialog.vue'
-import SelectChainForApp from '@/components/select_chain/SelectChainForApp.vue'
 import PerpsMainBanner from '@/modules/perps/components/PerpsMainBanner.vue'
 import { useWalletMenuStore } from '@/stores/walletMenuStore'
 import { useWalletStore } from '@/stores/walletStore'
 import { usePerpsAuth } from '@/modules/perps/composables/usePerpsAuth'
 import { useAppBreakpoints } from '@/composables/useAppBreakpoints'
-import { useGlobalStore } from '@/stores/globalStore'
 import { useAccessStore } from '@/stores/accessStore'
 
 const router = useRouter()
@@ -108,10 +91,6 @@ watch(
 
 const connectWallet = () => useAccessStore().openAccessDialog()
 
-const globalStore = useGlobalStore()
-const { selectedNetwork } = storeToRefs(globalStore)
-
-const isSupportedNetwork = computed(() => selectedNetwork.value === 'ETHEREUM')
 const showDeposit = ref(false)
 const showWithdraw = ref(false)
 


### PR DESCRIPTION
## Summary

Removes the top "Perps is only available on Ethereum" banner from `ViewPerps` and replaces the existing action buttons with a `Switch to Ethereum` button when the user is on a non-Ethereum network. The button switches network directly via `globalStore.setSelectedNetwork('ETHEREUM')` + toast — no chain-selection dialog opens.

- **PerpsMainBanner** (not connected / not signed in): non-ETH → `Switch to Ethereum` + subtext `text-s-13` "Perpetuals feature is only available on the Ethereum network". UniSat keeps `Download Enkrypt` (it cannot switch to ETH).
- **PerpsPortfolioSummary** (signed in): non-ETH → `Switch to Ethereum` instead of `Deposit`/`Withdraw` (or `Connect your wallet` for watch-only).
- **ModulePerpsTrade drawer**: bottom `Switch to Ethereum` button under "Perps is only available on Ethereum" now switches the network directly, matching the new pattern.

<img width="1719" height="538" alt="Screenshot 2026-06-08 at 5 15 54 PM" src="https://github.com/user-attachments/assets/4d79fea7-a07d-4e51-b887-8aaadec3e0ca" />


## Test plan

- [ ] Open `/perps` on a non-ETH network (e.g. Polygon): main banner shows `Switch to Ethereum` + the new subtext.
- [ ] Click the button → network switches to Ethereum, toast appears, banner restores to normal.
- [ ] Signed-in, non-ETH: `PerpsPortfolioSummary` shows `Switch to Ethereum` instead of Deposit/Withdraw; clicking switches network.
- [ ] Watch-only, non-ETH: `PerpsPortfolioSummary` shows `Switch to Ethereum` instead of `Connect your wallet`.
- [ ] Open the perps side drawer on a non-ETH network: bottom `Switch to Ethereum` button switches directly (no chain modal).
- [ ] UniSat wallet (Bitcoin chain) still sees `Download Enkrypt`.
- [ ] No "Perps is only available on Ethereum" banner appears at the top of `/perps` in any state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Direct "Switch to Ethereum" button now appears when using unsupported networks, replacing the previous network selector
  * Added confirmation notifications when networks are successfully switched
  * Streamlined and consistent network switching experience across the app

<!-- end of auto-generated comment: release notes by coderabbit.ai -->