### PR TITLE
refactor: ♻️  network switching and overlay

### DIFF
--- a/src/i18n/locales/purchase/en.json
+++ b/src/i18n/locales/purchase/en.json
@@ -8,6 +8,8 @@
       "connect_wallet": "Connect wallet",
       "no_quotes": "No quotes found",
       "need_help": "Need help buying?",
+      "network_not_supported": "Network not supported",
+      "network_not_available": "Buying is not available on {network}. Switch to a supported network.",
       "error": {
         "min": "Minimum {min} allowed",
         "max": "Maximum {max} allowed",
@@ -24,6 +26,8 @@
       "need_help": "Need help selling?",
       "network_fee": "Network fee",
       "network_fee_tooltip": "Fees in the {chain} network are charged in {symbol}",
+      "network_not_supported": "Network not supported",
+      "network_not_available": "Selling is not available on {network}. Switch to a supported network.",
       "error": {
         "min": "Minimum {min} allowed",
         "max": "Maximum {max} allowed",

--- a/src/modules/purchase/ModuleBuy.vue
+++ b/src/modules/purchase/ModuleBuy.vue
@@ -1,54 +1,70 @@
 <template>
-  <div class="flex flex-col gap-3 h-full">
-    <purchase-token-select-card
-      v-if="displayChain"
-      :chain="displayChain"
-      :token="selectedToken"
-      @click="showTokenModal = true"
-    />
-    <purchase-amount-input
-      :label="t('purchase.buy.youre_buying')"
-      :currency="selectedFiat"
-      :amount="fiatAmount"
-      :estimate="formattedCryptoEstimate"
-      :is-loading="isFetchingEstimate"
-      :error-message="amountError"
-      :helper-message="amountHelper"
-      :quick-buttons="quickButtons"
-      @update:amount="onFiatAmountChange"
-      @open-currency="showCurrencyModal = true"
-      @focus="isInputFocused = true"
-      @blur="isInputFocused = false"
-    />
-
-    <button
-      type="button"
-      :class="[
-        'h-12 w-full rounded-24 px-4 flex items-center justify-center gap-2 font-semibold text-s-16 tracking-[-0.32px] transition-colors',
-        ctaIsPrimary
-          ? 'bg-primary text-white hoverOpacityHasBG'
-          : 'bg-bgBase text-grey-50 cursor-not-allowed',
-      ]"
-      :disabled="ctaDisabled"
-      @click="onSubmit"
-    >
-      <span
-        v-if="ctaIsLoading"
-        class="inline-block w-5 h-5 rounded-full border-2 border-white/30 border-t-white animate-spin"
+  <div class="relative flex flex-col h-full">
+    <div :class="['flex flex-col gap-3 h-full', blurClass]">
+      <purchase-token-select-card
+        v-if="displayChain"
+        :chain="displayChain"
+        :token="selectedToken"
+        @click="showTokenModal = true"
       />
-      <span v-else>{{ ctaLabel }}</span>
-    </button>
+      <purchase-amount-input
+        :label="t('purchase.buy.youre_buying')"
+        :currency="selectedFiat"
+        :amount="fiatAmount"
+        :estimate="formattedCryptoEstimate"
+        :is-loading="isFetchingEstimate"
+        :error-message="amountError"
+        :helper-message="amountHelper"
+        :quick-buttons="quickButtons"
+        @update:amount="onFiatAmountChange"
+        @open-currency="showCurrencyModal = true"
+        @focus="isInputFocused = true"
+        @blur="isInputFocused = false"
+      />
 
-    <a
-      href="https://help.myetherwallet.com/"
-      target="_blank"
-      rel="noopener"
-      class="mt-auto self-center text-s-12 font-semibold text-primary tracking-[-0.24px] hover:underline"
-    >
-      {{ t('purchase.buy.need_help') }}
-    </a>
+      <button
+        type="button"
+        :class="[
+          'h-12 w-full rounded-24 px-4 flex items-center justify-center gap-2 font-semibold text-s-16 tracking-[-0.32px] transition-colors',
+          ctaIsPrimary
+            ? 'bg-primary text-white hoverOpacityHasBG'
+            : 'bg-bgBase text-grey-50 cursor-not-allowed',
+        ]"
+        :disabled="ctaDisabled"
+        @click="onSubmit"
+      >
+        <span
+          v-if="ctaIsLoading"
+          class="inline-block w-5 h-5 rounded-full border-2 border-white/30 border-t-white animate-spin"
+        />
+        <span v-else>{{ ctaLabel }}</span>
+      </button>
 
-    <purchase-footer class="pt-2" />
+      <a
+        href="https://help.myetherwallet.com/"
+        target="_blank"
+        rel="noopener"
+        class="mt-auto self-center text-s-12 font-semibold text-primary tracking-[-0.24px] hover:underline"
+      >
+        {{ t('purchase.buy.need_help') }}
+      </a>
+
+      <purchase-footer class="pt-2" />
+    </div>
+
+    <purchase-unsupported-network
+      v-if="showUnsupportedNetwork"
+      :title="t('purchase.buy.network_not_supported')"
+      :description="
+        t('purchase.buy.network_not_available', {
+          network:
+            walletChain?.nameLong ?? walletChain?.name ?? t('common.network'),
+        })
+      "
+      :chains="supportedNetworkChains"
+      :default-chain="defaultSupportedChain"
+      class="absolute inset-x-2 top-[88px] z-20"
+    />
 
     <purchase-token-modal
       v-model:is-open="showTokenModal"
@@ -91,10 +107,12 @@ import PurchaseTokenModal from './components/PurchaseTokenModal.vue'
 import PurchaseCurrencyModal from './components/PurchaseCurrencyModal.vue'
 import BuyProviderModal from './components/BuyProviderModal.vue'
 import PurchaseFooter from './components/PurchaseFooter.vue'
+import PurchaseUnsupportedNetwork from './components/PurchaseUnsupportedNetwork.vue'
 
 import { usePurchaseStore } from '@/stores/purchaseStore'
 import { useWalletStore } from '@/stores/walletStore'
 import { useChainsStore } from '@/stores/chainsStore'
+import { useGlobalStore } from '@/stores/globalStore'
 import { useAccessStore } from '@/stores/accessStore'
 import { useWalletMenuStore } from '@/stores/walletMenuStore'
 
@@ -140,8 +158,35 @@ const isReady = computed(() => isWalletConnected.value && !isWatchOnly.value)
 
 const chainsStore = useChainsStore()
 const { selectedChain: walletChain, chains } = storeToRefs(chainsStore)
+const globalStore = useGlobalStore()
 
 const { compatibleChainCodes, incompatibleChainCodes } = usePurchaseCompatibility(buyNetworks, walletChain, chains)
+
+const supportedNetworkChains = computed<Chain[]>(() =>
+  compatibleChainCodes.value
+    .map(code => purchaseChainToChain(code, chains.value))
+    .filter((c): c is Chain => !!c),
+)
+
+const supportedNetwork = computed(() => {
+  const code = v7ToPurchaseChain(walletChain.value?.name)
+  return !!code && compatibleChainCodes.value.includes(code)
+})
+
+const defaultSupportedChain = computed<Chain | null>(
+  () =>
+    supportedNetworkChains.value.find(c => c.name === 'ETHEREUM') ??
+    supportedNetworkChains.value[0] ??
+    null,
+)
+
+const showUnsupportedNetwork = computed(
+  () => !!purchaseInfo.value && !supportedNetwork.value,
+)
+
+const blurClass = computed(() =>
+  showUnsupportedNetwork.value ? 'blur-sm pointer-events-none opacity-60' : '',
+)
 
 const accessStore = useAccessStore()
 
@@ -298,11 +343,12 @@ const ctaIsPrimary = computed(
 
 const ctaDisabled = computed(
   () =>
-    isReady.value &&
-    (!amountIsValid.value ||
-      isFetchingEstimate.value ||
-      isFetchingQuotes.value ||
-      hasNoQuotes.value),
+    showUnsupportedNetwork.value ||
+    (isReady.value &&
+      (!amountIsValid.value ||
+        isFetchingEstimate.value ||
+        isFetchingQuotes.value ||
+        hasNoQuotes.value)),
 )
 
 const ctaIsLoading = computed(
@@ -353,6 +399,14 @@ watch(walletChain, chain => {
   }
 })
 
+watch(selectedToken, token => {
+  if (!token) return
+  const tokenChain = purchaseChainToChain(token.chain, chains.value)
+  if (tokenChain && tokenChain.name !== walletChain.value?.name) {
+    globalStore.setSelectedNetwork(tokenChain.name)
+  }
+})
+
 watch(currencyOptions, options => {
   if (options.length && !options.includes(selectedFiat.value)) {
     selectedFiat.value = options.includes(DEFAULT_FIAT) ? DEFAULT_FIAT : options[0]
@@ -381,6 +435,7 @@ watch(
 )
 
 const onSubmit = async () => {
+  if (showUnsupportedNetwork.value) return
   if (!isReady.value) {
     accessStore.openAccessDialog()
     return

--- a/src/modules/purchase/ModuleSell.vue
+++ b/src/modules/purchase/ModuleSell.vue
@@ -1,5 +1,6 @@
 <template>
-  <div class="flex flex-col gap-3 h-full">
+  <div class="relative flex flex-col h-full">
+    <div :class="['flex flex-col gap-3 h-full', blurClass]">
     <purchase-token-select-card
       v-if="displayChain"
       :chain="displayChain"
@@ -100,6 +101,21 @@
     <div class="hidden">
       <app-select-tx-fee ref="feeSelector" />
     </div>
+    </div>
+
+    <purchase-unsupported-network
+      v-if="showUnsupportedNetwork"
+      :title="t('purchase.sell.network_not_supported')"
+      :description="
+        t('purchase.sell.network_not_available', {
+          network:
+            walletChain?.nameLong ?? walletChain?.name ?? t('common.network'),
+        })
+      "
+      :chains="supportedNetworkChains"
+      :default-chain="defaultSupportedChain"
+      class="absolute inset-x-2 top-[88px] z-20"
+    />
 
     <purchase-token-modal
       v-model:is-open="showTokenModal"
@@ -140,6 +156,7 @@ import PurchaseAmountInput from './components/PurchaseAmountInput.vue'
 import PurchaseTokenModal from './components/PurchaseTokenModal.vue'
 import PurchaseCurrencyModal from './components/PurchaseCurrencyModal.vue'
 import SellProviderModal from './components/SellProviderModal.vue'
+import PurchaseUnsupportedNetwork from './components/PurchaseUnsupportedNetwork.vue'
 import AppSelectTxFee from '@/components/AppSelectTxFee.vue'
 
 import { usePurchaseStore } from '@/stores/purchaseStore'
@@ -164,6 +181,7 @@ const { t } = useI18n()
 
 const purchaseStore = usePurchaseStore()
 const {
+  purchaseInfo,
   isFetching,
   sellNetworks,
   sellFiats,
@@ -191,6 +209,32 @@ const { selectedChain: walletChain, chains } = storeToRefs(chainsStore)
 const globalStore = useGlobalStore()
 
 const { compatibleChainCodes, incompatibleChainCodes } = usePurchaseCompatibility(sellNetworks, walletChain, chains)
+
+const supportedNetworkChains = computed<Chain[]>(() =>
+  compatibleChainCodes.value
+    .map(code => purchaseChainToChain(code, chains.value))
+    .filter((c): c is Chain => !!c),
+)
+
+const supportedNetwork = computed(() => {
+  const code = v7ToPurchaseChain(walletChain.value?.name)
+  return !!code && compatibleChainCodes.value.includes(code)
+})
+
+const defaultSupportedChain = computed<Chain | null>(
+  () =>
+    supportedNetworkChains.value.find(c => c.name === 'ETHEREUM') ??
+    supportedNetworkChains.value[0] ??
+    null,
+)
+
+const showUnsupportedNetwork = computed(
+  () => !!purchaseInfo.value && !supportedNetwork.value,
+)
+
+const blurClass = computed(() =>
+  showUnsupportedNetwork.value ? 'blur-sm pointer-events-none opacity-60' : '',
+)
 
 const accessStore = useAccessStore()
 
@@ -426,7 +470,8 @@ const ctaIsPrimary = computed(() => !isReady.value || amountIsValid.value)
 
 const ctaDisabled = computed(
   () =>
-    isReady.value && (!amountIsValid.value || isFetchingSellQuote.value),
+    showUnsupportedNetwork.value ||
+    (isReady.value && (!amountIsValid.value || isFetchingSellQuote.value)),
 )
 
 const ctaIsLoading = computed(
@@ -486,6 +531,7 @@ watch(
 )
 
 const onSubmit = () => {
+  if (showUnsupportedNetwork.value) return
   if (!isReady.value) {
     accessStore.openAccessDialog()
     return

--- a/src/modules/purchase/components/PurchaseUnsupportedNetwork.vue
+++ b/src/modules/purchase/components/PurchaseUnsupportedNetwork.vue
@@ -1,0 +1,38 @@
+<template>
+  <div
+    class="px-5 py-5 bg-white border border-warning rounded-16 shadow-button shadow-button-elevated"
+  >
+    <div class="flex items-center gap-2 justify-center mb-2">
+      <exclamation-circle-icon class="w-5 h-5 text-warning" />
+      <p class="text-warning font-medium text-s-16">{{ title }}</p>
+    </div>
+    <p class="text-info text-s-14 text-center mb-4">{{ description }}</p>
+    <select-chain-for-app
+      :passed-chains="chains"
+      :preselected-chain="defaultChain"
+      :can-store="false"
+      id="PURCHASE:NetworkNotSupported"
+      @update:selected-chain="onSelect"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ExclamationCircleIcon } from '@heroicons/vue/24/solid'
+import SelectChainForApp from '@/components/select_chain/SelectChainForApp.vue'
+import { useGlobalStore } from '@/stores/globalStore'
+import type { Chain } from '@/mew_api/types'
+
+defineProps<{
+  title: string
+  description: string
+  chains: Chain[]
+  defaultChain: Chain | null
+}>()
+
+const globalStore = useGlobalStore()
+
+const onSelect = (chain: Chain) => {
+  globalStore.setSelectedNetwork(chain.name)
+}
+</script>


### PR DESCRIPTION
### Fix

## What
Add an unsupported-network overlay to the Buy and Sell modules that blurs the form and lets the user switch to a supported network when the current wallet chain isn't available for purchase.

## Why
Buying/selling is restricted to certain networks; previously the form was usable on unsupported chains, leading to failed flows. This guides the user to a valid network instead.

## How
- New PurchaseUnsupportedNetwork component with a warning message and a chain selector
- ModuleBuy and ModuleSell blur and disable the form when the wallet chain isn't supported, showing the overlay
- Selecting a chain updates the global network; selecting a token also syncs the network in Buy
- Add network_not_supported / network_not_available i18n strings for buy and sell



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added unsupported-network handling to both the buy and sell purchase flows
  * Introduced a new “network not supported” overlay with a chain selector to switch to supported networks
* **Bug Fixes**
  * Prevents purchase submission from starting when the selected wallet network is unsupported
* **UI Improvements**
  * Purchase inputs and actions are now blurred/disabled when unsupported
  * Added localized “network not supported” / “network not available” messaging for purchase flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->