### PR TITLE
feat: [MEW-1890] add perps sign in amplitude events

### DIFF
--- a/src/analytics/amplitude.ts
+++ b/src/analytics/amplitude.ts
@@ -50,6 +50,9 @@ import type {
   PerpsSignInEvent,
   PerpsSignInPayload,
   PerpsSignInErrorPayload,
+  PerpsDepositEvent,
+  PerpsDepositPayload,
+  PerpsDepositErrorPayload,
 } from './events'
 import {
   type BalanceBracket,
@@ -626,6 +629,24 @@ export class Analytics {
   readonly trackPerpsSignInErrorEvent = (
     event: typeof PerpsSignInEvent.ERROR,
     payload: PerpsSignInErrorPayload,
+  ): Promise<void> => {
+    return this._track(event, { ...payload })
+  }
+
+  // =============================================================================
+  // PERPS DEPOSIT
+  // =============================================================================
+
+  readonly trackPerpsDepositEvent = (
+    event: PerpsDepositEvent,
+    payload?: PerpsDepositPayload,
+  ): Promise<void> => {
+    return this._track(event, { ...payload })
+  }
+
+  readonly trackPerpsDepositErrorEvent = (
+    event: typeof PerpsDepositEvent.ERROR,
+    payload: PerpsDepositErrorPayload,
   ): Promise<void> => {
     return this._track(event, { ...payload })
   }

--- a/src/analytics/amplitude.ts
+++ b/src/analytics/amplitude.ts
@@ -47,6 +47,9 @@ import type {
   TradeClickSortEvent,
   SwapClickSortEvent,
   ClickSortPayload,
+  PerpsSignInEvent,
+  PerpsSignInPayload,
+  PerpsSignInErrorPayload,
 } from './events'
 import {
   type BalanceBracket,
@@ -605,6 +608,24 @@ export class Analytics {
   readonly trackSwapClickSortEvent = (
     event: typeof SwapClickSortEvent,
     payload: ClickSortPayload,
+  ): Promise<void> => {
+    return this._track(event, { ...payload })
+  }
+
+  // =============================================================================
+  // PERPS SIGN IN
+  // =============================================================================
+
+  readonly trackPerpsSignInEvent = (
+    event: PerpsSignInEvent,
+    payload?: PerpsSignInPayload,
+  ): Promise<void> => {
+    return this._track(event, { ...payload })
+  }
+
+  readonly trackPerpsSignInErrorEvent = (
+    event: typeof PerpsSignInEvent.ERROR,
+    payload: PerpsSignInErrorPayload,
   ): Promise<void> => {
     return this._track(event, { ...payload })
   }

--- a/src/analytics/events.ts
+++ b/src/analytics/events.ts
@@ -196,6 +196,28 @@ export type TradeEventStatusPayload = TradePayloadShared & {
 }
 
 // =============================================================================
+// PERPS SIGN IN
+// =============================================================================
+
+export const PerpsSignInEvent = {
+  CLICKED: 'Perps_Sign_In_Clicked',
+  SUCCESS: 'Perps_Sign_In_Success',
+  ERROR: 'Perps_Sign_In_Error',
+  CANCEL: 'Perps_Sign_In_Cancel',
+} as const
+export type PerpsSignInEvent =
+  (typeof PerpsSignInEvent)[keyof typeof PerpsSignInEvent]
+
+export type PerpsSignInPayload = {
+  source?: string
+}
+
+export type PerpsSignInErrorPayload = PerpsSignInPayload & {
+  errorMessage: string
+  walletType?: string
+}
+
+// =============================================================================
 // DEPOSIT
 // =============================================================================
 

--- a/src/analytics/events.ts
+++ b/src/analytics/events.ts
@@ -227,6 +227,29 @@ export const DepositEvent = {
 export type DepositEvent = (typeof DepositEvent)[keyof typeof DepositEvent]
 
 // =============================================================================
+// PERPS DEPOSIT
+// =============================================================================
+
+export const PerpsDepositEvent = {
+  CLICKED: 'Perps_Deposit_Clicked',
+  SUBMIT: 'Perps_Deposit_Submit',
+  SUCCESS: 'Perps_Deposit_Success',
+  ERROR: 'Perps_Deposit_Error',
+  COMPLETED: 'Perps_Deposit_Completed',
+} as const
+export type PerpsDepositEvent =
+  (typeof PerpsDepositEvent)[keyof typeof PerpsDepositEvent]
+
+export type PerpsDepositPayload = {
+  depositAmount?: string
+  token?: string
+}
+
+export type PerpsDepositErrorPayload = PerpsDepositPayload & {
+  errorMessage: string
+}
+
+// =============================================================================
 // NOTIFICATIONS
 // =============================================================================
 

--- a/src/modules/perps/ModulePerpsTrade.vue
+++ b/src/modules/perps/ModulePerpsTrade.vue
@@ -645,7 +645,7 @@
         >
           <button
             class="bg-primary text-white rounded-full px-6 py-2.5 text-s-14 font-medium hoverOpacity w-full"
-            @click="login"
+            @click="login('Perps_Trade')"
           >
             Sign in to Perps
           </button>

--- a/src/modules/perps/components/PerpsDepositDialog.vue
+++ b/src/modules/perps/components/PerpsDepositDialog.vue
@@ -660,6 +660,7 @@ const sendLiveDeposit = async () => {
 function sendDeposit() {
   const amt = parseFloat(amount.value)
   if (!amt || amt <= 0) return
+  if (!accountId.value) return
   analytics.trackPerpsDepositEvent(PerpsDepositEvent.SUBMIT, {
     depositAmount: amount.value,
     token: 'USDC',

--- a/src/modules/perps/components/PerpsDepositDialog.vue
+++ b/src/modules/perps/components/PerpsDepositDialog.vue
@@ -267,6 +267,7 @@ import { useI18n } from 'vue-i18n'
 import { parseUnits, formatUnits } from 'viem'
 import { type TokenBalance } from '@/mew_api/types'
 import { truncateAddress } from '@/utils/filters'
+import { analytics, PerpsDepositEvent } from '@/analytics'
 
 const { t } = useI18n()
 const SANDBOX_MAX_DEPOSIT = 1000
@@ -293,6 +294,7 @@ watch(isOpen, open => {
     // regardless of whether the dialog is closed.
     return
   }
+  analytics.trackPerpsDepositEvent(PerpsDepositEvent.CLICKED)
   if (selectedChain.value?.name !== 'ETHEREUM') {
     const ethChain = chains.value.find(c => c.name === 'ETHEREUM')
     if (ethChain) {
@@ -520,17 +522,26 @@ const fetchDepositAddress = async () => {
 
 const sendSandboxDeposit = async () => {
   if (!amount.value || !accountId.value) return
+  const depositAmount = amount.value
   sending.value = true
   error.value = null
   try {
     await perpsClient.sandboxDeposit({
-      amount: parseFloat(amount.value).toFixed(2),
+      amount: parseFloat(depositAmount).toFixed(2),
       symbol: 'USDC',
       deposit_destination: { id: accountId.value, wallet: 'margin' },
       chain_id: 'eth-sepolia',
     })
     triggerRefresh()
-    perpsToasts.toastDepositComplete(amount.value, 'USDC')
+    analytics.trackPerpsDepositEvent(PerpsDepositEvent.SUCCESS, {
+      depositAmount,
+      token: 'USDC',
+    })
+    analytics.trackPerpsDepositEvent(PerpsDepositEvent.COMPLETED, {
+      depositAmount,
+      token: 'USDC',
+    })
+    perpsToasts.toastDepositComplete(depositAmount, 'USDC')
     clearAmount()
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : String(e ?? '')
@@ -539,6 +550,11 @@ const sendSandboxDeposit = async () => {
       perpsToasts.toastDepositCanceled()
     } else {
       error.value = msg || 'Sandbox deposit failed'
+      analytics.trackPerpsDepositErrorEvent(PerpsDepositEvent.ERROR, {
+        depositAmount,
+        token: 'USDC',
+        errorMessage: msg,
+      })
       perpsToasts.toastFailedToInitiateDeposit()
     }
   } finally {
@@ -554,6 +570,7 @@ const sendLiveDeposit = async () => {
     !usdcBalance.value
   )
     return
+  const depositAmount = amount.value
   sending.value = true
   error.value = null
   try {
@@ -611,6 +628,14 @@ const sendLiveDeposit = async () => {
       throw new Error('Transaction was not broadcast')
     }
     triggerRefresh()
+    analytics.trackPerpsDepositEvent(PerpsDepositEvent.SUCCESS, {
+      depositAmount,
+      token: 'USDC',
+    })
+    analytics.trackPerpsDepositEvent(PerpsDepositEvent.COMPLETED, {
+      depositAmount,
+      token: 'USDC',
+    })
     perpsToasts.toastDepositInitiated()
     clearAmount()
   } catch (e: unknown) {
@@ -620,6 +645,11 @@ const sendLiveDeposit = async () => {
       perpsToasts.toastDepositCanceled()
     } else {
       error.value = msg || 'Transaction failed'
+      analytics.trackPerpsDepositErrorEvent(PerpsDepositEvent.ERROR, {
+        depositAmount,
+        token: 'USDC',
+        errorMessage: msg,
+      })
       perpsToasts.toastFailedToCreditAccount()
     }
   } finally {
@@ -630,6 +660,10 @@ const sendLiveDeposit = async () => {
 function sendDeposit() {
   const amt = parseFloat(amount.value)
   if (!amt || amt <= 0) return
+  analytics.trackPerpsDepositEvent(PerpsDepositEvent.SUBMIT, {
+    depositAmount: amount.value,
+    token: 'USDC',
+  })
   if (showIsLive.value) {
     sendLiveDeposit()
   } else {

--- a/src/modules/perps/components/PerpsMainBanner.vue
+++ b/src/modules/perps/components/PerpsMainBanner.vue
@@ -136,7 +136,7 @@
           <app-base-button
             class="w-full lg:w-auto lg:px-10"
             :is-loading="isAuthenticating"
-            @click="login"
+            @click="login('Perps_Main_Banner')"
             @mouseenter="isHoveringCta = true"
             @mouseleave="isHoveringCta = false"
           >

--- a/src/modules/perps/composables/usePerpsAuth.ts
+++ b/src/modules/perps/composables/usePerpsAuth.ts
@@ -9,6 +9,7 @@ import { WalletType } from '@/providers/types'
 import { perpsWs } from '../sdk/ws'
 import { ensurePerpsWsLifecycle } from './usePerpsWsLifecycle'
 import { analytics, PerpsSignInEvent } from '@/analytics'
+import { isUserRejectionError } from '@/utils/walletUtils'
 
 const STORAGE_KEY_TOKEN = 'perps_auth_token'
 const STORAGE_KEY_ACCOUNT = 'perps_auth_account'
@@ -206,7 +207,7 @@ export function usePerpsAuth() {
       analytics.trackPerpsSignInEvent(PerpsSignInEvent.SUCCESS, { source })
     } catch (e) {
       const errorMessage = e instanceof Error ? e.message : 'Authentication failed'
-      if (errorMessage === 'cancelled') {
+      if (isUserRejectionError(e)) {
         analytics.trackPerpsSignInEvent(PerpsSignInEvent.CANCEL, { source })
       } else {
         authError.value = errorMessage

--- a/src/modules/perps/composables/usePerpsAuth.ts
+++ b/src/modules/perps/composables/usePerpsAuth.ts
@@ -8,6 +8,7 @@ import { decrypt, encrypt } from '@/utils/crypto'
 import { WalletType } from '@/providers/types'
 import { perpsWs } from '../sdk/ws'
 import { ensurePerpsWsLifecycle } from './usePerpsWsLifecycle'
+import { analytics, PerpsSignInEvent } from '@/analytics'
 
 const STORAGE_KEY_TOKEN = 'perps_auth_token'
 const STORAGE_KEY_ACCOUNT = 'perps_auth_account'
@@ -141,14 +142,16 @@ export function usePerpsAuth() {
     )
   }
 
-  async function login() {
+  async function login(source?: string) {
     if (_authRestored || isAuthenticating.value || isWaitingForConfirm.value) return
     if (!wallet.value || !isWalletConnected.value) {
       authError.value = 'Wallet not connected'
       return
     }
+    analytics.trackPerpsSignInEvent(PerpsSignInEvent.CLICKED, { source })
     isAuthenticating.value = true
     authError.value = null
+    let walletTypeStr: string | undefined
     try {
       const address = await wallet.value.getAddress()
       const challenge = await perpsClient.getLoginChallenge({
@@ -156,6 +159,7 @@ export function usePerpsAuth() {
         chainId: '1',
       })
       const walletType = wallet.value.getWalletType()
+      walletTypeStr = walletType
       const isInjected = walletType === WalletType.WAGMI || walletType === WalletType.INJECTED
 
       if (!isInjected) {
@@ -199,9 +203,18 @@ export function usePerpsAuth() {
         termsVersion: 1,
         privacyVersion: 1,
       })
+      analytics.trackPerpsSignInEvent(PerpsSignInEvent.SUCCESS, { source })
     } catch (e) {
-      if ((e as Error)?.message !== 'cancelled') {
-        authError.value = e instanceof Error ? e.message : 'Authentication failed'
+      const errorMessage = e instanceof Error ? e.message : 'Authentication failed'
+      if (errorMessage === 'cancelled') {
+        analytics.trackPerpsSignInEvent(PerpsSignInEvent.CANCEL, { source })
+      } else {
+        authError.value = errorMessage
+        analytics.trackPerpsSignInErrorEvent(PerpsSignInEvent.ERROR, {
+          source,
+          errorMessage,
+          walletType: walletTypeStr,
+        })
       }
     } finally {
       showSigningPrompt.value = false


### PR DESCRIPTION
## What changed

Introduces `PerpsSignInEvent` with four states for the Perps signing flow:

| Event | When |
|---|---|
| `Perps_Sign_In_Clicked` | User clicks Sign In CTA |
| `Perps_Sign_In_Success` | Login completes (token stored + agreement accepted) |
| `Perps_Sign_In_Error`   | Login fails with any non-cancel error |
| `Perps_Sign_In_Cancel`  | User dismisses the signing prompt |

`login()` now accepts a `source` argument carried through all four events so PMs can attribute funnel drop-off by entry point.

### Sources

| Surface | `source` |
|---|---|
| Main banner "Sign in" CTA | `Perps_Main_Banner` |
| Trade panel "Sign in to Perps" CTA | `Perps_Trade` |

### Error payload

`Perps_Sign_In_Error` carries `errorMessage` and `walletType` to help debug provider-specific failures.

## How to test

1. Open the Perps page with a wallet connected (not yet signed in).
2. Click "Sign in" — observe `Perps_Sign_In_Clicked { source: 'Perps_Main_Banner' }` then either:
   - approve the signature → `Perps_Sign_In_Success`
   - reject in the hardware-wallet prompt → `Perps_Sign_In_Cancel`
   - fail any other way → `Perps_Sign_In_Error { errorMessage, walletType }`
3. Repeat from the Trade panel CTA — confirm `source: 'Perps_Trade'` on all four events.

## Stacked on

Based on `feat/v7-MEW-1889-perps-connect-wallet-events` (#5531). Will be rebased onto `feat/v7-o-perps` after the parent merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Perps deposit analytics events and tracking alongside Perps sign-in events.

* **Improvements**
  * Sign-in flows now record click, success, cancel, and error outcomes with explicit source identifiers and wallet type where relevant.
  * Deposit flow now records clicked, submit, success, completed, and error events and captures deposit amount for reporting.
* **Behavior**
  * Sign-in and deposit flows avoid reporting canceled attempts as errors; submit is blocked when account is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->