### PR TITLE
fix: 🐛 trap keyboard focus inside open dialogs

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="relative h-screen overflow-hidden">
+  <div class="relative h-screen overflow-hidden" :inert="isAreaHidden || undefined">
     <welcome-dialog v-if="!isDevMode" />
     <the-app-layout v-if="isLoadingComplete" :aria-hidden="isAreaHidden" />
     <module-toast />

--- a/src/components/AppDialog.vue
+++ b/src/components/AppDialog.vue
@@ -111,15 +111,13 @@
  * </template>
  * </app-dialog>
  */
-import { shallowRef, watch } from 'vue'
+import { shallowRef, watch, nextTick } from 'vue'
 import AppBtnIconClose from './AppBtnIconClose.vue'
-import { useFocus } from '@vueuse/core'
 import { useDialogStore } from '@/stores/dialogStore'
 import { storeToRefs } from 'pinia'
 
 const targetDialog = shallowRef<HTMLElement | null>(null)
 
-const { focused } = useFocus(targetDialog, { initialValue: true })
 const dialogStore = useDialogStore()
 const { isAreaHidden } = storeToRefs(dialogStore)
 
@@ -200,12 +198,13 @@ const setIsOpen = (_value: boolean = false) => {
 
 watch(
   () => isOpen.value,
-  () => {
-    if (isOpen.value && focused.value) {
-      isAreaHidden.value = true
-    } else {
-      isAreaHidden.value = false
+  async value => {
+    isAreaHidden.value = value
+    if (value) {
+      await nextTick()
+      targetDialog.value?.focus()
     }
   },
+  { immediate: true },
 )
 </script>


### PR DESCRIPTION
### Fix

### What
Add focus trapping to dialogs so Tab key navigation stays within the open modal instead of cycling through background elements.

### Why
When a dialog was open, pressing Tab allowed navigation through buttons behind the overlay, breaking keyboard accessibility expectations.

### How
Add :inert attribute to the app's main content wrapper when a dialog is open, preventing Tab from reaching background elements
Fix the dialog watch to always sync isAreaHidden with isOpen state (removed a buggy focused.value condition that caused timing issues)
Auto-focus the dialog container on open using nextTick to ensure the DOM is ready
Remove unused useFocus import that was no longer needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where background content remained interactive and focusable when a dialog was displayed, preventing unintended user interactions behind the modal.
  * Enhanced dialog focus management to ensure keyboard focus is properly placed on the dialog element when it opens, improving accessibility and overall user experience when navigating with keyboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->