### PR TITLE
feat: [MEW-1894] add Perps Change Leverage amplitude events

### DIFF
--- a/src/analytics/amplitude.ts
+++ b/src/analytics/amplitude.ts
@@ -61,6 +61,9 @@ import type {
   PerpsChangeLeverageEvent,
   PerpsChangeLeveragePayload,
   PerpsChangeLeverageFailPayload,
+  PerpsClosePositionEvent,
+  PerpsClosePositionPayload,
+  PerpsClosePositionFailPayload,
 } from './events'
 import {
   type BalanceBracket,
@@ -702,6 +705,24 @@ export class Analytics {
   readonly trackPerpsChangeLeverageFailEvent = (
     event: typeof PerpsChangeLeverageEvent.SUBMIT_FAIL,
     payload: PerpsChangeLeverageFailPayload,
+  ): Promise<void> => {
+    return this._track(event, { ...payload })
+  }
+
+  // =============================================================================
+  // PERPS CLOSE POSITION
+  // =============================================================================
+
+  readonly trackPerpsClosePositionEvent = (
+    event: PerpsClosePositionEvent,
+    payload: PerpsClosePositionPayload,
+  ): Promise<void> => {
+    return this._track(event, { ...payload })
+  }
+
+  readonly trackPerpsClosePositionFailEvent = (
+    event: typeof PerpsClosePositionEvent.SUBMIT_FAIL,
+    payload: PerpsClosePositionFailPayload,
   ): Promise<void> => {
     return this._track(event, { ...payload })
   }

--- a/src/analytics/amplitude.ts
+++ b/src/analytics/amplitude.ts
@@ -53,6 +53,9 @@ import type {
   PerpsDepositEvent,
   PerpsDepositPayload,
   PerpsDepositErrorPayload,
+  PerpsTradeOrderEvent,
+  PerpsTradeOrderPayload,
+  PerpsTradeOrderFailPayload,
 } from './events'
 import {
   type BalanceBracket,
@@ -647,6 +650,24 @@ export class Analytics {
   readonly trackPerpsDepositErrorEvent = (
     event: typeof PerpsDepositEvent.ERROR,
     payload: PerpsDepositErrorPayload,
+  ): Promise<void> => {
+    return this._track(event, { ...payload })
+  }
+
+  // =============================================================================
+  // PERPS TRADE ORDER
+  // =============================================================================
+
+  readonly trackPerpsTradeOrderEvent = (
+    event: PerpsTradeOrderEvent,
+    payload?: PerpsTradeOrderPayload,
+  ): Promise<void> => {
+    return this._track(event, { ...payload })
+  }
+
+  readonly trackPerpsTradeOrderFailEvent = (
+    event: typeof PerpsTradeOrderEvent.SUBMIT_FAIL,
+    payload: PerpsTradeOrderFailPayload,
   ): Promise<void> => {
     return this._track(event, { ...payload })
   }

--- a/src/analytics/amplitude.ts
+++ b/src/analytics/amplitude.ts
@@ -56,6 +56,8 @@ import type {
   PerpsTradeOrderEvent,
   PerpsTradeOrderPayload,
   PerpsTradeOrderFailPayload,
+  PerpsTpSlEvent,
+  PerpsTpSlSavePayload,
 } from './events'
 import {
   type BalanceBracket,
@@ -668,6 +670,17 @@ export class Analytics {
   readonly trackPerpsTradeOrderFailEvent = (
     event: typeof PerpsTradeOrderEvent.SUBMIT_FAIL,
     payload: PerpsTradeOrderFailPayload,
+  ): Promise<void> => {
+    return this._track(event, { ...payload })
+  }
+
+  // =============================================================================
+  // PERPS TP/SL
+  // =============================================================================
+
+  readonly trackPerpsTpSlEvent = (
+    event: PerpsTpSlEvent,
+    payload?: PerpsTpSlSavePayload,
   ): Promise<void> => {
     return this._track(event, { ...payload })
   }

--- a/src/analytics/amplitude.ts
+++ b/src/analytics/amplitude.ts
@@ -58,6 +58,9 @@ import type {
   PerpsTradeOrderFailPayload,
   PerpsTpSlEvent,
   PerpsTpSlSavePayload,
+  PerpsChangeLeverageEvent,
+  PerpsChangeLeveragePayload,
+  PerpsChangeLeverageFailPayload,
 } from './events'
 import {
   type BalanceBracket,
@@ -681,6 +684,24 @@ export class Analytics {
   readonly trackPerpsTpSlEvent = (
     event: PerpsTpSlEvent,
     payload?: PerpsTpSlSavePayload,
+  ): Promise<void> => {
+    return this._track(event, { ...payload })
+  }
+
+  // =============================================================================
+  // PERPS CHANGE LEVERAGE
+  // =============================================================================
+
+  readonly trackPerpsChangeLeverageEvent = (
+    event: PerpsChangeLeverageEvent,
+    payload: PerpsChangeLeveragePayload,
+  ): Promise<void> => {
+    return this._track(event, { ...payload })
+  }
+
+  readonly trackPerpsChangeLeverageFailEvent = (
+    event: typeof PerpsChangeLeverageEvent.SUBMIT_FAIL,
+    payload: PerpsChangeLeverageFailPayload,
   ): Promise<void> => {
     return this._track(event, { ...payload })
   }

--- a/src/analytics/events.ts
+++ b/src/analytics/events.ts
@@ -286,6 +286,27 @@ export type PerpsTradeOrderFailPayload = PerpsTradeOrderPayload & {
 }
 
 // =============================================================================
+// PERPS TP/SL
+// =============================================================================
+
+export const PerpsTpSlEvent = {
+  CLICKED: 'Perps_Tp_Sl_Clicked',
+  CLICKED_ADD_TP: 'Perps_Tp_Sl_Clicked_Add_Tp',
+  CLICKED_ADD_SL: 'Perps_Tp_Sl_Clicked_Add_Sl',
+  CLICKED_SAVE: 'Perps_Tp_Sl_Clicked_Save',
+  CLICKED_CANCEL: 'Perps_Tp_Sl_Clicked_Cancel',
+} as const
+export type PerpsTpSlEvent =
+  (typeof PerpsTpSlEvent)[keyof typeof PerpsTpSlEvent]
+
+export type PerpsTpSlSavePayload = {
+  tpAmount?: string
+  tpPercentageDiffFromCurrent?: string
+  slAmount?: string
+  slPercentageDiffFromCurrent?: string
+}
+
+// =============================================================================
 // NOTIFICATIONS
 // =============================================================================
 

--- a/src/analytics/events.ts
+++ b/src/analytics/events.ts
@@ -250,6 +250,42 @@ export type PerpsDepositErrorPayload = PerpsDepositPayload & {
 }
 
 // =============================================================================
+// PERPS TRADE ORDER
+// =============================================================================
+
+export const PerpsTradeOrderEvent = {
+  CLICKED_PREVIEW: 'Perps_Trade_Order_Clicked_Preview',
+  CLICKED_SUBMIT: 'Perps_Trade_Order_Clicked_Submit',
+  SUBMIT_SUCCESS: 'Perps_Trade_Order_Submit_Success',
+  SUBMIT_FAIL: 'Perps_Trade_Order_Submit_Fail',
+  CLICKED_CANCEL: 'Perps_Trade_Order_Clicked_Cancel',
+  FILLED: 'Perps_Trade_Order_Filled',
+} as const
+export type PerpsTradeOrderEvent =
+  (typeof PerpsTradeOrderEvent)[keyof typeof PerpsTradeOrderEvent]
+
+export type PerpsTradeOrderPayload = {
+  market?: string
+  currentPrice?: number
+  orderSide?: 'buy' | 'sell'
+  orderType?: 'market' | 'limit'
+  leverage?: number
+  previousLeverage?: number
+  maxLeverage?: number
+  margin?: string
+  estimatedLiquidation?: number | null
+  takeProfit?: number | null
+  stopLoss?: number | null
+  marginRatio?: number | null
+  feeRate?: string
+}
+
+export type PerpsTradeOrderFailPayload = PerpsTradeOrderPayload & {
+  errorMessage: string
+  higherThanReasonablePrice?: boolean
+}
+
+// =============================================================================
 // NOTIFICATIONS
 // =============================================================================
 
@@ -301,7 +337,7 @@ export type ClickTokenTradePayload = {
 export const ClickMainMenuEvent = 'Clicked_Wallet_Menu' as const
 
 export type ClickMainMenuPayload = {
-  button: 'trade' | 'swap' | 'bridge' | 'buy' | 'sell' | 'send'
+  button: 'trade' | 'swap' | 'bridge' | 'buy' | 'sell' | 'send' | 'perps'
 }
 
 // =============================================================================

--- a/src/analytics/events.ts
+++ b/src/analytics/events.ts
@@ -330,6 +330,36 @@ export type PerpsChangeLeverageFailPayload = PerpsChangeLeveragePayload & {
 }
 
 // =============================================================================
+// PERPS CLOSE POSITION
+// =============================================================================
+
+export const PerpsClosePositionEvent = {
+  CLICKED: 'Perps_Close_Position_Clicked',
+  CLICKED_SUBMIT: 'Perps_Close_Position_Clicked_Submit',
+  SUBMIT_SUCCESS: 'Perps_Close_Position_Submit_Success',
+  SUBMIT_FAIL: 'Perps_Close_Position_Submit_Fail',
+  FILLED: 'Perps_Close_Position_Filled',
+} as const
+export type PerpsClosePositionEvent =
+  (typeof PerpsClosePositionEvent)[keyof typeof PerpsClosePositionEvent]
+
+export type PerpsClosePositionPayload = {
+  assetName: string
+  orderDirection: 'buy' | 'sell'
+  orderType: 'market' | 'limit'
+  newPositionSize: string
+  oldPositionSize: string
+  isClosedInFull: boolean
+  marketPrice: number
+  currentUPnL: number
+  amountToClose: string
+}
+
+export type PerpsClosePositionFailPayload = PerpsClosePositionPayload & {
+  errorMessage: string
+}
+
+// =============================================================================
 // NOTIFICATIONS
 // =============================================================================
 

--- a/src/analytics/events.ts
+++ b/src/analytics/events.ts
@@ -307,6 +307,29 @@ export type PerpsTpSlSavePayload = {
 }
 
 // =============================================================================
+// PERPS CHANGE LEVERAGE
+// =============================================================================
+
+export const PerpsChangeLeverageEvent = {
+  CLICKED_SUBMIT: 'Perps_Change_Leverage_Clicked_Submit',
+  SUBMIT_SUCCESS: 'Perps_Change_Leverage_Submit_Success',
+  SUBMIT_FAIL: 'Perps_Change_Leverage_Submit_Fail',
+} as const
+export type PerpsChangeLeverageEvent =
+  (typeof PerpsChangeLeverageEvent)[keyof typeof PerpsChangeLeverageEvent]
+
+export type PerpsChangeLeveragePayload = {
+  assetName: string
+  oldLeverage: number
+  maxLeverage: number
+  newLeverage: number
+}
+
+export type PerpsChangeLeverageFailPayload = PerpsChangeLeveragePayload & {
+  errorMessage: string
+}
+
+// =============================================================================
 // NOTIFICATIONS
 // =============================================================================
 

--- a/src/components/core_layouts/LayoutWallet.vue
+++ b/src/components/core_layouts/LayoutWallet.vue
@@ -326,7 +326,7 @@ const openPanel = (panel: WalletPanel) => {
   }
   walletMenu.setWalletPanel(panel)
   analytics.trackClickMainMenuEvent(ClickMainMenuEvent, {
-    button: panel as any,
+    button: panel,
   })
 }
 

--- a/src/modules/perps/ModulePerpInfo.vue
+++ b/src/modules/perps/ModulePerpInfo.vue
@@ -955,7 +955,11 @@ import { useAppBreakpoints } from '@/composables/useAppBreakpoints'
 import type { ApiOrder, ApiFill, MarketInfoData } from './sdk/types'
 import { useWalletMenuStore } from '@/stores/walletMenuStore'
 import { useAccessStore } from '@/stores/accessStore'
-import { analytics, ConnectWalletEvent } from '@/analytics'
+import { analytics, ConnectWalletEvent, PerpsChangeLeverageEvent } from '@/analytics'
+import type {
+  PerpsChangeLeveragePayload,
+  PerpsChangeLeverageFailPayload,
+} from '@/analytics'
 
 const { setSelectedTradeManageMode, setWalletPanel, setIsOpenSideMenu } =
   useWalletMenuStore()
@@ -1383,15 +1387,37 @@ const marketMaxLeverage = computed(() => {
 const saveLeverage = async () => {
   isSavingLeverage.value = true
   leverageError.value = ''
+  const payload: PerpsChangeLeveragePayload = {
+    assetName: props.market,
+    oldLeverage: leverage.value,
+    maxLeverage: marketMaxLeverage.value,
+    newLeverage: tempLeverage.value,
+  }
+  void analytics.trackPerpsChangeLeverageEvent(
+    PerpsChangeLeverageEvent.CLICKED_SUBMIT,
+    payload,
+  )
   try {
     await perpsClient.setLeverage(props.market, tempLeverage.value)
     showLeverageDialog.value = false
     leverage.value = tempLeverage.value
     perpsToasts.toastLeverageUpdated(tempLeverage.value, props.market)
+    void analytics.trackPerpsChangeLeverageEvent(
+      PerpsChangeLeverageEvent.SUBMIT_SUCCESS,
+      payload,
+    )
   } catch (e) {
     leverageError.value =
       e instanceof Error ? e.message : 'Failed to set leverage'
     perpsToasts.toastFailedToSetLeverage()
+    const failPayload: PerpsChangeLeverageFailPayload = {
+      ...payload,
+      errorMessage: leverageError.value,
+    }
+    void analytics.trackPerpsChangeLeverageFailEvent(
+      PerpsChangeLeverageEvent.SUBMIT_FAIL,
+      failPayload,
+    )
   } finally {
     isSavingLeverage.value = false
   }

--- a/src/modules/perps/components/PerpsMarketList.vue
+++ b/src/modules/perps/components/PerpsMarketList.vue
@@ -621,6 +621,11 @@ import PerpsSelectLeverageDialog from './PerpsSelectLeverageDialog.vue'
 import { usePerpsToasts } from '../composables/usePerpsToasts'
 import { useWalletStore } from '@/stores/walletStore'
 import { storeToRefs } from 'pinia'
+import { analytics, PerpsChangeLeverageEvent } from '@/analytics'
+import type {
+  PerpsChangeLeveragePayload,
+  PerpsChangeLeverageFailPayload,
+} from '@/analytics'
 
 const walletStore = useWalletStore()
 const { isWatchOnly } = storeToRefs(walletStore)
@@ -638,6 +643,7 @@ const leverageError = ref('')
 const leverageMarket = ref('')
 const leverageSymbol = ref('')
 const leverageMaxLeverage = ref(20)
+const leverageOldValue = ref(1)
 const perpsToasts = usePerpsToasts()
 
 const openLeverage = (
@@ -656,6 +662,7 @@ const openLeverage = (
     ? parsedCurrent
     : maxLev
   tempLeverage.value = Math.min(initial, maxLev)
+  leverageOldValue.value = tempLeverage.value
   leverageError.value = ''
   showLeverageDialog.value = true
 }
@@ -663,14 +670,36 @@ const openLeverage = (
 const saveLeverage = async () => {
   isSavingLeverage.value = true
   leverageError.value = ''
+  const payload: PerpsChangeLeveragePayload = {
+    assetName: leverageMarket.value,
+    oldLeverage: leverageOldValue.value,
+    maxLeverage: leverageMaxLeverage.value,
+    newLeverage: tempLeverage.value,
+  }
+  void analytics.trackPerpsChangeLeverageEvent(
+    PerpsChangeLeverageEvent.CLICKED_SUBMIT,
+    payload,
+  )
   try {
     await perpsClient.setLeverage(leverageMarket.value, tempLeverage.value)
     showLeverageDialog.value = false
     perpsToasts.toastLeverageUpdated(tempLeverage.value, leverageMarket.value)
+    void analytics.trackPerpsChangeLeverageEvent(
+      PerpsChangeLeverageEvent.SUBMIT_SUCCESS,
+      payload,
+    )
   } catch (e) {
     leverageError.value =
       e instanceof Error ? e.message : 'Failed to set leverage'
     perpsToasts.toastFailedToSetLeverage()
+    const failPayload: PerpsChangeLeverageFailPayload = {
+      ...payload,
+      errorMessage: leverageError.value,
+    }
+    void analytics.trackPerpsChangeLeverageFailEvent(
+      PerpsChangeLeverageEvent.SUBMIT_FAIL,
+      failPayload,
+    )
   } finally {
     isSavingLeverage.value = false
   }

--- a/src/modules/perps/components/PerpsPositionsTable.vue
+++ b/src/modules/perps/components/PerpsPositionsTable.vue
@@ -916,11 +916,13 @@ const saveLeverage = async () => {
       payload,
     )
   } catch (e: unknown) {
-    leverageError.value = (e as Error).message
+    const errorMessage =
+      e instanceof Error ? e.message : String(e ?? 'Failed to set leverage')
+    leverageError.value = errorMessage
     perpsToasts.toastFailedToSetLeverage()
     const failPayload: PerpsChangeLeverageFailPayload = {
       ...payload,
-      errorMessage: leverageError.value,
+      errorMessage,
     }
     void analytics.trackPerpsChangeLeverageFailEvent(
       PerpsChangeLeverageEvent.SUBMIT_FAIL,

--- a/src/modules/perps/components/PerpsPositionsTable.vue
+++ b/src/modules/perps/components/PerpsPositionsTable.vue
@@ -878,12 +878,18 @@ import { usePaginate } from '@/composables/usePaginate'
 import type { Position, ApiOrder, ApiFill } from '../sdk/types'
 import { useWalletStore } from '@/stores/walletStore'
 import { storeToRefs } from 'pinia'
+import { analytics, PerpsChangeLeverageEvent } from '@/analytics'
+import type {
+  PerpsChangeLeveragePayload,
+  PerpsChangeLeverageFailPayload,
+} from '@/analytics'
 
 const walletStore = useWalletStore()
 const { isWatchOnly } = storeToRefs(walletStore)
 
 const localLeverage = ref(1)
 const localMaxLeverage = ref(20)
+const localOldLeverage = ref(1)
 const leverageError = ref('')
 const isSavingLeverage = ref(false)
 const fullMarketName = ref('')
@@ -891,13 +897,35 @@ const showLeverageModal = ref(false)
 
 const saveLeverage = async () => {
   isSavingLeverage.value = true
+  const payload: PerpsChangeLeveragePayload = {
+    assetName: fullMarketName.value,
+    oldLeverage: localOldLeverage.value,
+    maxLeverage: localMaxLeverage.value,
+    newLeverage: localLeverage.value,
+  }
+  void analytics.trackPerpsChangeLeverageEvent(
+    PerpsChangeLeverageEvent.CLICKED_SUBMIT,
+    payload,
+  )
   try {
     await perpsClient.setLeverage(fullMarketName.value, localLeverage.value)
     showLeverageModal.value = false
     perpsToasts.toastLeverageUpdated(localLeverage.value, fullMarketName.value)
+    void analytics.trackPerpsChangeLeverageEvent(
+      PerpsChangeLeverageEvent.SUBMIT_SUCCESS,
+      payload,
+    )
   } catch (e: unknown) {
     leverageError.value = (e as Error).message
     perpsToasts.toastFailedToSetLeverage()
+    const failPayload: PerpsChangeLeverageFailPayload = {
+      ...payload,
+      errorMessage: leverageError.value,
+    }
+    void analytics.trackPerpsChangeLeverageFailEvent(
+      PerpsChangeLeverageEvent.SUBMIT_FAIL,
+      failPayload,
+    )
   } finally {
     isSavingLeverage.value = false
   }
@@ -913,6 +941,7 @@ const openLeverage = (pos: Position) => {
   const parsedPos = Number(pos.leverage)
   const initial = Number.isFinite(parsedPos) && parsedPos > 0 ? parsedPos : maxLev
   localLeverage.value = Math.min(initial, maxLev)
+  localOldLeverage.value = localLeverage.value
   fullMarketName.value = pos.market
   showLeverageModal.value = true
 }

--- a/src/modules/perps/components/PerpsTakeProfitStopLossDialog.vue
+++ b/src/modules/perps/components/PerpsTakeProfitStopLossDialog.vue
@@ -199,6 +199,7 @@ import PerpsAmount from './PerpsAmount.vue'
 import { formatUsd } from '../utils/formatters'
 import { getLogoUrl } from '../utils/market'
 import { PlusCircleIcon } from '@heroicons/vue/24/solid'
+import { analytics, PerpsTpSlEvent } from '@/analytics'
 
 const isOpen = defineModel<boolean>('isOpen', { default: false })
 
@@ -247,6 +248,7 @@ const setTempTakeProfitPrice = () => {
     emit('setTakeProfitPct', 30)
   }
   hasTakeProfit.value = true
+  void analytics.trackPerpsTpSlEvent(PerpsTpSlEvent.CLICKED_ADD_TP)
 }
 
 const setTempStopLossPrice = () => {
@@ -254,6 +256,7 @@ const setTempStopLossPrice = () => {
     emit('setStopLossPct', 3)
   }
   hasStopLoss.value = true
+  void analytics.trackPerpsTpSlEvent(PerpsTpSlEvent.CLICKED_ADD_SL)
 }
 
 const removeTakeProfit = () => {

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -6,6 +6,7 @@ import {
   PerpsTradeOrderEvent,
   PerpsTpSlEvent,
   PerpsChangeLeverageEvent,
+  PerpsClosePositionEvent,
 } from '@/analytics'
 import type {
   PerpsTradeOrderPayload,
@@ -13,6 +14,8 @@ import type {
   PerpsTpSlSavePayload,
   PerpsChangeLeveragePayload,
   PerpsChangeLeverageFailPayload,
+  PerpsClosePositionPayload,
+  PerpsClosePositionFailPayload,
 } from '@/analytics'
 import type { MaxOrderSizeResult } from '../sdk/types'
 import { perpsClient } from '../configs'
@@ -433,30 +436,67 @@ export function usePerpsTradeForm() {
     closeAmount.value = amt.toFixed(2)
   }
 
+  function buildClosePositionPayload(
+    placedSize: string,
+    closeSide: 'buy' | 'sell',
+    isLimit: boolean,
+    closePct: number,
+  ): PerpsClosePositionPayload {
+    const oldSize = activePosition.value?.netQuantity ?? '0'
+    const oldSizeNum = parseFloat(oldSize)
+    const placedNum = parseFloat(placedSize)
+    const newSize =
+      closePct >= 100 ? 0 : Math.max(oldSizeNum - placedNum, 0)
+    return {
+      assetName: fullMarketName.value,
+      orderDirection: closeSide,
+      orderType: isLimit ? 'limit' : 'market',
+      newPositionSize: newSize.toString(),
+      oldPositionSize: oldSize,
+      isClosedInFull: closePct >= 100,
+      marketPrice: currentPrice.value,
+      currentUPnL: positionPnl.value,
+      amountToClose: closeAmount.value || '0',
+    }
+  }
+
   async function handleClosePosition() {
     if (!activePosition.value || isClosing.value) return
     isClosing.value = true
     closeError.value = ''
+    const closePct = closeSliderValue.value
+    const isLimit = orderType.value === 'limit'
+    const closeSide: 'buy' | 'sell' =
+      activePosition.value.direction === 'long' ? 'sell' : 'buy'
+    let placedSize: string = activePosition.value.netQuantity
+    if (!(closePct >= 100)) {
+      const closeUsd = parseFloat(closeAmount.value) || 0
+      if (closeUsd > 0) {
+        const rawSize = closeUsd / effectivePrice.value
+        placedSize = floorToIncrement(rawSize, activeMarketIncrement.value)
+      }
+    }
+    const closePayload = buildClosePositionPayload(
+      placedSize,
+      closeSide,
+      isLimit,
+      closePct,
+    )
+    void analytics.trackPerpsClosePositionEvent(
+      PerpsClosePositionEvent.CLICKED_SUBMIT,
+      closePayload,
+    )
     try {
-      const closePct = closeSliderValue.value
-      const isLimit = orderType.value === 'limit'
-      const closeSide: 'buy' | 'sell' =
-        activePosition.value.direction === 'long' ? 'sell' : 'buy'
-      let placedSize: string
-
       if (closePct >= 100 && !isLimit) {
         // Full close via market order
-        placedSize = activePosition.value.netQuantity
         await closePosition(activePosition.value)
       } else {
-        if (closePct >= 100) {
-          // Full close via limit
-          placedSize = activePosition.value.netQuantity
-        } else {
+        if (closePct < 100) {
           const closeUsd = parseFloat(closeAmount.value) || 0
-          if (closeUsd <= 0) return
-          const rawSize = closeUsd / effectivePrice.value
-          placedSize = floorToIncrement(rawSize, activeMarketIncrement.value)
+          if (closeUsd <= 0) {
+            isClosing.value = false
+            return
+          }
         }
 
         const orderParams: Record<string, unknown> = {
@@ -487,12 +527,24 @@ export function usePerpsTradeForm() {
         market: closeDisplayMarket,
         price: isLimit ? (limitPrice.value ?? undefined) : undefined,
       })
+      void analytics.trackPerpsClosePositionEvent(
+        PerpsClosePositionEvent.SUBMIT_SUCCESS,
+        closePayload,
+      )
       closeAmount.value = ''
       closeSliderValue.value = 0
       triggerRefresh()
     } catch (e: any) {
       closeError.value =
         e?.message || e?.toString() || 'Failed to close position.'
+      const failPayload: PerpsClosePositionFailPayload = {
+        ...closePayload,
+        errorMessage: closeError.value,
+      }
+      void analytics.trackPerpsClosePositionFailEvent(
+        PerpsClosePositionEvent.SUBMIT_FAIL,
+        failPayload,
+      )
     } finally {
       isClosing.value = false
     }
@@ -1105,6 +1157,24 @@ export function usePerpsTradeForm() {
     if (closeDisabled.value) return
     closeError.value = ''
     showCloseConfirmModal.value = true
+    if (activePosition.value) {
+      const closePct = closeSliderValue.value
+      const isLimit = orderType.value === 'limit'
+      const closeSide: 'buy' | 'sell' =
+        activePosition.value.direction === 'long' ? 'sell' : 'buy'
+      let placedSize: string = activePosition.value.netQuantity
+      if (!(closePct >= 100)) {
+        const closeUsd = parseFloat(closeAmount.value) || 0
+        if (closeUsd > 0 && effectivePrice.value > 0) {
+          const rawSize = closeUsd / effectivePrice.value
+          placedSize = floorToIncrement(rawSize, activeMarketIncrement.value)
+        }
+      }
+      void analytics.trackPerpsClosePositionEvent(
+        PerpsClosePositionEvent.CLICKED,
+        buildClosePositionPayload(placedSize, closeSide, isLimit, closePct),
+      )
+    }
   }
 
   async function confirmAndSubmitOrder() {

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -472,6 +472,14 @@ export function usePerpsTradeForm() {
     if (!(closePct >= 100)) {
       const closeUsd = parseFloat(closeAmount.value) || 0
       if (closeUsd > 0) {
+        if (
+          !Number.isFinite(effectivePrice.value) ||
+          effectivePrice.value <= 0
+        ) {
+          closeError.value = 'Invalid market price. Please try again.'
+          isClosing.value = false
+          return
+        }
         const rawSize = closeUsd / effectivePrice.value
         placedSize = floorToIncrement(rawSize, activeMarketIncrement.value)
       }

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -1,6 +1,11 @@
 import { ref, computed, watch, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useWalletMenuStore } from '@/stores/walletMenuStore'
+import { analytics, PerpsTradeOrderEvent } from '@/analytics'
+import type {
+  PerpsTradeOrderPayload,
+  PerpsTradeOrderFailPayload,
+} from '@/analytics'
 import type { MaxOrderSizeResult } from '../sdk/types'
 import { perpsClient } from '../configs'
 import { usePerpsAuth, usePerpsBalance } from './usePerpsAuth'
@@ -986,10 +991,53 @@ export function usePerpsTradeForm() {
   }
 
   // ── Confirm / submit ──────────────────────────────────────
+  const activeContract = computed(() =>
+    contracts.value.find(c => c.market === fullMarketName.value),
+  )
+
+  const isMakerOrder = computed(() => {
+    if (orderType.value !== 'limit') return false
+    const limit = parseFloat(limitPrice.value || '')
+    if (!Number.isFinite(limit) || !currentPrice.value) return false
+    return orderSide.value === 'buy'
+      ? limit < currentPrice.value
+      : limit > currentPrice.value
+  })
+
+  function buildTradeOrderPayload(): PerpsTradeOrderPayload {
+    const priorLeverage = activePosition.value?.leverage
+      ? parseInt(activePosition.value.leverage)
+      : undefined
+    const feeRate = isMakerOrder.value
+      ? activeContract.value?.makerFee
+      : activeContract.value?.takerFee
+    return {
+      market: fullMarketName.value,
+      currentPrice: currentPrice.value,
+      orderSide: orderSide.value,
+      orderType: orderType.value,
+      leverage: leverage.value,
+      previousLeverage: priorLeverage,
+      maxLeverage: marketMaxLeverage.value,
+      margin: inputAmount.value,
+      estimatedLiquidation: estimatedLiquidation.value || null,
+      takeProfit: takeProfitPrice.value,
+      stopLoss: stopLossPrice.value,
+      marginRatio: newMarginRatio.value,
+      feeRate,
+    }
+  }
+
+  let justSubmittedOrder = false
+
   function showConfirmation() {
     if (submitDisabled.value) return
     orderError.value = ''
     showConfirmModal.value = true
+    void analytics.trackPerpsTradeOrderEvent(
+      PerpsTradeOrderEvent.CLICKED_PREVIEW,
+      buildTradeOrderPayload(),
+    )
   }
 
   function showCloseConfirmation() {
@@ -1000,6 +1048,11 @@ export function usePerpsTradeForm() {
 
   async function confirmAndSubmitOrder() {
     if (submitDisabled.value) return
+    const tradePayload = buildTradeOrderPayload()
+    void analytics.trackPerpsTradeOrderEvent(
+      PerpsTradeOrderEvent.CLICKED_SUBMIT,
+      tradePayload,
+    )
     isSubmitting.value = true
     // Snapshot prior SL/TP state BEFORE the SDK call so "prior" reflects what
     // the user was about to change. Reading it afterward would see the new
@@ -1054,6 +1107,10 @@ export function usePerpsTradeForm() {
         }
       }
       await perpsClient.createOrder(orderParams as any)
+      void analytics.trackPerpsTradeOrderEvent(
+        PerpsTradeOrderEvent.SUBMIT_SUCCESS,
+        tradePayload,
+      )
       // Fire Order Placed + SL/TP toasts only after the SDK call succeeded.
       const marketMatch = markets.value.find(
         m => m.market === fullMarketName.value,
@@ -1079,6 +1136,7 @@ export function usePerpsTradeForm() {
         if (hadPriorTakeProfit) perpsToasts.toastTakeProfitModified(args)
         else perpsToasts.toastTakeProfitAdded(args)
       }
+      justSubmittedOrder = true
       showConfirmModal.value = false
       inputAmount.value = ''
       sliderValue.value = 0
@@ -1107,12 +1165,37 @@ export function usePerpsTradeForm() {
           perpsToasts.toastTakeProfitInvalid()
         }
       }
-      orderError.value =
+      const errorMessage =
         error?.message || error?.toString() || 'Order failed. Please try again.'
+      orderError.value = errorMessage
+      const failPayload: PerpsTradeOrderFailPayload = {
+        ...tradePayload,
+        errorMessage,
+        higherThanReasonablePrice: limitPriceOutOfTolerance.value,
+      }
+      void analytics.trackPerpsTradeOrderFailEvent(
+        PerpsTradeOrderEvent.SUBMIT_FAIL,
+        failPayload,
+      )
     } finally {
       isSubmitting.value = false
     }
   }
+
+  // Track CANCEL when the confirm modal closes without a successful submit
+  // (e.g. user hit Cancel or closed the dialog).
+  watch(showConfirmModal, (open, prev) => {
+    if (prev && !open) {
+      if (justSubmittedOrder) {
+        justSubmittedOrder = false
+        return
+      }
+      void analytics.trackPerpsTradeOrderEvent(
+        PerpsTradeOrderEvent.CLICKED_CANCEL,
+        buildTradeOrderPayload(),
+      )
+    }
+  })
 
   // NOTE(perps-toasts): Dedicated remove-stop-loss / remove-take-profit flows
   // are not yet wired in this composable. The SDK client today exposes

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -1,10 +1,11 @@
 import { ref, computed, watch, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useWalletMenuStore } from '@/stores/walletMenuStore'
-import { analytics, PerpsTradeOrderEvent } from '@/analytics'
+import { analytics, PerpsTradeOrderEvent, PerpsTpSlEvent } from '@/analytics'
 import type {
   PerpsTradeOrderPayload,
   PerpsTradeOrderFailPayload,
+  PerpsTpSlSavePayload,
 } from '@/analytics'
 import type { MaxOrderSizeResult } from '../sdk/types'
 import { perpsClient } from '../configs'
@@ -919,6 +920,7 @@ export function usePerpsTradeForm() {
     // Default to +30% TP and -3% SL if nothing is set yet
 
     showAutoCloseModal.value = true
+    void analytics.trackPerpsTpSlEvent(PerpsTpSlEvent.CLICKED)
   }
 
   function setTakeProfitPct(pct: number) {
@@ -970,11 +972,41 @@ export function usePerpsTradeForm() {
     { flush: 'sync' },
   )
 
+  let justSavedAutoClose = false
+
   function confirmAutoClose() {
-    takeProfitPrice.value = tempTakeProfitPrice.value
-    stopLossPrice.value = tempStopLossPrice.value
+    const tp = tempTakeProfitPrice.value
+    const sl = tempStopLossPrice.value
+    const pricePct = (target: number) => {
+      if (!currentPrice.value) return undefined
+      const diff = ((target - currentPrice.value) / currentPrice.value) * 100
+      return diff.toFixed(2)
+    }
+    const savePayload: PerpsTpSlSavePayload = {
+      tpAmount: tp !== null ? String(tp) : undefined,
+      tpPercentageDiffFromCurrent: tp !== null ? pricePct(tp) : undefined,
+      slAmount: sl !== null ? String(sl) : undefined,
+      slPercentageDiffFromCurrent: sl !== null ? pricePct(sl) : undefined,
+    }
+    void analytics.trackPerpsTpSlEvent(
+      PerpsTpSlEvent.CLICKED_SAVE,
+      savePayload,
+    )
+    takeProfitPrice.value = tp
+    stopLossPrice.value = sl
+    justSavedAutoClose = true
     showAutoCloseModal.value = false
   }
+
+  watch(showAutoCloseModal, (open, prev) => {
+    if (prev && !open) {
+      if (justSavedAutoClose) {
+        justSavedAutoClose = false
+        return
+      }
+      void analytics.trackPerpsTpSlEvent(PerpsTpSlEvent.CLICKED_CANCEL)
+    }
+  })
 
   const hasAutoCloseEdits = computed(
     () =>

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -1,11 +1,18 @@
 import { ref, computed, watch, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useWalletMenuStore } from '@/stores/walletMenuStore'
-import { analytics, PerpsTradeOrderEvent, PerpsTpSlEvent } from '@/analytics'
+import {
+  analytics,
+  PerpsTradeOrderEvent,
+  PerpsTpSlEvent,
+  PerpsChangeLeverageEvent,
+} from '@/analytics'
 import type {
   PerpsTradeOrderPayload,
   PerpsTradeOrderFailPayload,
   PerpsTpSlSavePayload,
+  PerpsChangeLeveragePayload,
+  PerpsChangeLeverageFailPayload,
 } from '@/analytics'
 import type { MaxOrderSizeResult } from '../sdk/types'
 import { perpsClient } from '../configs'
@@ -798,6 +805,16 @@ export function usePerpsTradeForm() {
   async function saveLeverage() {
     isSavingLeverage.value = true
     leverageError.value = ''
+    const payload: PerpsChangeLeveragePayload = {
+      assetName: fullMarketName.value,
+      oldLeverage: leverage.value,
+      maxLeverage: marketMaxLeverage.value,
+      newLeverage: tempLeverage.value,
+    }
+    void analytics.trackPerpsChangeLeverageEvent(
+      PerpsChangeLeverageEvent.CLICKED_SUBMIT,
+      payload,
+    )
     try {
       if (token.value && markets.value.length) {
         await perpsClient.setLeverage(fullMarketName.value, tempLeverage.value)
@@ -806,12 +823,24 @@ export function usePerpsTradeForm() {
       showLeverageModal.value = false
       fetchMaxOrderSize()
       perpsToasts.toastLeverageUpdated(tempLeverage.value, fullMarketName.value)
+      void analytics.trackPerpsChangeLeverageEvent(
+        PerpsChangeLeverageEvent.SUBMIT_SUCCESS,
+        payload,
+      )
     } catch (e: any) {
       leverageError.value =
         e?.message ||
         e?.toString() ||
         'Failed to save leverage. Please try again.'
       perpsToasts.toastFailedToSetLeverage()
+      const failPayload: PerpsChangeLeverageFailPayload = {
+        ...payload,
+        errorMessage: leverageError.value,
+      }
+      void analytics.trackPerpsChangeLeverageFailEvent(
+        PerpsChangeLeverageEvent.SUBMIT_FAIL,
+        failPayload,
+      )
     } finally {
       isSavingLeverage.value = false
     }


### PR DESCRIPTION
## What was wrong
Perps "Change Leverage" interactions were not being tracked in Amplitude, so we had no insight into how often users adjust leverage, what targets they pick, or which save attempts fail.

## What changed
Wires three new Amplitude events at all four `setLeverage` call-sites:

- `Perps_Change_Leverage_Clicked_Submit` — fired when the user clicks Save in any leverage dialog.
- `Perps_Change_Leverage_Submit_Success` — fired after the SDK call resolves.
- `Perps_Change_Leverage_Submit_Fail` — fired in the catch branch, with an `errorMessage` field.

Payload (all three): `assetName`, `oldLeverage`, `maxLeverage`, `newLeverage`.

Call-sites touched:
- `src/modules/perps/composables/usePerpsTradeForm.ts` — trade form leverage modal
- `src/modules/perps/ModulePerpInfo.vue` — Change Leverage manage action on the market page
- `src/modules/perps/components/PerpsMarketList.vue` — market row leverage button
- `src/modules/perps/components/PerpsPositionsTable.vue` — positions row leverage button

## How to test
1. Open Perps on any market.
2. Open the leverage dialog from the trade form, from the position row, from the market row, and from the market-page Manage > Change Leverage action.
3. For each entry point, change the slider and click Save. Watch Amplitude dev console for `Perps_Change_Leverage_Clicked_Submit` + `Perps_Change_Leverage_Submit_Success` with the right asset and old/max/new values.
4. To verify the fail event, simulate an SDK error (e.g. offline or invalid value) and confirm `Perps_Change_Leverage_Submit_Fail` fires with `errorMessage`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added analytics tracking for leverage-change workflows in perpetual futures: captures submit clicked, submit success, and submit fail (with error) across dialogs/tables/forms.
  * Added analytics tracking for close-position workflows: captures clicked, submit events, success, and failure (with error) and emits contextual payloads when showing confirmations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->