### PR TITLE
fix: 🐛 sentry error proposal expired

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -35,6 +35,10 @@ if (dsn) {
       'TypeError: Failed to fetch',
       'TypeError: NetworkError when attempting to fetch resource',
       'TypeError: Load failed',
+      // WalletConnect benign rejections when the user abandons the connection flow
+      'Proposal expired',
+      'Pairing expired',
+      'Request expired',
     ],
     integrations: [
       browserTracingIntegration({ router }),

--- a/src/modules/access/composables/useConnectWallet.ts
+++ b/src/modules/access/composables/useConnectWallet.ts
@@ -269,13 +269,6 @@ export const useConnectWallet = () => {
           error = 'Connection timed out. Please try again.'
           _type = ToastType.Info
         }
-        if (
-          err.message &&
-          err.message.toLowerCase().includes('proposal expired')
-        ) {
-          error = 'Connection timed out. Please try again.'
-          _type = ToastType.Info
-        }
         toastStore.addToastMessage({
           text: 'Could not connect to wallet',
           textSecondary: error,


### PR DESCRIPTION
### Fix

## What
Filter WalletConnect "Proposal expired" rejections out of Sentry and remove duplicated error-handling code in the wallet connection flow.

## Why
"Proposal expired" is a benign WalletConnect rejection that fires when a user abandons the connection flow (the session proposal times out after 300s). It was being reported as an unhandled rejection via the browser global handler, generating ~4.2K noisy Sentry events with no actionable signal.

## How
- Add `Proposal expired`, `Pairing expired` and `Request expired` to Sentry's `ignoreErrors` so these expirations stop counting as crashes.
- Remove a duplicated `if` block (merge artifact) in `useConnectWallet` that handled the same "proposal expired" case twice.
- User-facing behavior is unchanged: the informational "Connection timed out" toast still shows when applicable.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of WalletConnect-related timeouts and rejections so routine expiration messages are no longer reported as errors.
  * Restored the standard connection error feedback when a wallet connection request expires, keeping the in-app message and alert style consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->