### PR TITLE
feat: [MEW-1891] add Perps Deposit Amplitude events

### DIFF
--- a/src/analytics/amplitude.ts
+++ b/src/analytics/amplitude.ts
@@ -50,6 +50,9 @@ import type {
   PerpsSignInEvent,
   PerpsSignInPayload,
   PerpsSignInErrorPayload,
+  PerpsDepositEvent,
+  PerpsDepositPayload,
+  PerpsDepositErrorPayload,
 } from './events'
 import {
   type BalanceBracket,
@@ -626,6 +629,24 @@ export class Analytics {
   readonly trackPerpsSignInErrorEvent = (
     event: typeof PerpsSignInEvent.ERROR,
     payload: PerpsSignInErrorPayload,
+  ): Promise<void> => {
+    return this._track(event, { ...payload })
+  }
+
+  // =============================================================================
+  // PERPS DEPOSIT
+  // =============================================================================
+
+  readonly trackPerpsDepositEvent = (
+    event: PerpsDepositEvent,
+    payload?: PerpsDepositPayload,
+  ): Promise<void> => {
+    return this._track(event, { ...payload })
+  }
+
+  readonly trackPerpsDepositErrorEvent = (
+    event: typeof PerpsDepositEvent.ERROR,
+    payload: PerpsDepositErrorPayload,
   ): Promise<void> => {
     return this._track(event, { ...payload })
   }

--- a/src/analytics/events.ts
+++ b/src/analytics/events.ts
@@ -227,6 +227,29 @@ export const DepositEvent = {
 export type DepositEvent = (typeof DepositEvent)[keyof typeof DepositEvent]
 
 // =============================================================================
+// PERPS DEPOSIT
+// =============================================================================
+
+export const PerpsDepositEvent = {
+  CLICKED: 'Perps_Deposit_Clicked',
+  SUBMIT: 'Perps_Deposit_Submit',
+  SUCCESS: 'Perps_Deposit_Success',
+  ERROR: 'Perps_Deposit_Error',
+  COMPLETED: 'Perps_Deposit_Completed',
+} as const
+export type PerpsDepositEvent =
+  (typeof PerpsDepositEvent)[keyof typeof PerpsDepositEvent]
+
+export type PerpsDepositPayload = {
+  depositAmount?: string
+  token?: string
+}
+
+export type PerpsDepositErrorPayload = PerpsDepositPayload & {
+  errorMessage: string
+}
+
+// =============================================================================
 // NOTIFICATIONS
 // =============================================================================
 

--- a/src/modules/perps/components/PerpsDepositDialog.vue
+++ b/src/modules/perps/components/PerpsDepositDialog.vue
@@ -660,6 +660,7 @@ const sendLiveDeposit = async () => {
 function sendDeposit() {
   const amt = parseFloat(amount.value)
   if (!amt || amt <= 0) return
+  if (!accountId.value) return
   analytics.trackPerpsDepositEvent(PerpsDepositEvent.SUBMIT, {
     depositAmount: amount.value,
     token: 'USDC',

--- a/src/modules/perps/components/PerpsDepositDialog.vue
+++ b/src/modules/perps/components/PerpsDepositDialog.vue
@@ -267,6 +267,7 @@ import { useI18n } from 'vue-i18n'
 import { parseUnits, formatUnits } from 'viem'
 import { type TokenBalance } from '@/mew_api/types'
 import { truncateAddress } from '@/utils/filters'
+import { analytics, PerpsDepositEvent } from '@/analytics'
 
 const { t } = useI18n()
 const SANDBOX_MAX_DEPOSIT = 1000
@@ -293,6 +294,7 @@ watch(isOpen, open => {
     // regardless of whether the dialog is closed.
     return
   }
+  analytics.trackPerpsDepositEvent(PerpsDepositEvent.CLICKED)
   if (selectedChain.value?.name !== 'ETHEREUM') {
     const ethChain = chains.value.find(c => c.name === 'ETHEREUM')
     if (ethChain) {
@@ -520,17 +522,26 @@ const fetchDepositAddress = async () => {
 
 const sendSandboxDeposit = async () => {
   if (!amount.value || !accountId.value) return
+  const depositAmount = amount.value
   sending.value = true
   error.value = null
   try {
     await perpsClient.sandboxDeposit({
-      amount: parseFloat(amount.value).toFixed(2),
+      amount: parseFloat(depositAmount).toFixed(2),
       symbol: 'USDC',
       deposit_destination: { id: accountId.value, wallet: 'margin' },
       chain_id: 'eth-sepolia',
     })
     triggerRefresh()
-    perpsToasts.toastDepositComplete(amount.value, 'USDC')
+    analytics.trackPerpsDepositEvent(PerpsDepositEvent.SUCCESS, {
+      depositAmount,
+      token: 'USDC',
+    })
+    analytics.trackPerpsDepositEvent(PerpsDepositEvent.COMPLETED, {
+      depositAmount,
+      token: 'USDC',
+    })
+    perpsToasts.toastDepositComplete(depositAmount, 'USDC')
     clearAmount()
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : String(e ?? '')
@@ -539,6 +550,11 @@ const sendSandboxDeposit = async () => {
       perpsToasts.toastDepositCanceled()
     } else {
       error.value = msg || 'Sandbox deposit failed'
+      analytics.trackPerpsDepositErrorEvent(PerpsDepositEvent.ERROR, {
+        depositAmount,
+        token: 'USDC',
+        errorMessage: msg,
+      })
       perpsToasts.toastFailedToInitiateDeposit()
     }
   } finally {
@@ -554,6 +570,7 @@ const sendLiveDeposit = async () => {
     !usdcBalance.value
   )
     return
+  const depositAmount = amount.value
   sending.value = true
   error.value = null
   try {
@@ -611,6 +628,14 @@ const sendLiveDeposit = async () => {
       throw new Error('Transaction was not broadcast')
     }
     triggerRefresh()
+    analytics.trackPerpsDepositEvent(PerpsDepositEvent.SUCCESS, {
+      depositAmount,
+      token: 'USDC',
+    })
+    analytics.trackPerpsDepositEvent(PerpsDepositEvent.COMPLETED, {
+      depositAmount,
+      token: 'USDC',
+    })
     perpsToasts.toastDepositInitiated()
     clearAmount()
   } catch (e: unknown) {
@@ -620,6 +645,11 @@ const sendLiveDeposit = async () => {
       perpsToasts.toastDepositCanceled()
     } else {
       error.value = msg || 'Transaction failed'
+      analytics.trackPerpsDepositErrorEvent(PerpsDepositEvent.ERROR, {
+        depositAmount,
+        token: 'USDC',
+        errorMessage: msg,
+      })
       perpsToasts.toastFailedToCreditAccount()
     }
   } finally {
@@ -630,6 +660,10 @@ const sendLiveDeposit = async () => {
 function sendDeposit() {
   const amt = parseFloat(amount.value)
   if (!amt || amt <= 0) return
+  analytics.trackPerpsDepositEvent(PerpsDepositEvent.SUBMIT, {
+    depositAmount: amount.value,
+    token: 'USDC',
+  })
   if (showIsLive.value) {
     sendLiveDeposit()
   } else {


### PR DESCRIPTION
## What was missing

We had no Amplitude visibility into the perps deposit funnel — we couldn't tell how many users opened the deposit dialog, how many actually submitted a deposit, and where deposits failed.

## What changed

Wires five Amplitude events through the deposit dialog (sandbox + live paths):

- `Perps_Deposit_Clicked` — fires when the dialog opens.
- `Perps_Deposit_Submit` — fires when the user clicks **Deposit**, with `depositAmount` and `token`.
- `Perps_Deposit_Success` — fires on successful sandbox response or successful live broadcast.
- `Perps_Deposit_Completed` — fires alongside Success once the deposit is credited (sandbox) or initiated (live).
- `Perps_Deposit_Error` — fires on non-user-cancel failures with `errorMessage` and the attempted `depositAmount` / `token`.

User-cancel rejections (wallet prompt dismissed) are intentionally not tracked as errors — same logic that drives the "Deposit Canceled" toast.

## How to test

1. Connect a wallet, sign in to perps.
2. Open the deposit dialog — confirm `Perps_Deposit_Clicked` fires in Amplitude.
3. Enter an amount and click Deposit — confirm `Perps_Deposit_Submit` fires with the entered amount.
4. On success: confirm `Perps_Deposit_Success` and `Perps_Deposit_Completed` both fire.
5. On a forced failure (e.g. flip to live, deposit with insufficient balance or trigger a wallet error): confirm `Perps_Deposit_Error` fires with the error message.
6. On user-cancel (reject in wallet): confirm NO error event fires.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved analytics instrumentation for perpetuals deposit flows to enhance monitoring and error tracking across user interactions and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->