### PR TITLE
fix: [MEW-1937] handle European locale comma and invalid values in parseUnits

### DIFF
--- a/src/components/AppEnterAmount.vue
+++ b/src/components/AppEnterAmount.vue
@@ -81,6 +81,7 @@ import {
   formatFiatValue,
 } from '@/utils/numberFormatHelper'
 import { useInFocusInput } from '@/composables/useInFocusInput'
+import { useNumericInput } from '@/composables/useNumericInput'
 
 const walletStore = useWalletStore()
 const { isLoadingBalances: isLoading, isWalletConnected } =
@@ -195,38 +196,5 @@ watch(
   },
 )
 
-const checkIfNumber = (e: KeyboardEvent) => {
-  const key = e.key
-  if (key >= '0' && key <= '9') {
-    return
-  }
-  if (key === '.' || key === ',') {
-    const input = amount.value.toString()
-    if (!input.includes('.')) {
-      if (key === ',') {
-        e.preventDefault()
-        const el = e.target as HTMLInputElement
-        const start = el.selectionStart ?? input.length
-        amount.value = input.slice(0, start) + '.' + input.slice(start)
-        nextTick(() => el.setSelectionRange(start + 1, start + 1))
-      }
-      return
-    }
-  }
-  e.preventDefault()
-}
-
-const onAmountPaste = (e: ClipboardEvent) => {
-  const pasted = e.clipboardData?.getData('text') ?? ''
-  if (/[,]/.test(pasted)) {
-    e.preventDefault()
-    const normalized = pasted.replace(/,/g, '.')
-    const el = e.target as HTMLInputElement
-    const start = el.selectionStart ?? 0
-    const end = el.selectionEnd ?? 0
-    const current = amount.value.toString()
-    amount.value =
-      current.slice(0, start) + normalized + current.slice(end)
-  }
-}
+const { checkIfNumber, onPaste: onAmountPaste } = useNumericInput(amount)
 </script>

--- a/src/components/AppEnterAmount.vue
+++ b/src/components/AppEnterAmount.vue
@@ -19,6 +19,7 @@
         v-model="amount"
         @focus="setInFocusInput"
         @keypress="checkIfNumber"
+        @paste="onAmountPaste"
       />
       <app-token-select
         v-model:selected-token-contract="selectedToken"
@@ -196,18 +197,36 @@ watch(
 
 const checkIfNumber = (e: KeyboardEvent) => {
   const key = e.key
-  // Numeric
   if (key >= '0' && key <= '9') {
     return
   }
-  // Only allow a single period
-  if (key === '.') {
+  if (key === '.' || key === ',') {
     const input = amount.value.toString()
     if (!input.includes('.')) {
+      if (key === ',') {
+        e.preventDefault()
+        const el = e.target as HTMLInputElement
+        const start = el.selectionStart ?? input.length
+        amount.value = input.slice(0, start) + '.' + input.slice(start)
+        nextTick(() => el.setSelectionRange(start + 1, start + 1))
+      }
       return
     }
   }
-  // Alphabetical (/non-numeric) or multiple periods. Don't propagate change
   e.preventDefault()
+}
+
+const onAmountPaste = (e: ClipboardEvent) => {
+  const pasted = e.clipboardData?.getData('text') ?? ''
+  if (/[,]/.test(pasted)) {
+    e.preventDefault()
+    const normalized = pasted.replace(/,/g, '.')
+    const el = e.target as HTMLInputElement
+    const start = el.selectionStart ?? 0
+    const end = el.selectionEnd ?? 0
+    const current = amount.value.toString()
+    amount.value =
+      current.slice(0, start) + normalized + current.slice(end)
+  }
 }
 </script>

--- a/src/composables/useNumericInput.ts
+++ b/src/composables/useNumericInput.ts
@@ -1,0 +1,39 @@
+import { nextTick, type Ref } from 'vue'
+
+export const useNumericInput = (model: Ref<string | number>) => {
+  const checkIfNumber = (e: KeyboardEvent) => {
+    const key = e.key
+    if (key >= '0' && key <= '9') {
+      return
+    }
+    if (key === '.' || key === ',') {
+      const input = model.value.toString()
+      if (!input.includes('.')) {
+        if (key === ',') {
+          e.preventDefault()
+          const el = e.target as HTMLInputElement
+          const start = el.selectionStart ?? input.length
+          model.value = input.slice(0, start) + '.' + input.slice(start)
+          nextTick(() => el.setSelectionRange(start + 1, start + 1))
+        }
+        return
+      }
+    }
+    e.preventDefault()
+  }
+
+  const onPaste = (e: ClipboardEvent) => {
+    const pasted = e.clipboardData?.getData('text') ?? ''
+    if (/[,]/.test(pasted)) {
+      e.preventDefault()
+      const normalized = pasted.replace(/,/g, '.')
+      const el = e.target as HTMLInputElement
+      const start = el.selectionStart ?? 0
+      const end = el.selectionEnd ?? 0
+      const current = model.value.toString()
+      model.value = current.slice(0, start) + normalized + current.slice(end)
+    }
+  }
+
+  return { checkIfNumber, onPaste }
+}

--- a/src/modules/send/ModuleSend.vue
+++ b/src/modules/send/ModuleSend.vue
@@ -140,6 +140,14 @@ import { useGlobalStore } from '@/stores/globalStore'
 import { ToastType } from '@/types/notification'
 import { useI18n } from 'vue-i18n'
 import { parseUnits, formatUnits } from 'viem'
+
+const safeParseUnits = (value: string, decimals: number): bigint => {
+  const normalized = value.replace(/,/g, '.')
+  if (!/^(-?)([0-9]*)\.?([0-9]*)$/.test(normalized) || normalized === '') {
+    return BigInt(0)
+  }
+  return parseUnits(normalized, decimals)
+}
 import { watchDebounced } from '@vueuse/core'
 import { useAddressInput } from '@/composables/useAddressInput'
 import { useMaxAmount } from '@/composables/useMaxAmount'
@@ -283,12 +291,12 @@ const checkAmountForError = () => {
   }
   //TODO: IMPLEMENET PROPER TO BASE AMOUNT in tokens
 
-  const baseTokenBalance = parseUnits(
+  const baseTokenBalance = safeParseUnits(
     tokenSelected.value?.balance || '0',
     tokenSelected.value?.decimals ?? 18,
   )
   const baseAmount = amount.value
-    ? parseUnits(amount.value.toString(), tokenSelected.value?.decimals ?? 18)
+    ? safeParseUnits(amount.value.toString(), tokenSelected.value?.decimals ?? 18)
     : BigInt(0)
   if (amount.value === undefined || amount.value === '')
     amountError.value = t('error.amount.required') // amount is undefined or blank
@@ -368,7 +376,7 @@ watch(
   },
 )
 const amountToHex = computed(() => {
-  const amountBase = parseUnits(
+  const amountBase = safeParseUnits(
     amount.value.toString(),
     tokenSelected.value?.decimals ?? 18,
   )
@@ -393,7 +401,7 @@ const getTxRequestBody = ():
         data.value = web3Contract.methods
           .transfer(
             toAddress.value,
-            parseUnits(
+            safeParseUnits(
               amount.value.toString(),
               tokenSelected.value?.decimals ?? 18,
             ).toString(),
@@ -419,7 +427,7 @@ const getTxRequestBody = ():
         outputs: [
           {
             address: toAddress.value ?? '',
-            amount: parseUnits(amount.value.toString(), 8).toString(),
+            amount: safeParseUnits(amount.value.toString(), 8).toString(),
           },
         ],
       }

--- a/src/modules/send/ModuleSend.vue
+++ b/src/modules/send/ModuleSend.vue
@@ -139,15 +139,8 @@ import { useToastStore } from '@/stores/toastStore'
 import { useGlobalStore } from '@/stores/globalStore'
 import { ToastType } from '@/types/notification'
 import { useI18n } from 'vue-i18n'
-import { parseUnits, formatUnits } from 'viem'
-
-const safeParseUnits = (value: string, decimals: number): bigint => {
-  const normalized = value.replace(/,/g, '.')
-  if (!/^(-?)([0-9]*)\.?([0-9]*)$/.test(normalized) || normalized === '') {
-    return BigInt(0)
-  }
-  return parseUnits(normalized, decimals)
-}
+import { formatUnits } from 'viem'
+import { safeParseUnits } from '@/utils/unit'
 import { watchDebounced } from '@vueuse/core'
 import { useAddressInput } from '@/composables/useAddressInput'
 import { useMaxAmount } from '@/composables/useMaxAmount'

--- a/src/utils/unit.ts
+++ b/src/utils/unit.ts
@@ -158,7 +158,7 @@ const toBase = (etherInput: string | number, decimals: number) => {
 
 const safeParseUnits = (value: string, decimals: number): bigint => {
   const normalized = value.replace(/,/g, '.')
-  if (!/^(-?)([0-9]*)\.?([0-9]*)$/.test(normalized) || normalized === '') {
+  if (!/^-?([0-9]+\.?[0-9]*|[0-9]*\.?[0-9]+)$/.test(normalized)) {
     return BigInt(0)
   }
   return parseUnits(normalized, decimals)

--- a/src/utils/unit.ts
+++ b/src/utils/unit.ts
@@ -7,6 +7,7 @@ Note, Richard is a god of ether gods. Follow and respect him, and use Ethers.io!
 */
 
 import BN from 'bn.js'
+import { parseUnits } from 'viem'
 
 const zero = new BN(0)
 const negative1 = new BN(-1)
@@ -155,4 +156,12 @@ const toBase = (etherInput: string | number, decimals: number) => {
   return wei.toString()
 }
 
-export { fromBase, toBase }
+const safeParseUnits = (value: string, decimals: number): bigint => {
+  const normalized = value.replace(/,/g, '.')
+  if (!/^(-?)([0-9]*)\.?([0-9]*)$/.test(normalized) || normalized === '') {
+    return BigInt(0)
+  }
+  return parseUnits(normalized, decimals)
+}
+
+export { fromBase, toBase, safeParseUnits }


### PR DESCRIPTION
## What was wrong

Users with European locales (Poland, Germany, France, etc.) type commas as decimal separators — e.g. `0,125` instead of `0.125`. viem's `parseUnits` only accepts periods, so it throws `InvalidDecimalNumberError` and crashes the Send module. A secondary variant occurs when a token's `balance` field contains a non-decimal string (hex hash from a malformed API response).

566 occurrences since April 2026 (Sentry APP-MEW-WEB-W5).

## What changed

- **AppEnterAmount.vue**: Comma keypress is now auto-converted to a period instead of being blocked. Pasted text with commas is also normalized to periods.
- **ModuleSend.vue**: All `parseUnits` calls are wrapped in a `safeParseUnits` helper that normalizes commas→periods and validates the input is a valid decimal before parsing. Invalid values fall back to `BigInt(0)` instead of throwing.

## How to test

1. Open the Send module (connect any wallet on Ethereum)
2. Type an amount using a comma as decimal separator (e.g. `0,125`) — it should auto-convert to `0.125`
3. Paste a value with commas (e.g. `1,5`) — should normalize to `1.5`
4. Verify normal decimal input (`0.5`, `100`) still works as expected
5. Verify balance validation (insufficient balance) still triggers correctly

Sentry: https://myetherwallet-inc.sentry.io/issues/7432800886/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved amount entry handling by converting comma decimal separators to periods during typing and paste, while preserving cursor/selection position.
  * Strengthened send amount parsing and validation to safely handle empty or malformed inputs, improving correctness for both token transfers and BTC sends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->