### PR TITLE
feat: [MEW-1892] add Perps Trade Order amplitude events

### DIFF
--- a/src/analytics/amplitude.ts
+++ b/src/analytics/amplitude.ts
@@ -53,6 +53,9 @@ import type {
   PerpsDepositEvent,
   PerpsDepositPayload,
   PerpsDepositErrorPayload,
+  PerpsTradeOrderEvent,
+  PerpsTradeOrderPayload,
+  PerpsTradeOrderFailPayload,
 } from './events'
 import {
   type BalanceBracket,
@@ -647,6 +650,24 @@ export class Analytics {
   readonly trackPerpsDepositErrorEvent = (
     event: typeof PerpsDepositEvent.ERROR,
     payload: PerpsDepositErrorPayload,
+  ): Promise<void> => {
+    return this._track(event, { ...payload })
+  }
+
+  // =============================================================================
+  // PERPS TRADE ORDER
+  // =============================================================================
+
+  readonly trackPerpsTradeOrderEvent = (
+    event: PerpsTradeOrderEvent,
+    payload?: PerpsTradeOrderPayload,
+  ): Promise<void> => {
+    return this._track(event, { ...payload })
+  }
+
+  readonly trackPerpsTradeOrderFailEvent = (
+    event: typeof PerpsTradeOrderEvent.SUBMIT_FAIL,
+    payload: PerpsTradeOrderFailPayload,
   ): Promise<void> => {
     return this._track(event, { ...payload })
   }

--- a/src/analytics/amplitude.ts
+++ b/src/analytics/amplitude.ts
@@ -56,6 +56,8 @@ import type {
   PerpsTradeOrderEvent,
   PerpsTradeOrderPayload,
   PerpsTradeOrderFailPayload,
+  PerpsTpSlEvent,
+  PerpsTpSlSavePayload,
 } from './events'
 import {
   type BalanceBracket,
@@ -668,6 +670,17 @@ export class Analytics {
   readonly trackPerpsTradeOrderFailEvent = (
     event: typeof PerpsTradeOrderEvent.SUBMIT_FAIL,
     payload: PerpsTradeOrderFailPayload,
+  ): Promise<void> => {
+    return this._track(event, { ...payload })
+  }
+
+  // =============================================================================
+  // PERPS TP/SL
+  // =============================================================================
+
+  readonly trackPerpsTpSlEvent = (
+    event: PerpsTpSlEvent,
+    payload?: PerpsTpSlSavePayload,
   ): Promise<void> => {
     return this._track(event, { ...payload })
   }

--- a/src/analytics/events.ts
+++ b/src/analytics/events.ts
@@ -286,6 +286,27 @@ export type PerpsTradeOrderFailPayload = PerpsTradeOrderPayload & {
 }
 
 // =============================================================================
+// PERPS TP/SL
+// =============================================================================
+
+export const PerpsTpSlEvent = {
+  CLICKED: 'Perps_Tp_Sl_Clicked',
+  CLICKED_ADD_TP: 'Perps_Tp_Sl_Clicked_Add_Tp',
+  CLICKED_ADD_SL: 'Perps_Tp_Sl_Clicked_Add_Sl',
+  CLICKED_SAVE: 'Perps_Tp_Sl_Clicked_Save',
+  CLICKED_CANCEL: 'Perps_Tp_Sl_Clicked_Cancel',
+} as const
+export type PerpsTpSlEvent =
+  (typeof PerpsTpSlEvent)[keyof typeof PerpsTpSlEvent]
+
+export type PerpsTpSlSavePayload = {
+  tpAmount?: string
+  tpPercentageDiffFromCurrent?: string
+  slAmount?: string
+  slPercentageDiffFromCurrent?: string
+}
+
+// =============================================================================
 // NOTIFICATIONS
 // =============================================================================
 

--- a/src/analytics/events.ts
+++ b/src/analytics/events.ts
@@ -250,6 +250,42 @@ export type PerpsDepositErrorPayload = PerpsDepositPayload & {
 }
 
 // =============================================================================
+// PERPS TRADE ORDER
+// =============================================================================
+
+export const PerpsTradeOrderEvent = {
+  CLICKED_PREVIEW: 'Perps_Trade_Order_Clicked_Preview',
+  CLICKED_SUBMIT: 'Perps_Trade_Order_Clicked_Submit',
+  SUBMIT_SUCCESS: 'Perps_Trade_Order_Submit_Success',
+  SUBMIT_FAIL: 'Perps_Trade_Order_Submit_Fail',
+  CLICKED_CANCEL: 'Perps_Trade_Order_Clicked_Cancel',
+  FILLED: 'Perps_Trade_Order_Filled',
+} as const
+export type PerpsTradeOrderEvent =
+  (typeof PerpsTradeOrderEvent)[keyof typeof PerpsTradeOrderEvent]
+
+export type PerpsTradeOrderPayload = {
+  market?: string
+  currentPrice?: number
+  orderSide?: 'buy' | 'sell'
+  orderType?: 'market' | 'limit'
+  leverage?: number
+  previousLeverage?: number
+  maxLeverage?: number
+  margin?: string
+  estimatedLiquidation?: number | null
+  takeProfit?: number | null
+  stopLoss?: number | null
+  marginRatio?: number | null
+  feeRate?: string
+}
+
+export type PerpsTradeOrderFailPayload = PerpsTradeOrderPayload & {
+  errorMessage: string
+  higherThanReasonablePrice?: boolean
+}
+
+// =============================================================================
 // NOTIFICATIONS
 // =============================================================================
 
@@ -301,7 +337,7 @@ export type ClickTokenTradePayload = {
 export const ClickMainMenuEvent = 'Clicked_Wallet_Menu' as const
 
 export type ClickMainMenuPayload = {
-  button: 'trade' | 'swap' | 'bridge' | 'buy' | 'sell' | 'send'
+  button: 'trade' | 'swap' | 'bridge' | 'buy' | 'sell' | 'send' | 'perps'
 }
 
 // =============================================================================

--- a/src/components/core_layouts/LayoutWallet.vue
+++ b/src/components/core_layouts/LayoutWallet.vue
@@ -326,7 +326,7 @@ const openPanel = (panel: WalletPanel) => {
   }
   walletMenu.setWalletPanel(panel)
   analytics.trackClickMainMenuEvent(ClickMainMenuEvent, {
-    button: panel as any,
+    button: panel,
   })
 }
 

--- a/src/modules/perps/components/PerpsTakeProfitStopLossDialog.vue
+++ b/src/modules/perps/components/PerpsTakeProfitStopLossDialog.vue
@@ -199,6 +199,7 @@ import PerpsAmount from './PerpsAmount.vue'
 import { formatUsd } from '../utils/formatters'
 import { getLogoUrl } from '../utils/market'
 import { PlusCircleIcon } from '@heroicons/vue/24/solid'
+import { analytics, PerpsTpSlEvent } from '@/analytics'
 
 const isOpen = defineModel<boolean>('isOpen', { default: false })
 
@@ -247,6 +248,7 @@ const setTempTakeProfitPrice = () => {
     emit('setTakeProfitPct', 30)
   }
   hasTakeProfit.value = true
+  void analytics.trackPerpsTpSlEvent(PerpsTpSlEvent.CLICKED_ADD_TP)
 }
 
 const setTempStopLossPrice = () => {
@@ -254,6 +256,7 @@ const setTempStopLossPrice = () => {
     emit('setStopLossPct', 3)
   }
   hasStopLoss.value = true
+  void analytics.trackPerpsTpSlEvent(PerpsTpSlEvent.CLICKED_ADD_SL)
 }
 
 const removeTakeProfit = () => {

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -1,6 +1,11 @@
 import { ref, computed, watch, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useWalletMenuStore } from '@/stores/walletMenuStore'
+import { analytics, PerpsTradeOrderEvent } from '@/analytics'
+import type {
+  PerpsTradeOrderPayload,
+  PerpsTradeOrderFailPayload,
+} from '@/analytics'
 import type { MaxOrderSizeResult } from '../sdk/types'
 import { perpsClient } from '../configs'
 import { usePerpsAuth, usePerpsBalance } from './usePerpsAuth'
@@ -986,10 +991,53 @@ export function usePerpsTradeForm() {
   }
 
   // ── Confirm / submit ──────────────────────────────────────
+  const activeContract = computed(() =>
+    contracts.value.find(c => c.market === fullMarketName.value),
+  )
+
+  const isMakerOrder = computed(() => {
+    if (orderType.value !== 'limit') return false
+    const limit = parseFloat(limitPrice.value || '')
+    if (!Number.isFinite(limit) || !currentPrice.value) return false
+    return orderSide.value === 'buy'
+      ? limit < currentPrice.value
+      : limit > currentPrice.value
+  })
+
+  function buildTradeOrderPayload(): PerpsTradeOrderPayload {
+    const priorLeverage = activePosition.value?.leverage
+      ? parseInt(activePosition.value.leverage)
+      : undefined
+    const feeRate = isMakerOrder.value
+      ? activeContract.value?.makerFee
+      : activeContract.value?.takerFee
+    return {
+      market: fullMarketName.value,
+      currentPrice: currentPrice.value,
+      orderSide: orderSide.value,
+      orderType: orderType.value,
+      leverage: leverage.value,
+      previousLeverage: priorLeverage,
+      maxLeverage: marketMaxLeverage.value,
+      margin: inputAmount.value,
+      estimatedLiquidation: estimatedLiquidation.value || null,
+      takeProfit: takeProfitPrice.value,
+      stopLoss: stopLossPrice.value,
+      marginRatio: newMarginRatio.value,
+      feeRate,
+    }
+  }
+
+  let justSubmittedOrder = false
+
   function showConfirmation() {
     if (submitDisabled.value) return
     orderError.value = ''
     showConfirmModal.value = true
+    void analytics.trackPerpsTradeOrderEvent(
+      PerpsTradeOrderEvent.CLICKED_PREVIEW,
+      buildTradeOrderPayload(),
+    )
   }
 
   function showCloseConfirmation() {
@@ -1000,6 +1048,11 @@ export function usePerpsTradeForm() {
 
   async function confirmAndSubmitOrder() {
     if (submitDisabled.value) return
+    const tradePayload = buildTradeOrderPayload()
+    void analytics.trackPerpsTradeOrderEvent(
+      PerpsTradeOrderEvent.CLICKED_SUBMIT,
+      tradePayload,
+    )
     isSubmitting.value = true
     // Snapshot prior SL/TP state BEFORE the SDK call so "prior" reflects what
     // the user was about to change. Reading it afterward would see the new
@@ -1054,6 +1107,10 @@ export function usePerpsTradeForm() {
         }
       }
       await perpsClient.createOrder(orderParams as any)
+      void analytics.trackPerpsTradeOrderEvent(
+        PerpsTradeOrderEvent.SUBMIT_SUCCESS,
+        tradePayload,
+      )
       // Fire Order Placed + SL/TP toasts only after the SDK call succeeded.
       const marketMatch = markets.value.find(
         m => m.market === fullMarketName.value,
@@ -1079,6 +1136,7 @@ export function usePerpsTradeForm() {
         if (hadPriorTakeProfit) perpsToasts.toastTakeProfitModified(args)
         else perpsToasts.toastTakeProfitAdded(args)
       }
+      justSubmittedOrder = true
       showConfirmModal.value = false
       inputAmount.value = ''
       sliderValue.value = 0
@@ -1107,12 +1165,37 @@ export function usePerpsTradeForm() {
           perpsToasts.toastTakeProfitInvalid()
         }
       }
-      orderError.value =
+      const errorMessage =
         error?.message || error?.toString() || 'Order failed. Please try again.'
+      orderError.value = errorMessage
+      const failPayload: PerpsTradeOrderFailPayload = {
+        ...tradePayload,
+        errorMessage,
+        higherThanReasonablePrice: limitPriceOutOfTolerance.value,
+      }
+      void analytics.trackPerpsTradeOrderFailEvent(
+        PerpsTradeOrderEvent.SUBMIT_FAIL,
+        failPayload,
+      )
     } finally {
       isSubmitting.value = false
     }
   }
+
+  // Track CANCEL when the confirm modal closes without a successful submit
+  // (e.g. user hit Cancel or closed the dialog).
+  watch(showConfirmModal, (open, prev) => {
+    if (prev && !open) {
+      if (justSubmittedOrder) {
+        justSubmittedOrder = false
+        return
+      }
+      void analytics.trackPerpsTradeOrderEvent(
+        PerpsTradeOrderEvent.CLICKED_CANCEL,
+        buildTradeOrderPayload(),
+      )
+    }
+  })
 
   // NOTE(perps-toasts): Dedicated remove-stop-loss / remove-take-profit flows
   // are not yet wired in this composable. The SDK client today exposes

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -1,10 +1,11 @@
 import { ref, computed, watch, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useWalletMenuStore } from '@/stores/walletMenuStore'
-import { analytics, PerpsTradeOrderEvent } from '@/analytics'
+import { analytics, PerpsTradeOrderEvent, PerpsTpSlEvent } from '@/analytics'
 import type {
   PerpsTradeOrderPayload,
   PerpsTradeOrderFailPayload,
+  PerpsTpSlSavePayload,
 } from '@/analytics'
 import type { MaxOrderSizeResult } from '../sdk/types'
 import { perpsClient } from '../configs'
@@ -919,6 +920,7 @@ export function usePerpsTradeForm() {
     // Default to +30% TP and -3% SL if nothing is set yet
 
     showAutoCloseModal.value = true
+    void analytics.trackPerpsTpSlEvent(PerpsTpSlEvent.CLICKED)
   }
 
   function setTakeProfitPct(pct: number) {
@@ -970,11 +972,41 @@ export function usePerpsTradeForm() {
     { flush: 'sync' },
   )
 
+  let justSavedAutoClose = false
+
   function confirmAutoClose() {
-    takeProfitPrice.value = tempTakeProfitPrice.value
-    stopLossPrice.value = tempStopLossPrice.value
+    const tp = tempTakeProfitPrice.value
+    const sl = tempStopLossPrice.value
+    const pricePct = (target: number) => {
+      if (!currentPrice.value) return undefined
+      const diff = ((target - currentPrice.value) / currentPrice.value) * 100
+      return diff.toFixed(2)
+    }
+    const savePayload: PerpsTpSlSavePayload = {
+      tpAmount: tp !== null ? String(tp) : undefined,
+      tpPercentageDiffFromCurrent: tp !== null ? pricePct(tp) : undefined,
+      slAmount: sl !== null ? String(sl) : undefined,
+      slPercentageDiffFromCurrent: sl !== null ? pricePct(sl) : undefined,
+    }
+    void analytics.trackPerpsTpSlEvent(
+      PerpsTpSlEvent.CLICKED_SAVE,
+      savePayload,
+    )
+    takeProfitPrice.value = tp
+    stopLossPrice.value = sl
+    justSavedAutoClose = true
     showAutoCloseModal.value = false
   }
+
+  watch(showAutoCloseModal, (open, prev) => {
+    if (prev && !open) {
+      if (justSavedAutoClose) {
+        justSavedAutoClose = false
+        return
+      }
+      void analytics.trackPerpsTpSlEvent(PerpsTpSlEvent.CLICKED_CANCEL)
+    }
+  })
 
   const hasAutoCloseEdits = computed(
     () =>


### PR DESCRIPTION
## Summary

Adds Amplitude analytics events for the Perps Trade Order flow plus the main-menu Perps button click.

### What changed

- New `PerpsTradeOrderEvent` const + payload/fail-payload types in `src/analytics/events.ts`
- New `trackPerpsTradeOrderEvent` / `trackPerpsTradeOrderFailEvent` methods on the Analytics class
- `ClickMainMenuPayload.button` union extended with `'perps'`; removed the `as any` cast in `LayoutWallet.vue`
- Wired 5 events in `usePerpsTradeForm.ts`:
  - **CLICKED_PREVIEW** in `showConfirmation()` when the confirm modal opens
  - **CLICKED_SUBMIT** at the top of `confirmAndSubmitOrder()` once submit is permitted
  - **SUBMIT_SUCCESS** after `perpsClient.createOrder` resolves
  - **SUBMIT_FAIL** in the catch block, with `errorMessage` and `higherThanReasonablePrice` (driven by `limitPriceOutOfTolerance`)
  - **CLICKED_CANCEL** via a watcher on `showConfirmModal` false-transition (gated by a `justSubmittedOrder` flag so success doesn't fire CANCEL)

### How to test

1. Open the Perps trade panel from the main menu — `Clicked_Wallet_Menu` with `button: "perps"` fires.
2. Set up a market or limit order with valid margin/leverage and click Preview — `Perps_Trade_Order_Clicked_Preview` fires with full payload.
3. Cancel the confirmation modal — `Perps_Trade_Order_Clicked_Cancel` fires.
4. Re-open and submit a valid order — `Perps_Trade_Order_Clicked_Submit` then `Perps_Trade_Order_Submit_Success` fire.
5. Force a failure (e.g. invalid SL/TP, oversized order) and submit — `Perps_Trade_Order_Submit_Fail` fires with `errorMessage`.

Sentry: n/a (analytics-only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced analytics for perps trading: tracks previews, submissions, successes, failures, and cancellations.
  * Added analytics for TP/SL editor: tracks opening, adding TP/SL, saving, and cancel actions.
  * More detailed failure context captured for perps submit errors.
  * Main menu interactions now include the perps option for tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->