### PR TITLE
fix: [MEW-1883] prevent null destructure crash in useFetchMewApi retry

### DIFF
--- a/src/composables/useFetchMewApi.ts
+++ b/src/composables/useFetchMewApi.ts
@@ -81,7 +81,13 @@ export const useFetchMewApi = (
           await new Promise(resolve => setTimeout(resolve, delay.value))
           delay.value = delay.value + 1000
 
-          return execute()
+          // useFetch's execute() resolves to fetchResponse | null, not the
+          // { error, data } ctx shape @vueuse destructures from the
+          // onFetchError return value. Returning it caused a null destructure
+          // crash when the retry chain also failed. Trigger the retry and
+          // return ctx so the caller always sees a valid object.
+          await execute()
+          return ctx
         } else {
           if (isDevMode) {
             console.error('Failed to fetch. URL: ', url.value)


### PR DESCRIPTION
## What was wrong

On the **/access** route, a top Sentry crash (`APP-MEW-WEB-CG`, ~1867 events on release 7.0.7) fired with:

```
TypeError: Cannot destructure property 'error' of '(intermediate value)' as it is null
```

It surfaces as an unhandled promise rejection when one of the API calls feeding the access screen hits a network error or 5xx response. Users in regions with restricted endpoints (e.g. EU) were the most exposed because their initial requests fail more often.

## What changed

`src/composables/useFetchMewApi.ts` — the retry path inside `onFetchError` was returning the raw `execute()` promise. In `@vueuse/core` v14, `useFetch`'s `execute()` resolves to `fetchResponse | null` — not the `{ error, data }` shape the outer `useFetch` destructures from `onFetchError`'s return value. When the retry chain also failed, `execute()` resolved to `null` and the outer destructure threw.

The fix awaits the retry and then returns the original `ctx`, so the outer caller always sees a valid object and the crash disappears.

Single-file, 7-line patch — no behavior change for first-attempt success or for non-retried failures (e.g. 4xx).

## How to test

1. Open the app on the **/access** route on a fresh session.
2. Confirm the page loads normally; no Sentry rejection in the console.
3. (Optional, deeper check) In DevTools → Network, block the API calls that feed the page (e.g. `*/v1/chains*`, `*/v1/evm/chains/*/balances*`), reload, and confirm the page renders an empty/error state without an unhandled rejection in the console.

## Sentry

https://myetherwallet-inc.sentry.io/issues/7371090386/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error handling in API request retries to prevent crashes and ensure proper execution flow completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->