### PR TITLE
fix: [MEW-1949] look up hardware wallet by derivation index in access()

### DIFF
--- a/src/modules/access/ModuleAccessHardwareWallet.vue
+++ b/src/modules/access/ModuleAccessHardwareWallet.vue
@@ -566,7 +566,15 @@ const walletConfig: ComputedRef<WalletConfig | null> = computed(() => {
 const { closeAccessDialog } = useAccessStore()
 
 const access = async () => {
-  const wallet = walletList.value[selectedIndex.value]?.walletInstance
+  // `selectedIndex` holds the derivation index (set by SelectAddressList from
+  // `walletList[i].index`), not the array position. On page 2+ those differ, so
+  // indexing the array directly returned undefined and crashed in
+  // markRaw(undefined). Look the entry up by its derivation index and bail out
+  // if none matches.
+  const wallet = walletList.value.find(
+    item => item.index === selectedIndex.value,
+  )?.walletInstance
+  if (!wallet) return
   isUnlockingWallet.value = true
 
   setWallet(


### PR DESCRIPTION
## What was wrong

When connecting a hardware wallet (Ledger), the address list is paginated 5 at a time. If the user clicked **next page**, selected an address on page 2 or later, and pressed **Access Wallet**, the app crashed (`TypeError: Cannot convert undefined or null to object`). It only worked on the first page — a real, unhandled crash (584 occurrences in Sentry).

## What changed

The connect action now finds the selected address by its actual derivation index instead of assuming it matches a position in the current page's list, so selecting an address on any page connects correctly. If somehow no matching address is found, it safely does nothing instead of crashing.

## How to test

1. Open `/access` → **Ledger** (hardware wallet) flow → connect the device and reach the address list (step 2). *(A real Ledger or the usual test device is needed for the full flow.)*
2. Click **Next** to load page 2 of addresses.
3. Select any address on page 2 → click **Access Wallet**.
4. **Expected:** the wallet connects with the selected address (dialog closes, wallet shown). No crash.
5. Regression check: page 1 selection + connect still works as before.

## Sentry

https://myetherwallet-inc.sentry.io/issues/7367768284/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hardware wallet selection failing on paginated results or later pages by correctly resolving the chosen wallet instance based on its derivation index.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->