### PR TITLE
fix: [MEW-1956] don't report expected 1inch 4xx quote errors to sentry

### DIFF
--- a/src/modules/trade/composables/useTradeQuote.ts
+++ b/src/modules/trade/composables/useTradeQuote.ts
@@ -121,9 +121,13 @@ export function useTradeQuote(options: UseTradeQuoteOptions) {
     } catch (e) {
       generalError.value = (e as Error).message || 'Failed to fetch quote'
       toAmount.value = '0'
+      // Expected client errors (1inch 4xx, flagged by OneInchFusion.getQuote)
+      // are surfaced to the user above but are pure Sentry noise — skip them.
+      const isExpectedClientError = !!(e as { expectedClientError?: boolean })
+        .expectedClientError
       if (isDevMode) {
         console.error('Error fetching quote:', e)
-      } else {
+      } else if (!isExpectedClientError) {
         captureException(e, {
           ...SENTRY_MODULE_TAGS.TRADE,
           extra: {

--- a/src/modules/trade/providers/oneinch_fusion/oneInchFusion.ts
+++ b/src/modules/trade/providers/oneinch_fusion/oneInchFusion.ts
@@ -161,15 +161,24 @@ class OneInchFusion {
           2n,
       }
     } catch (e: unknown) {
+      const status = (e as AxiosError).response?.status
       const response =
         ((e as AxiosError).response?.data as any)?.description || null
 
-      captureException(e, {
-        ...SENTRY_MODULE_TAGS.TRADE,
-        extra: {
-          title: 'TRADE: Error fetching quote from 1inch',
-        },
-      })
+      // 1inch returns 4xx (e.g. 400 Bad Request) for expected, user-facing quote
+      // failures: amount below minimum, illiquid/unsupported pair, invalid params.
+      // Those are surfaced to the user by the caller — don't report them to Sentry
+      // as noise. Only report genuinely unexpected errors (5xx / network / no response).
+      const isExpectedClientError =
+        typeof status === 'number' && status >= 400 && status < 500
+      if (!isExpectedClientError) {
+        captureException(e, {
+          ...SENTRY_MODULE_TAGS.TRADE,
+          extra: {
+            title: 'TRADE: Error fetching quote from 1inch',
+          },
+        })
+      }
       throw new Error(
         response || (e as Error).message || 'Failed to fetch quote from 1inch',
       )

--- a/src/modules/trade/providers/oneinch_fusion/oneInchFusion.ts
+++ b/src/modules/trade/providers/oneinch_fusion/oneInchFusion.ts
@@ -28,6 +28,8 @@ import {
 } from './configs'
 import { Web3ProviderConnector } from './oneInchProvider'
 import type { AxiosError } from 'axios'
+// NOTE: getQuote no longer reports to Sentry directly — reporting is centralized
+// in the caller (useTradeQuote) so expected 4xx client errors can be skipped.
 import type BaseEvmWallet from '@/providers/ethereum/baseEvmWallet'
 import type {
   GetWebSwapOndoAssetsResponse,
@@ -37,8 +39,6 @@ import type {
 import { prepareTransactionRequest } from 'viem/actions'
 import { isSignableWallet } from '@/utils/walletUtils'
 import { getAPIPath } from '@/utils/constructAPIPath'
-import { captureException } from '@sentry/vue'
-import { SENTRY_MODULE_TAGS } from '@/sentry/constants'
 export type HardcodedTokenInfo = {
   address: string
   cgId: string
@@ -167,21 +167,15 @@ class OneInchFusion {
 
       // 1inch returns 4xx (e.g. 400 Bad Request) for expected, user-facing quote
       // failures: amount below minimum, illiquid/unsupported pair, invalid params.
-      // Those are surfaced to the user by the caller — don't report them to Sentry
-      // as noise. Only report genuinely unexpected errors (5xx / network / no response).
-      const isExpectedClientError =
-        typeof status === 'number' && status >= 400 && status < 500
-      if (!isExpectedClientError) {
-        captureException(e, {
-          ...SENTRY_MODULE_TAGS.TRADE,
-          extra: {
-            title: 'TRADE: Error fetching quote from 1inch',
-          },
-        })
-      }
-      throw new Error(
+      // Flag those so the single caller (useTradeQuote) can skip Sentry reporting
+      // — reporting is centralized there to avoid double-capture. Genuine failures
+      // (5xx / network / no response) stay unflagged and are reported by the caller.
+      const error = new Error(
         response || (e as Error).message || 'Failed to fetch quote from 1inch',
-      )
+      ) as Error & { expectedClientError?: boolean }
+      error.expectedClientError =
+        typeof status === 'number' && status >= 400 && status < 500
+      throw error
     }
   }
 


### PR DESCRIPTION
## What was wrong

On the Trade screen, when 1inch can't price a quote (amount below the minimum, an illiquid/unsupported pair, or otherwise invalid parameters) it returns a `400 Bad Request`. The app already shows the user a message for this, but it was *also* logging every one of these to Sentry as an error — 422 events with **0 users impacted**. Pure noise.

## What changed

Quote errors that are clearly the request's fault (HTTP 4xx, e.g. 400 Bad Request) are no longer sent to Sentry. Genuinely unexpected failures (server 5xx, network errors) are still reported. The user-facing behavior is unchanged — the same message is still shown.

## How to test

1. Open **Trade** on an EVM network (e.g. Ethereum), connect a wallet.
2. Enter a from/to + amount that 1inch can't quote — e.g. a very small amount, or an illiquid pair.
3. **Expected:** the quote fails with the usual inline error message; the app keeps working. No crash. (Under the hood, these 4xx no longer generate a Sentry event; a real 5xx/network failure still would.)
4. Sanity check the happy path: a normal liquid pair (e.g. ETH → a supported stock) still returns a quote.

## Sentry

https://myetherwallet-inc.sentry.io/issues/7430878183/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trade quote error handling to reduce noise by treating certain client-side (4xx) quote failures as expected and avoiding unnecessary error reporting.
  * Error messages now prefer API-provided descriptions for clearer feedback, with safe fallbacks when details aren’t available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->