### PR TITLE
feat: ✨ sort purchase currencies alphabetically

### DIFF
--- a/src/modules/purchase/components/PurchaseCurrencyModal.vue
+++ b/src/modules/purchase/components/PurchaseCurrencyModal.vue
@@ -110,7 +110,7 @@ const currencyName = (code: string): string => {
 
 const filteredCurrencies = computed(() => {
   const term = searchInput.value.trim()
-  if (!term) return props.currencies
+  if (!term) return [...props.currencies].sort((a, b) => a.localeCompare(b))
   const items = props.currencies.map(code => ({
     code,
     name: currencyName(code),


### PR DESCRIPTION
### Fix

## What
Purchase currencies in the modal are now displayed in alphabetical order when there is no search term.

## Why
Previously currencies appeared in the original list order, making it harder for users to find a specific currency while scrolling through the list.

## How
- Sort `props.currencies` using `localeCompare` when the search input is empty.
- Use a copy (`[...props.currencies]`) to avoid mutating the original prop.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Currency options now appear in a consistent, locale-sorted order when no search term is entered in the purchase currency picker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->