### PR TITLE
fix: [MEW-1948] detect fetch AbortError by error object, not typeof string

### DIFF
--- a/src/composables/useFetchMewApi.ts
+++ b/src/composables/useFetchMewApi.ts
@@ -61,11 +61,17 @@ export const useFetchMewApi = (
         if (isDevMode) {
           console.error('Fetch Error: ', data, error)
         }
-        if (
-          error &&
-          typeof error === 'string' &&
-          error.includes('AbortError')
-        ) {
+        // `ctx.error` from useFetch is an Error/DOMException object (name
+        // "AbortError"), not a string, when a request is aborted (refetch on
+        // input change, navigation, unmount, timeout). The old `typeof string`
+        // guard never matched, so aborts were needlessly retried 3x and then
+        // reported to Sentry as noise. Detect the abort from the error object.
+        const isAbortError =
+          (error instanceof DOMException && error.name === 'AbortError') ||
+          (error instanceof Error &&
+            error.message.toLowerCase().includes('abort')) ||
+          (typeof error === 'string' && error.toLowerCase().includes('abort'))
+        if (isAbortError) {
           delete ctx.error
           return ctx
         }

--- a/src/composables/useFetchMewApi.ts
+++ b/src/composables/useFetchMewApi.ts
@@ -65,12 +65,15 @@ export const useFetchMewApi = (
         // "AbortError"), not a string, when a request is aborted (refetch on
         // input change, navigation, unmount, timeout). The old `typeof string`
         // guard never matched, so aborts were needlessly retried 3x and then
-        // reported to Sentry as noise. Detect the abort from the error object.
+        // reported to Sentry as noise. Detect the abort from structured signals
+        // (name / known cancel code) rather than a loose message substring,
+        // which could swallow genuine errors that merely contain "abort".
         const isAbortError =
           (error instanceof DOMException && error.name === 'AbortError') ||
           (error instanceof Error &&
-            error.message.toLowerCase().includes('abort')) ||
-          (typeof error === 'string' && error.toLowerCase().includes('abort'))
+            ((error as Error & { code?: string }).name === 'AbortError' ||
+              (error as Error & { code?: string }).code === 'ERR_CANCELED')) ||
+          (typeof error === 'string' && error.includes('AbortError'))
         if (isAbortError) {
           delete ctx.error
           return ctx


### PR DESCRIPTION
## What was wrong

When the app fetches gas-fee estimates (e.g. on Send / Home), it cancels the in-flight request whenever inputs change, the user navigates away, or a request times out — this is normal and expected. But a guard meant to ignore those cancellations was checking the wrong thing, so each cancellation was (a) needlessly retried up to 3 times and (b) logged to Sentry as an error. 846 such events were recorded, with **0 users impacted** — pure noise.

## What changed

The cancellation (`AbortError`) is now correctly recognized, so the app stops retrying cancelled requests and no longer reports them to Sentry. No change to what the user sees.

## How to test

1. Open the app and go to a flow that estimates gas fees — **Send** (Home), connected with any wallet on an EVM network (e.g. Ethereum).
2. Type/change the amount or recipient a few times quickly so the fee estimate re-fetches and cancels the prior request; also try navigating away mid-estimate.
3. **Expected:** fees still load and display correctly; changing inputs updates the fee; no error toast; the app behaves exactly as before. (Under the hood, cancelled requests are no longer retried or sent to Sentry.)
4. Sanity check: trigger a genuine fee-fetch failure (e.g. offline) and confirm the normal error handling/retry still works.

## Sentry

https://myetherwallet-inc.sentry.io/issues/7420348948/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Improved handling of cancelled API requests to better recognize abort scenarios, preventing unnecessary error alerts and automatic retry/polling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->