### PR TITLE
feat: [MEW-1895] add Perps Close Position amplitude events

### DIFF
--- a/src/analytics/amplitude.ts
+++ b/src/analytics/amplitude.ts
@@ -61,6 +61,9 @@ import type {
   PerpsChangeLeverageEvent,
   PerpsChangeLeveragePayload,
   PerpsChangeLeverageFailPayload,
+  PerpsClosePositionEvent,
+  PerpsClosePositionPayload,
+  PerpsClosePositionFailPayload,
 } from './events'
 import {
   type BalanceBracket,
@@ -702,6 +705,24 @@ export class Analytics {
   readonly trackPerpsChangeLeverageFailEvent = (
     event: typeof PerpsChangeLeverageEvent.SUBMIT_FAIL,
     payload: PerpsChangeLeverageFailPayload,
+  ): Promise<void> => {
+    return this._track(event, { ...payload })
+  }
+
+  // =============================================================================
+  // PERPS CLOSE POSITION
+  // =============================================================================
+
+  readonly trackPerpsClosePositionEvent = (
+    event: PerpsClosePositionEvent,
+    payload: PerpsClosePositionPayload,
+  ): Promise<void> => {
+    return this._track(event, { ...payload })
+  }
+
+  readonly trackPerpsClosePositionFailEvent = (
+    event: typeof PerpsClosePositionEvent.SUBMIT_FAIL,
+    payload: PerpsClosePositionFailPayload,
   ): Promise<void> => {
     return this._track(event, { ...payload })
   }

--- a/src/analytics/events.ts
+++ b/src/analytics/events.ts
@@ -330,6 +330,36 @@ export type PerpsChangeLeverageFailPayload = PerpsChangeLeveragePayload & {
 }
 
 // =============================================================================
+// PERPS CLOSE POSITION
+// =============================================================================
+
+export const PerpsClosePositionEvent = {
+  CLICKED: 'Perps_Close_Position_Clicked',
+  CLICKED_SUBMIT: 'Perps_Close_Position_Clicked_Submit',
+  SUBMIT_SUCCESS: 'Perps_Close_Position_Submit_Success',
+  SUBMIT_FAIL: 'Perps_Close_Position_Submit_Fail',
+  FILLED: 'Perps_Close_Position_Filled',
+} as const
+export type PerpsClosePositionEvent =
+  (typeof PerpsClosePositionEvent)[keyof typeof PerpsClosePositionEvent]
+
+export type PerpsClosePositionPayload = {
+  assetName: string
+  orderDirection: 'buy' | 'sell'
+  orderType: 'market' | 'limit'
+  newPositionSize: string
+  oldPositionSize: string
+  isClosedInFull: boolean
+  marketPrice: number
+  currentUPnL: number
+  amountToClose: string
+}
+
+export type PerpsClosePositionFailPayload = PerpsClosePositionPayload & {
+  errorMessage: string
+}
+
+// =============================================================================
 // NOTIFICATIONS
 // =============================================================================
 

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -6,6 +6,7 @@ import {
   PerpsTradeOrderEvent,
   PerpsTpSlEvent,
   PerpsChangeLeverageEvent,
+  PerpsClosePositionEvent,
 } from '@/analytics'
 import type {
   PerpsTradeOrderPayload,
@@ -13,6 +14,8 @@ import type {
   PerpsTpSlSavePayload,
   PerpsChangeLeveragePayload,
   PerpsChangeLeverageFailPayload,
+  PerpsClosePositionPayload,
+  PerpsClosePositionFailPayload,
 } from '@/analytics'
 import type { MaxOrderSizeResult } from '../sdk/types'
 import { perpsClient } from '../configs'
@@ -433,30 +436,67 @@ export function usePerpsTradeForm() {
     closeAmount.value = amt.toFixed(2)
   }
 
+  function buildClosePositionPayload(
+    placedSize: string,
+    closeSide: 'buy' | 'sell',
+    isLimit: boolean,
+    closePct: number,
+  ): PerpsClosePositionPayload {
+    const oldSize = activePosition.value?.netQuantity ?? '0'
+    const oldSizeNum = parseFloat(oldSize)
+    const placedNum = parseFloat(placedSize)
+    const newSize =
+      closePct >= 100 ? 0 : Math.max(oldSizeNum - placedNum, 0)
+    return {
+      assetName: fullMarketName.value,
+      orderDirection: closeSide,
+      orderType: isLimit ? 'limit' : 'market',
+      newPositionSize: newSize.toString(),
+      oldPositionSize: oldSize,
+      isClosedInFull: closePct >= 100,
+      marketPrice: currentPrice.value,
+      currentUPnL: positionPnl.value,
+      amountToClose: closeAmount.value || '0',
+    }
+  }
+
   async function handleClosePosition() {
     if (!activePosition.value || isClosing.value) return
     isClosing.value = true
     closeError.value = ''
+    const closePct = closeSliderValue.value
+    const isLimit = orderType.value === 'limit'
+    const closeSide: 'buy' | 'sell' =
+      activePosition.value.direction === 'long' ? 'sell' : 'buy'
+    let placedSize: string = activePosition.value.netQuantity
+    if (!(closePct >= 100)) {
+      const closeUsd = parseFloat(closeAmount.value) || 0
+      if (closeUsd > 0) {
+        const rawSize = closeUsd / effectivePrice.value
+        placedSize = floorToIncrement(rawSize, activeMarketIncrement.value)
+      }
+    }
+    const closePayload = buildClosePositionPayload(
+      placedSize,
+      closeSide,
+      isLimit,
+      closePct,
+    )
+    void analytics.trackPerpsClosePositionEvent(
+      PerpsClosePositionEvent.CLICKED_SUBMIT,
+      closePayload,
+    )
     try {
-      const closePct = closeSliderValue.value
-      const isLimit = orderType.value === 'limit'
-      const closeSide: 'buy' | 'sell' =
-        activePosition.value.direction === 'long' ? 'sell' : 'buy'
-      let placedSize: string
-
       if (closePct >= 100 && !isLimit) {
         // Full close via market order
-        placedSize = activePosition.value.netQuantity
         await closePosition(activePosition.value)
       } else {
-        if (closePct >= 100) {
-          // Full close via limit
-          placedSize = activePosition.value.netQuantity
-        } else {
+        if (closePct < 100) {
           const closeUsd = parseFloat(closeAmount.value) || 0
-          if (closeUsd <= 0) return
-          const rawSize = closeUsd / effectivePrice.value
-          placedSize = floorToIncrement(rawSize, activeMarketIncrement.value)
+          if (closeUsd <= 0) {
+            isClosing.value = false
+            return
+          }
         }
 
         const orderParams: Record<string, unknown> = {
@@ -487,12 +527,24 @@ export function usePerpsTradeForm() {
         market: closeDisplayMarket,
         price: isLimit ? (limitPrice.value ?? undefined) : undefined,
       })
+      void analytics.trackPerpsClosePositionEvent(
+        PerpsClosePositionEvent.SUBMIT_SUCCESS,
+        closePayload,
+      )
       closeAmount.value = ''
       closeSliderValue.value = 0
       triggerRefresh()
     } catch (e: any) {
       closeError.value =
         e?.message || e?.toString() || 'Failed to close position.'
+      const failPayload: PerpsClosePositionFailPayload = {
+        ...closePayload,
+        errorMessage: closeError.value,
+      }
+      void analytics.trackPerpsClosePositionFailEvent(
+        PerpsClosePositionEvent.SUBMIT_FAIL,
+        failPayload,
+      )
     } finally {
       isClosing.value = false
     }
@@ -1105,6 +1157,24 @@ export function usePerpsTradeForm() {
     if (closeDisabled.value) return
     closeError.value = ''
     showCloseConfirmModal.value = true
+    if (activePosition.value) {
+      const closePct = closeSliderValue.value
+      const isLimit = orderType.value === 'limit'
+      const closeSide: 'buy' | 'sell' =
+        activePosition.value.direction === 'long' ? 'sell' : 'buy'
+      let placedSize: string = activePosition.value.netQuantity
+      if (!(closePct >= 100)) {
+        const closeUsd = parseFloat(closeAmount.value) || 0
+        if (closeUsd > 0 && effectivePrice.value > 0) {
+          const rawSize = closeUsd / effectivePrice.value
+          placedSize = floorToIncrement(rawSize, activeMarketIncrement.value)
+        }
+      }
+      void analytics.trackPerpsClosePositionEvent(
+        PerpsClosePositionEvent.CLICKED,
+        buildClosePositionPayload(placedSize, closeSide, isLimit, closePct),
+      )
+    }
   }
 
   async function confirmAndSubmitOrder() {

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -472,6 +472,14 @@ export function usePerpsTradeForm() {
     if (!(closePct >= 100)) {
       const closeUsd = parseFloat(closeAmount.value) || 0
       if (closeUsd > 0) {
+        if (
+          !Number.isFinite(effectivePrice.value) ||
+          effectivePrice.value <= 0
+        ) {
+          closeError.value = 'Invalid market price. Please try again.'
+          isClosing.value = false
+          return
+        }
         const rawSize = closeUsd / effectivePrice.value
         placedSize = floorToIncrement(rawSize, activeMarketIncrement.value)
       }


### PR DESCRIPTION
## What changed

Adds Amplitude analytics events for the Perps **Close Position** flow.

## Events

- `Perps_Close_Position_Clicked` — user opens the close-position confirmation modal
- `Perps_Close_Position_Clicked_Submit` — user confirms close (just before SDK call)
- `Perps_Close_Position_Submit_Success` — SDK accepted the close order
- `Perps_Close_Position_Submit_Fail` — SDK rejected the close order (includes `errorMessage`)
- `Perps_Close_Position_Filled` — defined for future WS fill detection (not yet emitted)

## Payload

```ts
{
  assetName: string
  orderDirection: 'buy' | 'sell'
  orderType: 'market' | 'limit'
  newPositionSize: string
  oldPositionSize: string
  isClosedInFull: boolean
  marketPrice: number
  currentUPnL: number
  amountToClose: string
}
```

`*_Submit_Fail` extends the payload with `errorMessage`.

## How to test

1. Open Perps, choose a market, place a position
2. Open the Close Position dialog from positions table → expect `Perps_Close_Position_Clicked`
3. Confirm → expect `Perps_Close_Position_Clicked_Submit` then `Perps_Close_Position_Submit_Success` (or `Submit_Fail` on error)
4. Verify payload fields in Amplitude debugger

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added comprehensive analytics event tracking for perpetuals position closure flows, capturing user interactions, submission outcomes, and error details to improve monitoring and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->