### PR TITLE
fix: [MEW-1927] guard swap gas-fee quote against empty transactions

### DIFF
--- a/src/modules/swap/ModuleSwap.vue
+++ b/src/modules/swap/ModuleSwap.vue
@@ -1460,22 +1460,32 @@ watch(
 
 watch(
   () => selectedQuote.value,
-  async provider => {
+  async (provider, _prev, onCleanup) => {
     if (!provider) return
+    // A newer selectedQuote invalidates this run: flag it so late-resolving
+    // getSwap / gas-fee-quote calls don't overwrite state with stale data.
+    let cancelled = false
+    onCleanup(() => {
+      cancelled = true
+    })
     // disable proceeding while we fetch swap info for the selected quote to prevent user from clicking "proceed" before we have the necessary transaction data
     txProceeding.value = true
     try {
       const res = await getSwap(provider)
+      if (cancelled) return
       swapInfo.value = res
       const quoteRes = await (isBitcoinChain.value
         ? generateBTCGasFeeQuote()
         : generateEVMGasFeeQuote())
+      if (cancelled) return
       swapGasFeeQuote.value = (quoteRes as QuotesResponse) || undefined
     } catch (err) {
+      if (cancelled) return
+      swapInfo.value = null
       swapGasFeeQuote.value = undefined
       captureException(err)
     } finally {
-      txProceeding.value = false
+      if (!cancelled) txProceeding.value = false
     }
   },
   { deep: true },

--- a/src/modules/swap/ModuleSwap.vue
+++ b/src/modules/swap/ModuleSwap.vue
@@ -949,6 +949,8 @@ const generateBTCGasFeeQuote = async () => {
     (swapInfo.value?.transactions as GenericTransaction[]) || []
   ).map(tx => ({ address: tx.to, amount: tx.value }))
 
+  if (transactions.length === 0) return undefined
+
   const txForm = {
     fromAddresses: [userAddress.value],
     consolidationAddress: userAddress.value,
@@ -972,6 +974,9 @@ const generateEVMGasFeeQuote = async () => {
     value: tx.value || '0x0',
     action: dataTxAction(tx) as EvmTransactionAction,
   }))
+
+  if (parsedTransactions.length === 0) return undefined
+
   const res = await wallet.value?.getMultipleGasFees?.(parsedTransactions)
   return res
 }
@@ -1456,16 +1461,20 @@ watch(
 watch(
   () => selectedQuote.value,
   async provider => {
-    if (provider) {
-      // disable proceeding while we fetch swap info for the selected quote to prevent user from clicking "proceed" before we have the necessary transaction data
-      txProceeding.value = true
-      await getSwap(provider).then(async res => {
-        swapInfo.value = res
-        const quoteRes = await (isBitcoinChain.value
-          ? generateBTCGasFeeQuote()
-          : generateEVMGasFeeQuote())
-        swapGasFeeQuote.value = (quoteRes as QuotesResponse) || undefined
-      })
+    if (!provider) return
+    // disable proceeding while we fetch swap info for the selected quote to prevent user from clicking "proceed" before we have the necessary transaction data
+    txProceeding.value = true
+    try {
+      const res = await getSwap(provider)
+      swapInfo.value = res
+      const quoteRes = await (isBitcoinChain.value
+        ? generateBTCGasFeeQuote()
+        : generateEVMGasFeeQuote())
+      swapGasFeeQuote.value = (quoteRes as QuotesResponse) || undefined
+    } catch (err) {
+      swapGasFeeQuote.value = undefined
+      captureException(err)
+    } finally {
       txProceeding.value = false
     }
   },


### PR DESCRIPTION
## What was wrong

After choosing a swap quote, the app was occasionally throwing an unhandled "Invalid request body." error from the gas-fee quote step. This generated ~1735 reports in Sentry over the last ~2 months and was visible to the user as a silent failure (and a Sentry alert for us).

## What changed

In `src/modules/swap/ModuleSwap.vue`:

- `generateEVMGasFeeQuote` and `generateBTCGasFeeQuote` now early-return when there are no transactions to quote, instead of posting an empty list to the backend (which the backend rightly rejects with a 400).
- The watcher that fires after a quote is selected is now wrapped in try/catch, so any unexpected error during quote fetching is reported to Sentry but does not bubble up as an unhandled rejection.

User experience: the existing toast that fires when `getSwap` fails still triggers; there is no new UI.

## How to test

1. Open the app, connect a wallet, go to the Swap module.
2. Pick a from-token and to-token on Ethereum, enter an amount that produces quotes.
3. Pick a provider from the quote list and let the gas-fee step run.
4. Repeat across a couple of token pairs (including one where you previously saw the error, if you have one). Mobile Safari on iOS is the original-reported environment.

Expected: no "Invalid request body." showing up in the console / Sentry; swap flow proceeds normally. If the backend does reject the gas-fee request for any reason, the existing "something went wrong" toast appears instead of an unhandled rejection.

## Sentry

https://myetherwallet-inc.sentry.io/issues/7431687868/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined gas fee quote generation to prevent unnecessary calculations when no underlying transactions are detected, improving efficiency.
  * Enhanced swap operation error handling with improved exception tracking, state management, and recovery mechanisms during the process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->