### PR TITLE
fix: [MEW-1957] don't report Ledger USB picker cancel to sentry

### DIFF
--- a/src/modules/access/ModuleAccessHardwareWallet.vue
+++ b/src/modules/access/ModuleAccessHardwareWallet.vue
@@ -365,14 +365,17 @@ onMounted(async () => {
 })
 
 // User dismissing the WebUSB/BLE device picker is an expected action, not an
-// error — the transport layer throws TransportOpenUserCancelled ("No device
-// selected"). Detect it so we don't toast or report it to Sentry as noise.
+// error. WebUSB surfaces it as TransportOpenUserCancelled / "No device selected"
+// (or a DOMException NotFoundError); the BLE flow surfaces it as a generic
+// "...was cancelled" message. Detect all of these so we don't toast or report
+// the cancellation to Sentry as noise.
 const isUserCancelledTransport = (e: unknown): boolean => {
   const name = (e as { name?: string })?.name
   const message = e instanceof Error ? e.message : String(e ?? '')
   return (
     name === 'TransportOpenUserCancelled' ||
-    /no device selected/i.test(message)
+    name === 'NotFoundError' ||
+    /no device selected|was cancelled|user cancel(l)?ed/i.test(message)
   )
 }
 

--- a/src/modules/access/ModuleAccessHardwareWallet.vue
+++ b/src/modules/access/ModuleAccessHardwareWallet.vue
@@ -364,13 +364,42 @@ onMounted(async () => {
   }
 })
 
+// User dismissing the WebUSB/BLE device picker is an expected action, not an
+// error — the transport layer throws TransportOpenUserCancelled ("No device
+// selected"). Detect it so we don't toast or report it to Sentry as noise.
+const isUserCancelledTransport = (e: unknown): boolean => {
+  const name = (e as { name?: string })?.name
+  const message = e instanceof Error ? e.message : String(e ?? '')
+  return (
+    name === 'TransportOpenUserCancelled' ||
+    /no device selected/i.test(message)
+  )
+}
+
+const openTransport = async (getTransport: () => Promise<unknown>) => {
+  try {
+    await getTransport()
+    return true
+  } catch (e) {
+    if (isUserCancelledTransport(e)) return false
+    const errorMessage = e instanceof Error ? e.message : String(e)
+    toastStore.addToastMessage({
+      type: ToastType.Error,
+      text: t('error_connecting'),
+      textSecondary: errorMessage,
+    })
+    captureException(e, SENTRY_MODULE_TAGS.ACCESS)
+    return false
+  }
+}
+
 const connectViaUSB = async () => {
-  await getLedgerWebUSBTransport()
+  if (!(await openTransport(getLedgerWebUSBTransport))) return
   return unlockWallet()
 }
 
 const connectViaBluetooth = async () => {
-  await getLedgerBLETransport()
+  if (!(await openTransport(getLedgerBLETransport))) return
   return unlockWallet()
 }
 


### PR DESCRIPTION
## What was wrong

When connecting a Ledger, the browser shows a device picker. If the user closes that picker without choosing a device, the app treated it as an error and logged it to Sentry — 753 times, with **0 users impacted**. Dismissing the picker is a normal user action, not a bug.

## What changed

Cancelling the USB (or Bluetooth) device picker is now handled gracefully: nothing is reported to Sentry and no error toast is shown — the user just stays on the connect screen. Genuine connection problems still show an error and are still reported.

## How to test

1. Open `/access` → **Ledger** (hardware wallet) → click connect (USB). *(A device/WebUSB-capable browser is needed; mobile Chrome or desktop Chrome.)*
2. When the browser's device picker appears, click **Cancel** (don't select a device).
3. **Expected:** no error toast, no crash; you remain on the Ledger connect screen and can try again. (No Sentry event is generated for the cancellation.)
4. Sanity check: actually selecting a device still proceeds to the address list as before.

## Sentry

https://myetherwallet-inc.sentry.io/issues/7366933027/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hardware wallet connection flow for both USB and Bluetooth to better handle transport-opening failures.
  * If the user cancels/dismisses device selection, the app now exits quietly (no error toast and no error reporting).
  * Wallet connection now proceeds only after a transport is successfully opened, reducing misleading error states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->