### PR TITLE
refactor: ♻️ localize buy quick amount buttons by currency

### DIFF
--- a/src/configs.ts
+++ b/src/configs.ts
@@ -5,6 +5,7 @@ const configs = {
   MEW_API_URL: import.meta.env.VITE_MEW_API || 'https://mew-api-dev.ethvm.dev',
   MEW_PURCHASE_BASE_URL: 'https://qa.mewwallet.dev',
   MEW_PURCHASE_API: 'https://qa.mewwallet.dev/v5/purchase/info',
+  MEW_EXCHANGE_RATES_API: 'https://mainnet.mewwallet.dev/v2/prices/exchange-rates',
   MEW_EMAIL: 'https://mainnet.mewwallet.dev/email-web',
   IS_DEV_MODE: import.meta.env.DEV,
   MEW_DONATION_ADDRESS: '0xDECAF9CD2367cdbb726E904cD6397eDFcAe6068D',

--- a/src/modules/purchase/ModuleBuy.vue
+++ b/src/modules/purchase/ModuleBuy.vue
@@ -14,7 +14,7 @@
       :is-loading="isFetchingEstimate"
       :error-message="amountError"
       :helper-message="amountHelper"
-      :preset-amounts="presetAmounts"
+      :quick-buttons="quickButtons"
       @update:amount="onFiatAmountChange"
       @open-currency="showCurrencyModal = true"
       @focus="isInputFocused = true"
@@ -116,6 +116,7 @@ const {
   buyQuotesError,
   cryptoEstimate,
   isFetchingEstimate,
+  exchangeRates,
 } = storeToRefs(purchaseStore)
 const {
   fetchPurchaseInfo,
@@ -192,9 +193,33 @@ const fiatLimits = computed(() => {
   return fiat?.limits ?? { min: 0, max: 0 }
 })
 
-const presetAmounts = computed(() =>
-  selectedFiat.value === 'USD' ? [15, 50, 100, 250] : [],
-)
+const USD_AMOUNTS = [15, 50, 100, 250]
+const MIN_USD = 2
+const MAX_USD = 250
+
+const currencyRate = computed(() => exchangeRates.value.get(selectedFiat.value))
+
+const formatLocalizedAmount = (usd: number, rate: number): string => {
+  const value = Math.round(usd * rate)
+  const symbol = getCurrencySymbol(selectedFiat.value)
+  return `${symbol}${value.toLocaleString('en-US')}`
+}
+
+const quickButtons = computed(() => {
+  const rate = currencyRate.value
+  if (!rate) return []
+  if (Math.round(15 * rate) >= 1) {
+    return USD_AMOUNTS.map(usd => ({
+      label: formatLocalizedAmount(usd, rate),
+      value: Math.round(usd * rate),
+      usdValue: usd,
+    }))
+  }
+  return [
+    { label: 'Min', value: Math.round(MIN_USD * rate), usdValue: MIN_USD },
+    { label: 'Max', value: Math.round(MAX_USD * rate), usdValue: MAX_USD },
+  ]
+})
 
 const formattedCryptoEstimate = computed(() => {
   if (!cryptoEstimate.value) return `0.00 ${tokenSymbol.value}`.trim()
@@ -273,6 +298,16 @@ watch(compatibleChainCodes, codes => {
   if (selectedToken.value && !codes.includes(selectedToken.value.chain)) {
     selectedToken.value = null
   }
+})
+
+watch(selectedFiat, (newFiat, oldFiat) => {
+  if (newFiat === oldFiat || isAmountEmpty.value) return
+  const newRate = exchangeRates.value.get(newFiat)
+  const oldRate = exchangeRates.value.get(oldFiat)
+  if (!newRate || !oldRate) return
+  const amountInUsd = Number(fiatAmount.value) / oldRate
+  const converted = amountInUsd * newRate
+  fiatAmount.value = converted.toFixed(2).replace(/\.?0+$/, '')
 })
 
 watch(

--- a/src/modules/purchase/components/PurchaseAmountInput.vue
+++ b/src/modules/purchase/components/PurchaseAmountInput.vue
@@ -84,20 +84,20 @@
     <!-- Quick amount buttons -->
     <div class="flex items-center justify-center gap-1 w-full">
       <button
-        v-for="preset in presetAmounts"
-        :key="preset"
+        v-for="btn in quickButtons"
+        :key="btn.usdValue"
         type="button"
         :class="[
           isFocused ? 'bg-bgBase' : 'bg-white',
-          selectedPreset === preset
+          selectedUsdValue === btn.usdValue
             ? 'outline-2 outline-black -outline-offset-2'
             : '',
           'flex-1 min-w-0 flex items-center justify-center px-3 py-2 rounded-8 hoverNoBG transition-colors',
         ]"
-        @click="onSelectPreset(preset)"
+        @click="onSelectPreset(btn)"
       >
         <span class="text-s-11 leading-[15px] font-bold tracking-sp-06 uppercase">
-          {{ currencySymbol }}{{ preset }}
+          {{ btn.label }}
         </span>
       </button>
     </div>
@@ -115,6 +115,15 @@ import {
 } from '../helpers/amountFormatting'
 import { useTextScaler } from '../composables/useTextScaler'
 
+export interface QuickButton {
+  /** Display label, already formatted with currency symbol or literal (e.g. "₩20,250", "Min"). */
+  label: string
+  /** Numeric value to set in the input when the button is clicked (in the selected currency). */
+  value: number
+  /** USD equivalent — kept for tracking/analytics. */
+  usdValue: number
+}
+
 const props = withDefaults(
   defineProps<{
     label: string
@@ -124,14 +133,14 @@ const props = withDefaults(
     isLoading?: boolean
     errorMessage?: string
     helperMessage?: string
-    presetAmounts?: number[]
+    quickButtons?: QuickButton[]
     autofocus?: boolean
   }>(),
   {
     isLoading: false,
     errorMessage: '',
     helperMessage: '',
-    presetAmounts: () => [15, 50, 100, 250],
+    quickButtons: () => [],
     autofocus: false,
   },
 )
@@ -139,7 +148,7 @@ const props = withDefaults(
 const emit = defineEmits<{
   'update:amount': [value: string]
   'open-currency': []
-  'select-preset': [value: number]
+  'select-preset': [usdValue: number]
   focus: []
   blur: []
 }>()
@@ -167,10 +176,10 @@ const onKeyDown = (event: KeyboardEvent) => {
 
 const currencySymbol = computed(() => getCurrencySymbol(props.currency))
 
-const selectedPreset = computed(() => {
+const selectedUsdValue = computed(() => {
   if (props.amount === '') return null
   const n = Number(props.amount)
-  return props.presetAmounts.find(p => p === n) ?? null
+  return props.quickButtons.find(b => b.value === n)?.usdValue ?? null
 })
 
 const displayValue = computed(() => formatWithCommas(props.amount))
@@ -223,9 +232,9 @@ const onInput = async (event: Event) => {
   target.setSelectionRange(newCursor, newCursor)
 }
 
-const onSelectPreset = (preset: number) => {
-  emit('update:amount', String(preset))
-  emit('select-preset', preset)
+const onSelectPreset = (btn: QuickButton) => {
+  emit('update:amount', String(btn.value))
+  emit('select-preset', btn.usdValue)
 }
 
 const focus = () => inputEl.value?.focus()

--- a/src/stores/purchaseStore.ts
+++ b/src/stores/purchaseStore.ts
@@ -38,6 +38,10 @@ export const usePurchaseStore = defineStore('purchase', () => {
   const purchaseInfo = ref<PurchaseInfo | null>(null)
   const isFetching = ref(false)
 
+  // USD → target currency rates. Used to convert between fiats and compute
+  // localized quick-amount presets.
+  const exchangeRates = ref<Map<string, number>>(new Map())
+
   const buyQuotes = ref<BuyQuote[]>([])
   const isFetchingQuotes = ref(false)
   const buyQuotesError = ref('')
@@ -137,13 +141,38 @@ export const usePurchaseStore = defineStore('purchase', () => {
     return fiatsMap
   })
 
+  const fetchExchangeRates = async () => {
+    if (exchangeRates.value.size > 0) return
+    try {
+      const response = await fetch(configs.MEW_EXCHANGE_RATES_API)
+      if (!response.ok) return
+      const data: Array<{ fiat_currency: string; exchange_rate: string }> =
+        await response.json()
+      const map = new Map<string, number>()
+      data.forEach(({ fiat_currency, exchange_rate }) => {
+        const rate = Number(exchange_rate)
+        if (Number.isFinite(rate) && rate > 0) {
+          map.set(fiat_currency, rate)
+        }
+      })
+      exchangeRates.value = map
+    } catch (error) {
+      if (isDevMode) {
+        console.error('Failed to fetch exchange rates:', error)
+      }
+    }
+  }
+
   const fetchPurchaseInfo = async () => {
     if (purchaseInfo.value || isFetching.value) return
     isFetching.value = true
     const { useMEWFetch } = useFetchMewApi()
     try {
       const url = `${configs.MEW_PURCHASE_API}?includeMarketData=true`
-      const { data } = await useMEWFetch(url).get().json<PurchaseInfo>()
+      const [{ data }] = await Promise.all([
+        useMEWFetch(url).get().json<PurchaseInfo>(),
+        fetchExchangeRates(),
+      ])
       purchaseInfo.value = data.value
     } catch (error) {
       if (isDevMode) {
@@ -289,6 +318,7 @@ export const usePurchaseStore = defineStore('purchase', () => {
   return {
     purchaseInfo,
     isFetching,
+    exchangeRates,
     buyableCoinIds,
     fetchPurchaseInfo,
     isBuyable,


### PR DESCRIPTION
### Fix

## What
Replace the USD-only preset amounts in the buy flow with localized quick-amount buttons that adapt to the selected fiat currency using live USD→fiat exchange rates, and auto-convert the entered amount when the user switches currencies.

## Why
Previously the quick amount shortcuts ($15/$50/$100/$250) only showed when USD was selected, leaving non-USD users without shortcuts. With exchange-rate-aware amounts, every supported fiat gets meaningful presets (e.g. `₩20,250`), and switching currency preserves the user's intent instead of resetting the input.

## How
- Add `MEW_EXCHANGE_RATES_API` endpoint to `configs.ts` and fetch USD→fiat rates into a new `exchangeRates` map in `purchaseStore` (fetched alongside purchase info).
- Compute `quickButtons` in `ModuleBuy.vue` from the current fiat's rate: rounded localized equivalents of `[15, 50, 100, 250]`, or `Min`/`Max` fallbacks when the smallest preset rounds below 1.
- Watch `selectedFiat` and convert the current amount through USD when the currency changes.
- Refactor `PurchaseAmountInput.vue` to accept a typed `quickButtons: QuickButton[]` prop (label + value + usdValue) instead of raw `presetAmounts: number[]`, tracking selection by `usdValue`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Dynamic quick-amount buttons now adjust to your selected currency instead of fixed preset values
  * Automatic amount conversion when switching currencies using real-time exchange rates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->