### PR TITLE
feat: [MEW-1889] add perps connect wallet source tracking

### DIFF
--- a/src/modules/perps/ModulePerpInfo.vue
+++ b/src/modules/perps/ModulePerpInfo.vue
@@ -955,6 +955,7 @@ import { useAppBreakpoints } from '@/composables/useAppBreakpoints'
 import type { ApiOrder, ApiFill, MarketInfoData } from './sdk/types'
 import { useWalletMenuStore } from '@/stores/walletMenuStore'
 import { useAccessStore } from '@/stores/accessStore'
+import { analytics, ConnectWalletEvent } from '@/analytics'
 
 const { setSelectedTradeManageMode, setWalletPanel, setIsOpenSideMenu } =
   useWalletMenuStore()
@@ -977,7 +978,12 @@ import {
   midPrice as computeMidPrice,
 } from './utils/market'
 
-const connectWallet = () => useAccessStore().openAccessDialog()
+const connectWallet = () => {
+  analytics.trackConnectWalletEvent(ConnectWalletEvent.CLICKED, {
+    source: 'Perps_Market_Info',
+  })
+  useAccessStore().openAccessDialog()
+}
 
 const props = defineProps({
   market: {

--- a/src/modules/perps/ModulePerpsTrade.vue
+++ b/src/modules/perps/ModulePerpsTrade.vue
@@ -797,6 +797,7 @@ import { useToastStore } from '@/stores/toastStore'
 import { ToastType } from '@/types/notification'
 import { storeToRefs } from 'pinia'
 import { useI18n } from 'vue-i18n'
+import { analytics, ConnectWalletEvent } from '@/analytics'
 
 const walletStore = useWalletStore()
 const { isWalletConnected, isWatchOnly } = storeToRefs(walletStore)
@@ -819,6 +820,9 @@ const onSwitchToEthereum = () => {
 
 const { setSelectedTradeManageMode } = useWalletMenuStore()
 const connectWallet = () => {
+  analytics.trackConnectWalletEvent(ConnectWalletEvent.CLICKED, {
+    source: 'Perps_Trade',
+  })
   accessStore.openAccessDialog()
 }
 

--- a/src/modules/perps/components/PerpsMainBanner.vue
+++ b/src/modules/perps/components/PerpsMainBanner.vue
@@ -176,6 +176,7 @@ import { useGlobalStore } from '@/stores/globalStore'
 import { useToastStore } from '@/stores/toastStore'
 import { ToastType } from '@/types/notification'
 import { usePerpsAuth } from '../composables/usePerpsAuth'
+import { analytics, ConnectWalletEvent } from '@/analytics'
 
 const walletStore = useWalletStore()
 const { isWalletConnected, isWatchOnly, walletName } = storeToRefs(walletStore)
@@ -194,6 +195,9 @@ const isUnisatWallet = computed(
 )
 
 const onConnectWallet = () => {
+  analytics.trackConnectWalletEvent(ConnectWalletEvent.CLICKED, {
+    source: 'Perps_Main_Banner',
+  })
   accessStore.openAccessDialog()
 }
 

--- a/src/modules/perps/components/PerpsPortfolioSummary.vue
+++ b/src/modules/perps/components/PerpsPortfolioSummary.vue
@@ -46,7 +46,7 @@
           </AppBaseButton>
         </div>
         <div v-else class="flex items-center gap-3 justify-start mt-5 -mx-1">
-          <AppBaseButton @click="$emit('access')" class="w-full" size="medium">
+          <AppBaseButton @click="onConnectWallet" class="w-full" size="medium">
             Connect your wallet
           </AppBaseButton>
         </div>
@@ -128,6 +128,7 @@ import { formatFiatValue } from '@/utils/numberFormatHelper'
 import { useGlobalStore } from '@/stores/globalStore'
 import { useToastStore } from '@/stores/toastStore'
 import { ToastType } from '@/types/notification'
+import { analytics, ConnectWalletEvent } from '@/analytics'
 
 defineProps({
   watchOnly: {
@@ -136,11 +137,18 @@ defineProps({
   },
 })
 
-defineEmits<{
+const emit = defineEmits<{
   deposit: []
   withdraw: []
   access: []
 }>()
+
+const onConnectWallet = () => {
+  analytics.trackConnectWalletEvent(ConnectWalletEvent.CLICKED, {
+    source: 'Perps_Portfolio',
+  })
+  emit('access')
+}
 
 const globalStore = useGlobalStore()
 const { selectedNetwork } = storeToRefs(globalStore)


### PR DESCRIPTION
## What changed

Wires the existing `ConnectWalletEvent.CLICKED` Amplitude event into the four Perps "Connect Wallet" entry points, each tagged with a distinct `source` so PMs can see which Perps surface drove the connection.

| Entry point | `source` value |
|---|---|
| Perps main banner CTA | `Perps_Main_Banner` |
| Portfolio sidebar "Connect your wallet" button | `Perps_Portfolio` |
| Market info "Connect wallet" CTA | `Perps_Market_Info` |
| Trade panel "Connect wallet" CTA | `Perps_Trade` |

No type or schema changes — `ConnectWalletPayload.source` is already a free-form `string`.

## How to test

1. Open the Perps page on the dev server.
2. With **no wallet connected**, click each of the four "Connect wallet" CTAs:
   - Main banner (large CTA in the Perps landing card)
   - Portfolio summary sidebar (watch-only / disconnected state)
   - Market info panel (inside a market detail view)
   - Trade panel (right-hand side, when no wallet is connected)
3. Open the Amplitude debug / network panel and confirm a `Connect Wallet` event fires for each click with the matching `source` value above.

Part of the Perps Amplitude Events workstream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added analytics tracking for wallet connection interactions across Perpetuals modules (Market Info, Trade, Main Banner, and Portfolio sections).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->