### PR TITLE
fix: [MEW-1887] guard getTxRequestBody against undefined toAddress

### DIFF
--- a/src/modules/send/ModuleSend.vue
+++ b/src/modules/send/ModuleSend.vue
@@ -382,7 +382,7 @@ const getTxRequestBody = ():
   if (
     tokenSelected.value &&
     tokenSelected.value.contract &&
-    toAddress.value !== '' &&
+    toAddress.value &&
     amount.value !== ''
   ) {
     if (isEvmChain.value) {


### PR DESCRIPTION
## What was wrong

The Send module silently spammed Sentry with ~999 `Web3ValidatorError: value at "/0" is required` events every time a user cleared the destination address while a contract token (ERC-20) and a valid amount were still selected. Nothing was visible to the user — these were unhandled promise rejections — but the noise floor in Sentry hid more important errors.

## What changed

`src/modules/send/ModuleSend.vue` — tightened the guard inside `getTxRequestBody` so the debounced gas-estimation watcher no longer encodes `methods.transfer(undefined, amount)` when the address ref is `undefined` (the previous check only rejected the empty string).

## How to test

1. Open the app on Ethereum mainnet (the route is `/`, the Send card).
2. Connect any wallet (Trezor in the original report, but any EVM wallet works).
3. Select an ERC-20 token (e.g. USDT, USDC — any non-ETH token).
4. Type a valid amount.
5. Type a valid destination address — observe the gas fee estimate appears.
6. Clear the destination address field.
7. **Expected:** no errors in the console, no Sentry capture. The "Send" button correctly disables.
8. (Regression check) Re-enter the address and confirm gas fees re-estimate normally and the happy-path Send still works.

## Sentry

https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-B5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted recipient address validation in the send transaction module to ensure proper validation flow during transaction preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->