### PR TITLE
feat: [MEW-1893] add Perps TP/SL amplitude events

### DIFF
--- a/src/analytics/amplitude.ts
+++ b/src/analytics/amplitude.ts
@@ -56,6 +56,8 @@ import type {
   PerpsTradeOrderEvent,
   PerpsTradeOrderPayload,
   PerpsTradeOrderFailPayload,
+  PerpsTpSlEvent,
+  PerpsTpSlSavePayload,
 } from './events'
 import {
   type BalanceBracket,
@@ -668,6 +670,17 @@ export class Analytics {
   readonly trackPerpsTradeOrderFailEvent = (
     event: typeof PerpsTradeOrderEvent.SUBMIT_FAIL,
     payload: PerpsTradeOrderFailPayload,
+  ): Promise<void> => {
+    return this._track(event, { ...payload })
+  }
+
+  // =============================================================================
+  // PERPS TP/SL
+  // =============================================================================
+
+  readonly trackPerpsTpSlEvent = (
+    event: PerpsTpSlEvent,
+    payload?: PerpsTpSlSavePayload,
   ): Promise<void> => {
     return this._track(event, { ...payload })
   }

--- a/src/analytics/events.ts
+++ b/src/analytics/events.ts
@@ -286,6 +286,27 @@ export type PerpsTradeOrderFailPayload = PerpsTradeOrderPayload & {
 }
 
 // =============================================================================
+// PERPS TP/SL
+// =============================================================================
+
+export const PerpsTpSlEvent = {
+  CLICKED: 'Perps_Tp_Sl_Clicked',
+  CLICKED_ADD_TP: 'Perps_Tp_Sl_Clicked_Add_Tp',
+  CLICKED_ADD_SL: 'Perps_Tp_Sl_Clicked_Add_Sl',
+  CLICKED_SAVE: 'Perps_Tp_Sl_Clicked_Save',
+  CLICKED_CANCEL: 'Perps_Tp_Sl_Clicked_Cancel',
+} as const
+export type PerpsTpSlEvent =
+  (typeof PerpsTpSlEvent)[keyof typeof PerpsTpSlEvent]
+
+export type PerpsTpSlSavePayload = {
+  tpAmount?: string
+  tpPercentageDiffFromCurrent?: string
+  slAmount?: string
+  slPercentageDiffFromCurrent?: string
+}
+
+// =============================================================================
 // NOTIFICATIONS
 // =============================================================================
 

--- a/src/modules/perps/components/PerpsTakeProfitStopLossDialog.vue
+++ b/src/modules/perps/components/PerpsTakeProfitStopLossDialog.vue
@@ -199,6 +199,7 @@ import PerpsAmount from './PerpsAmount.vue'
 import { formatUsd } from '../utils/formatters'
 import { getLogoUrl } from '../utils/market'
 import { PlusCircleIcon } from '@heroicons/vue/24/solid'
+import { analytics, PerpsTpSlEvent } from '@/analytics'
 
 const isOpen = defineModel<boolean>('isOpen', { default: false })
 
@@ -247,6 +248,7 @@ const setTempTakeProfitPrice = () => {
     emit('setTakeProfitPct', 30)
   }
   hasTakeProfit.value = true
+  void analytics.trackPerpsTpSlEvent(PerpsTpSlEvent.CLICKED_ADD_TP)
 }
 
 const setTempStopLossPrice = () => {
@@ -254,6 +256,7 @@ const setTempStopLossPrice = () => {
     emit('setStopLossPct', 3)
   }
   hasStopLoss.value = true
+  void analytics.trackPerpsTpSlEvent(PerpsTpSlEvent.CLICKED_ADD_SL)
 }
 
 const removeTakeProfit = () => {

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -1,10 +1,11 @@
 import { ref, computed, watch, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useWalletMenuStore } from '@/stores/walletMenuStore'
-import { analytics, PerpsTradeOrderEvent } from '@/analytics'
+import { analytics, PerpsTradeOrderEvent, PerpsTpSlEvent } from '@/analytics'
 import type {
   PerpsTradeOrderPayload,
   PerpsTradeOrderFailPayload,
+  PerpsTpSlSavePayload,
 } from '@/analytics'
 import type { MaxOrderSizeResult } from '../sdk/types'
 import { perpsClient } from '../configs'
@@ -919,6 +920,7 @@ export function usePerpsTradeForm() {
     // Default to +30% TP and -3% SL if nothing is set yet
 
     showAutoCloseModal.value = true
+    void analytics.trackPerpsTpSlEvent(PerpsTpSlEvent.CLICKED)
   }
 
   function setTakeProfitPct(pct: number) {
@@ -970,11 +972,41 @@ export function usePerpsTradeForm() {
     { flush: 'sync' },
   )
 
+  let justSavedAutoClose = false
+
   function confirmAutoClose() {
-    takeProfitPrice.value = tempTakeProfitPrice.value
-    stopLossPrice.value = tempStopLossPrice.value
+    const tp = tempTakeProfitPrice.value
+    const sl = tempStopLossPrice.value
+    const pricePct = (target: number) => {
+      if (!currentPrice.value) return undefined
+      const diff = ((target - currentPrice.value) / currentPrice.value) * 100
+      return diff.toFixed(2)
+    }
+    const savePayload: PerpsTpSlSavePayload = {
+      tpAmount: tp !== null ? String(tp) : undefined,
+      tpPercentageDiffFromCurrent: tp !== null ? pricePct(tp) : undefined,
+      slAmount: sl !== null ? String(sl) : undefined,
+      slPercentageDiffFromCurrent: sl !== null ? pricePct(sl) : undefined,
+    }
+    void analytics.trackPerpsTpSlEvent(
+      PerpsTpSlEvent.CLICKED_SAVE,
+      savePayload,
+    )
+    takeProfitPrice.value = tp
+    stopLossPrice.value = sl
+    justSavedAutoClose = true
     showAutoCloseModal.value = false
   }
+
+  watch(showAutoCloseModal, (open, prev) => {
+    if (prev && !open) {
+      if (justSavedAutoClose) {
+        justSavedAutoClose = false
+        return
+      }
+      void analytics.trackPerpsTpSlEvent(PerpsTpSlEvent.CLICKED_CANCEL)
+    }
+  })
 
   const hasAutoCloseEdits = computed(
     () =>


### PR DESCRIPTION
## Summary

Adds Amplitude analytics for the Perps Take Profit / Stop Loss (Auto Close) dialog.

### What changed

- `PerpsTpSlEvent` const + `PerpsTpSlSavePayload` type in `src/analytics/events.ts`
- `trackPerpsTpSlEvent` method on the Analytics class
- Wired 5 events:
  - **CLICKED** in `openAutoCloseModal()` when the Auto Close dialog opens
  - **CLICKED_ADD_TP** in the dialog when user clicks "Add Take Profit"
  - **CLICKED_ADD_SL** in the dialog when user clicks "Add Stop Loss"
  - **CLICKED_SAVE** in `confirmAutoClose()` with the TP/SL amounts + percentage diff from current price
  - **CLICKED_CANCEL** via a watcher on `showAutoCloseModal` false-transition (gated by a `justSavedAutoClose` flag so save doesn't double-fire as cancel)

### How to test

1. Open Perps trade panel, click the Auto Close (TP/SL) entry — `Perps_Tp_Sl_Clicked` fires.
2. Click "Add Take Profit" — `Perps_Tp_Sl_Clicked_Add_Tp` fires.
3. Click "Add Stop Loss" — `Perps_Tp_Sl_Clicked_Add_Sl` fires.
4. Click Save — `Perps_Tp_Sl_Clicked_Save` fires with `tpAmount`, `tpPercentageDiffFromCurrent`, `slAmount`, `slPercentageDiffFromCurrent`.
5. Re-open, change something, click Cancel — `Perps_Tp_Sl_Clicked_Cancel` fires.

Sentry: n/a (analytics-only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced analytics tracking for Take Profit and Stop Loss interactions, including user clicks, saves, and cancellations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->