### PR TITLE
fix: 🐛 disable swap for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "myetherwallet",
-  "version": "7.0.8",
+  "version": "7.0.8-hotfix.1",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/modules/trade/ModuleTrade.vue
+++ b/src/modules/trade/ModuleTrade.vue
@@ -92,7 +92,7 @@
 
           <!-- Arrow Button -->
           <div class="relative h-0 z-10 flex justify-center items-center">
-            <button
+            <!-- <button
               :aria-label="$t('trade.swap_from_to')"
               :class="[
                 'absolute right-[50%] top-1/2 bg-white rounded-xl h-10 w-10 flex justify-center items-center translate-x-1/2 -translate-y-1/4 shadow-button shadow-button-elevated transition-colors hoverBGWhite',
@@ -100,7 +100,13 @@
               @click="swapTokens"
             >
               <arrows-up-down-icon class="w-5 h-5 text-primary" />
-            </button>
+            </button> -->
+            <!-- Arrow Button -->
+            <div
+              class="absolute right-[50%+20px] top-[calc(50%-11px)] bg-white rounded-xl h-10 w-10 flex justify-center items-center"
+            >
+              <arrow-down-icon class="w-5 h-5 text-primary" />
+            </div>
           </div>
 
           <!-- To Section -->
@@ -376,7 +382,7 @@
 import { ref, onBeforeMount, computed, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { storeToRefs } from 'pinia'
-import { ArrowsUpDownIcon } from '@heroicons/vue/24/solid'
+import { ArrowDownIcon } from '@heroicons/vue/24/solid'
 import { parseUnits, formatUnits } from 'viem'
 
 // Components
@@ -765,15 +771,15 @@ const switchToNetwork = (chain: Chain) => {
   setFromChain(chain)
 }
 
-const swapTokens = () => {
-  const tempFrom = fromTokenSelected.value
-  const tempTo = toTokenSelected.value
+// const swapTokens = () => {
+//   const tempFrom = fromTokenSelected.value
+//   const tempTo = toTokenSelected.value
 
-  fromTokenSelected.value = tempTo
-  toTokenSelected.value = tempFrom
-  fromAmount.value = '0'
-  toAmount.value = '0'
-}
+//   fromTokenSelected.value = tempTo
+//   toTokenSelected.value = tempFrom
+//   fromAmount.value = '0'
+//   toAmount.value = '0'
+// }
 
 const setPercentageAmount = (percentage: number) => {
   if (!fromTokenSelected.value || !isWalletConnected.value) return


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the trade screen’s swap direction control to be a static, non-interactive indicator (no longer swaps the selected tokens or resets amounts when clicked).
  * Replaced the previous up/down swap icon with a down-arrow indicator.
* **Chores**
  * Bumped the package version for the hotfix release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->