### PR TITLE
fix: [MEW-1946] stop reporting expected swap pair-not-available to sentry

### DIFF
--- a/src/modules/swap/ModuleSwap.vue
+++ b/src/modules/swap/ModuleSwap.vue
@@ -1480,6 +1480,11 @@ watch(
         swapGasFeeQuote.value = (quoteRes as QuotesResponse) || undefined
       })
       txProceeding.value = false
+    } else {
+      // No quote selected (e.g. pair has no route). Clear stale swap data so
+      // swapForEvm's `!swapInfo.value` guard reliably reports "pair not
+      // available" instead of proceeding with data from a previous quote.
+      swapInfo.value = null
     }
   },
   { deep: true },

--- a/src/modules/swap/ModuleSwap.vue
+++ b/src/modules/swap/ModuleSwap.vue
@@ -985,15 +985,7 @@ const swapForEvm = async () => {
     await debounceFetchQuotes()
 
     if (!swapInfo.value) {
-      // Expected, user-facing condition: the selected pair has no available
-      // route/quote. Surface the message and track analytics, but do NOT throw
-      // into the catch below — that would report this to Sentry as noise.
-      generalError.value = t('swap.error.pair-not-available')
-      analytics.trackSwapEventError(SwapEventError.OFFER_ERROR, {
-        ...analyticsPayload,
-        errorMsg: 'Pair currently not available',
-      })
-      return
+      throw new Error(t('swap.error.pair-not-available'))
     }
     const res = await generateEVMGasFeeQuote()
 
@@ -1001,6 +993,11 @@ const swapForEvm = async () => {
     bestOfferSelectionOpen.value = true
   } catch (e: any) {
     generalError.value = e?.message || 'Error fetching gas fees'
+    // "Pair not available" is an expected, user-facing condition (the selected
+    // pair has no route/quote). Keep the throw so generalError + analytics are
+    // handled here as designed, but skip the Sentry report to avoid noise.
+    const isPairNotAvailable =
+      e?.message === t('swap.error.pair-not-available')
     if (isDevMode) {
       console.error('Error fetching gas fees:', e)
     } else {
@@ -1008,13 +1005,15 @@ const swapForEvm = async () => {
         ...analyticsPayload,
         errorMsg: generalError.value,
       })
-      captureException(e, {
-        ...SENTRY_MODULE_TAGS.SWAP,
-        extra: {
-          title: 'SWAP: Error fetching gas fees',
-          errorMessage: generalError.value,
-        },
-      })
+      if (!isPairNotAvailable) {
+        captureException(e, {
+          ...SENTRY_MODULE_TAGS.SWAP,
+          extra: {
+            title: 'SWAP: Error fetching gas fees',
+            errorMessage: generalError.value,
+          },
+        })
+      }
     }
   } finally {
     bestSwapLoadingOpen.value = false

--- a/src/modules/swap/ModuleSwap.vue
+++ b/src/modules/swap/ModuleSwap.vue
@@ -985,7 +985,15 @@ const swapForEvm = async () => {
     await debounceFetchQuotes()
 
     if (!swapInfo.value) {
-      throw new Error(t('swap.error.pair-not-available'))
+      // Expected, user-facing condition: the selected pair has no available
+      // route/quote. Surface the message and track analytics, but do NOT throw
+      // into the catch below — that would report this to Sentry as noise.
+      generalError.value = t('swap.error.pair-not-available')
+      analytics.trackSwapEventError(SwapEventError.OFFER_ERROR, {
+        ...analyticsPayload,
+        errorMsg: 'Pair currently not available',
+      })
+      return
     }
     const res = await generateEVMGasFeeQuote()
 


### PR DESCRIPTION
## What was wrong

When a user picked a token pair on Swap that has no available route, clicking **Swap** still showed the "Pair currently not available" message — but it was *also* being logged to Sentry as an error. This isn't a real crash; it's an expected outcome, so it just created noise (131 events, **0 users impacted**).

## What changed

The "no available pair" case is now treated as a normal, expected user message instead of an error: the message is shown to the user and the analytics event is tracked, but it's no longer sent to Sentry. Genuine failures while fetching gas fees are still reported to Sentry as before.

## How to test

1. Open the wallet and go to the **Swap** module (Home), connected on **Ethereum**.
2. Pick a from/to token pair that has **no available swap route** (an obscure/illiquid pairing).
3. Enter an amount and click **Swap**.
4. **Expected:** the UI shows "Pair currently not available" (or similar). No crash. (And no new Sentry event is generated for this case.)
5. Sanity check the happy path: a normal, liquid pair (e.g. ETH → USDC) still fetches quotes and opens the offer selection.

## Sentry

https://myetherwallet-inc.sentry.io/issues/7522959580/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap handling when no route/pair is available: users now reliably see a clear “pair not available” message, without triggering the generic exception/error flow.
  * When a previously selected quote becomes unavailable, the app now clears the related swap details immediately to prevent stale transaction data from being reused on the next swap attempt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->