### PR TITLE
fix: [MEW-1947] stop reporting wallet icon dynamic-import failures to sentry

### DIFF
--- a/src/modules/access/components/wallets_lists/BtnWallet.vue
+++ b/src/modules/access/components/wallets_lists/BtnWallet.vue
@@ -65,8 +65,6 @@ import {
 import { onMounted, ref } from 'vue'
 import { analytics } from '@/analytics'
 import { ConnectWalletEvent } from '@/analytics/events'
-import { captureException } from '@sentry/vue'
-import { SENTRY_MODULE_TAGS } from '@/sentry/constants'
 
 const props = defineProps<{
   wallet: WalletConfig
@@ -107,14 +105,12 @@ const resolveImg = async (_img: () => Promise<string>) => {
     const image = await _img()
     img.value = image
   } catch (error) {
-    captureException(error, {
-      ...SENTRY_MODULE_TAGS.ACCESS,
-      extra: {
-        title: 'BTN WALLET: Error loading wallet image',
-        walletName: props.wallet.name,
-        errorMessage: error,
-      },
-    })
+    // The wallet icon is lazily imported as a hashed JS chunk. Failing to load it
+    // (network blip, stale chunk after a redeploy, content blockers) is expected and
+    // non-actionable — AsyncImg already falls back to a placeholder. Don't report noise.
+    if (import.meta.env.DEV) {
+      console.error('Error loading wallet image:', props.wallet.name, error)
+    }
   } finally {
     isLoadedImg.value = true
   }


### PR DESCRIPTION
## What was wrong

On the wallet-selection screen (`/access`), some wallet logos are loaded on demand as small JS chunks. When one of those chunks failed to load (a network blip, a stale file after a new deploy, or a content blocker), the app logged it to Sentry as an error — 423 times so far, with **0 users impacted**. The logo simply doesn't appear (a grey placeholder shows instead), so there's no actual breakage for the user — it was just noise.

## What changed

The failed wallet-logo load is now treated as the expected, harmless event it is: the placeholder still shows, and we no longer send these to Sentry. In local development we still log it to the console for debugging.

## How to test

1. Open the app and go to **Access** / Connect Wallet (`/access`).
2. Select an EVM network so the full wallet list renders (Gate Wallet, oneInch, etc.).
3. **Expected:** the wallet list renders normally; every wallet shows either its logo or a neutral grey placeholder if the logo can't load. No crash.
4. (Optional, to simulate failure) In DevTools → Network, block/offline one of the `*Wallet-*.js` chunk requests and reopen the list — the wallet shows the grey placeholder, no error surfaces to the user, and no Sentry event is generated.

## Sentry

https://myetherwallet-inc.sentry.io/issues/7378467514/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated error logging for wallet image loading with development environment adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->