### PR TITLE
fix: [MEW-1886] btnwallet "me is not a function" loading mew mobile icon

### DIFF
--- a/src/composables/useWalletList.ts
+++ b/src/composables/useWalletList.ts
@@ -157,7 +157,11 @@ export const useWalletList = () => {
       const wallet = walletConfigs[key]
       if (wallet.isWC) {
         const wcWallet = connectors.find(w => w.id === wallet.id)
-        defaultWallets.push(Object.assign({}, wallet, wcWallet))
+        // Merge wcWallet first so the static walletConfigs UI metadata
+        // (icon, name, type) wins. The wagmi connector can expose `icon`
+        // as undefined or a non-function value, which used to overwrite
+        // the static MewLogo and crash BtnWallet's resolveImg.
+        defaultWallets.push(Object.assign({}, wcWallet, wallet))
       } else {
         defaultWallets.push(wallet)
       }

--- a/src/modules/access/components/wallets_lists/BtnWallet.vue
+++ b/src/modules/access/components/wallets_lists/BtnWallet.vue
@@ -106,7 +106,6 @@ const resolveImg = async (_img: () => Promise<string>) => {
   try {
     const image = await _img()
     img.value = image
-    isLoadedImg.value = true
   } catch (error) {
     captureException(error, {
       ...SENTRY_MODULE_TAGS.ACCESS,
@@ -116,7 +115,8 @@ const resolveImg = async (_img: () => Promise<string>) => {
         errorMessage: error,
       },
     })
-    return ''
+  } finally {
+    isLoadedImg.value = true
   }
 }
 onMounted(() => {

--- a/src/modules/access/components/wallets_lists/BtnWallet.vue
+++ b/src/modules/access/components/wallets_lists/BtnWallet.vue
@@ -100,10 +100,6 @@ const getBadge = (type: WalletConfigType) => {
   }
   return undefined
 }
-const checkIfIsString = (value: string | (() => Promise<string>)) => {
-  return typeof value === 'string'
-}
-
 const isLoadedImg = ref(false)
 const img = ref<string | undefined>(undefined)
 const resolveImg = async (_img: () => Promise<string>) => {
@@ -124,11 +120,14 @@ const resolveImg = async (_img: () => Promise<string>) => {
   }
 }
 onMounted(() => {
-  if (checkIfIsString(props.wallet.icon)) {
-    img.value = props.wallet.icon as string
+  const icon = props.wallet.icon
+  if (typeof icon === 'string') {
+    img.value = icon
     isLoadedImg.value = true
+  } else if (typeof icon === 'function') {
+    resolveImg(icon)
   } else {
-    resolveImg(props.wallet.icon as () => Promise<string>)
+    isLoadedImg.value = true
   }
 })
 </script>


### PR DESCRIPTION
## What was wrong

On `/access`, the wallet list sometimes crashed with `TypeError: me is not a function` (Sentry APP-MEW-WEB-9C, 2364 events in production since late March, mostly on the MEW Wallet mobile in-app WebView). The "MEW Mobile" button tried to load its icon and threw — the user saw a broken wallet list with no easy recovery.

## What changed

The MEW Mobile wallet config was being merged with its wagmi connector in a way that let the connector's runtime `icon` value (sometimes `undefined`, sometimes a function) overwrite the known-good static logo string. When the override landed as something other than a string, the icon loader awaited it as a function and crashed.

- Reversed the merge order in `useWalletList.defaultWallets` so the static wallet config (icon, name, type) wins over the wagmi connector's fields.
- Hardened `BtnWallet.vue` so it now branches on `typeof icon` — string is used directly, function is loaded via the async resolver, anything else just shows no icon instead of crashing.

## How to test

1. Open the dev server, go to `/access`.
2. Confirm the wallet list renders. The "MEW Mobile" tile must show the MEW logo (not a broken/blank icon).
3. Click "MEW Mobile" — the WalletConnect flow should still open as before.
4. Switch chain (e.g. Ethereum → Bitcoin) and back: the wallet list should re-render without errors in the console.

## Sentry

https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-9C

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed wallet icon display problems across different wallet types so icons render reliably.
  * Improved icon loading to correctly handle string icons, function-provided icons, and absent icons without breaking the UI.
  * Ensured wallet list shows consistent, correct metadata (name/type/icon) so connector-provided values no longer overwrite static UI fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->