### PR TITLE
fix: 🐛 disable 24/7 modal for trade restricted users

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "myetherwallet",
-  "version": "7.0.8-hotfix.2",
+  "version": "7.0.8-hotfix.3",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/components/core_layouts/WeekendTradingDialog.vue
+++ b/src/components/core_layouts/WeekendTradingDialog.vue
@@ -61,7 +61,6 @@ import AppDialog from '@/components/AppDialog.vue'
 import { useWalletStore } from '@/stores/walletStore'
 import { useWalletMenuStore } from '@/stores/walletMenuStore'
 import { useWeekendTradingAnnouncementStore } from '@/stores/weekendTradingAnnouncementStore'
-import { useGlobalStore } from '@/stores/globalStore'
 import { useMarketStatus } from '@/modules/trade/composables'
 import { analytics, WeekendTradingAnnouncementEvent } from '@/analytics'
 import { ROUTES_ACCESS, ROUTES_CREATE_WALLET } from '@/router/routeNames'
@@ -80,8 +79,8 @@ const walletMenu = useWalletMenuStore()
 const announcement = useWeekendTradingAnnouncementStore()
 const { modalSeen } = storeToRefs(announcement)
 
-const { isTradingRestrictedInRegion } = storeToRefs(useGlobalStore())
-const { fetchTradingRestriction } = useMarketStatus()
+const { isTradingRestrictedInRegion, fetchTradingRestriction } =
+  useMarketStatus()
 
 const isOpen = ref(false)
 

--- a/src/components/core_layouts/WeekendTradingDialog.vue
+++ b/src/components/core_layouts/WeekendTradingDialog.vue
@@ -61,6 +61,8 @@ import AppDialog from '@/components/AppDialog.vue'
 import { useWalletStore } from '@/stores/walletStore'
 import { useWalletMenuStore } from '@/stores/walletMenuStore'
 import { useWeekendTradingAnnouncementStore } from '@/stores/weekendTradingAnnouncementStore'
+import { useGlobalStore } from '@/stores/globalStore'
+import { useMarketStatus } from '@/modules/trade/composables'
 import { analytics, WeekendTradingAnnouncementEvent } from '@/analytics'
 import { ROUTES_ACCESS, ROUTES_CREATE_WALLET } from '@/router/routeNames'
 import nvda from '@/assets/images/weekend-trading/nvda.png'
@@ -78,6 +80,9 @@ const walletMenu = useWalletMenuStore()
 const announcement = useWeekendTradingAnnouncementStore()
 const { modalSeen } = storeToRefs(announcement)
 
+const { isTradingRestrictedInRegion } = storeToRefs(useGlobalStore())
+const { fetchTradingRestriction } = useMarketStatus()
+
 const isOpen = ref(false)
 
 const showAfter = ref(false)
@@ -87,6 +92,11 @@ const router = useRouter()
 const route = useRoute()
 onMounted(async () => {
   await router.isReady()
+  // Don't surface the 24/7 trading announcement where trading is restricted.
+  // Awaiting here (the result is cached per session) avoids flashing the modal
+  // before the restriction status resolves.
+  await fetchTradingRestriction()
+  if (isTradingRestrictedInRegion.value) return
   if (!modalSeen.value) {
     if (
       !isWalletUnlocked.value &&
@@ -103,6 +113,7 @@ onMounted(async () => {
 const openDialog = () => {
   // Defer behind the Welcome dialog so a brand-new user isn't shown two modals
   // at once. In dev the Welcome dialog never mounts, so don't require it there.
+  if (isTradingRestrictedInRegion.value) return
   if (!modalSeen.value) {
     isOpen.value = true
     announcement.markModalSeen()

--- a/src/components/core_layouts/WeekendTradingTooltip.vue
+++ b/src/components/core_layouts/WeekendTradingTooltip.vue
@@ -73,7 +73,7 @@ import { XMarkIcon } from '@heroicons/vue/20/solid'
 import { useWeekendTradingAnnouncementStore } from '@/stores/weekendTradingAnnouncementStore'
 import { useWalletMenuStore } from '@/stores/walletMenuStore'
 import { useWalletStore } from '@/stores/walletStore'
-import { useGlobalStore } from '@/stores/globalStore'
+import { useMarketStatus } from '@/modules/trade/composables'
 import { analytics, WeekendTradingAnnouncementEvent } from '@/analytics'
 import nvda from '@/assets/images/weekend-trading/nvda.png'
 import qqq from '@/assets/images/weekend-trading/qqq.png'
@@ -97,7 +97,7 @@ const { walletPanel } = storeToRefs(walletMenu)
 const walletStore = useWalletStore()
 const { isWalletConnected } = storeToRefs(walletStore)
 
-const { isTradingRestrictedInRegion } = storeToRefs(useGlobalStore())
+const { isTradingRestrictedInRegion } = useMarketStatus()
 
 const visible = ref(false)
 const anchorRect = ref<DOMRect | null>(null)

--- a/src/components/core_layouts/WeekendTradingTooltip.vue
+++ b/src/components/core_layouts/WeekendTradingTooltip.vue
@@ -73,6 +73,7 @@ import { XMarkIcon } from '@heroicons/vue/20/solid'
 import { useWeekendTradingAnnouncementStore } from '@/stores/weekendTradingAnnouncementStore'
 import { useWalletMenuStore } from '@/stores/walletMenuStore'
 import { useWalletStore } from '@/stores/walletStore'
+import { useGlobalStore } from '@/stores/globalStore'
 import { analytics, WeekendTradingAnnouncementEvent } from '@/analytics'
 import nvda from '@/assets/images/weekend-trading/nvda.png'
 import qqq from '@/assets/images/weekend-trading/qqq.png'
@@ -96,6 +97,8 @@ const { walletPanel } = storeToRefs(walletMenu)
 const walletStore = useWalletStore()
 const { isWalletConnected } = storeToRefs(walletStore)
 
+const { isTradingRestrictedInRegion } = storeToRefs(useGlobalStore())
+
 const visible = ref(false)
 const anchorRect = ref<DOMRect | null>(null)
 
@@ -116,6 +119,7 @@ const tooltipStyle = computed(() => {
 })
 
 const tryShow = async () => {
+  if (isTradingRestrictedInRegion.value) return
   if (!shouldShowTooltip.value || !props.anchor) return
   await nextTick()
   anchorRect.value = props.anchor.getBoundingClientRect()
@@ -154,7 +158,12 @@ onBeforeUnmount(() => {
 // anchor is null during this component's setup. tryShow() guards on
 // shouldShowTooltip + anchor and is idempotent (visible guard).
 watch(
-  [shouldShowTooltip, isWalletConnected, () => props.anchor],
+  [
+    shouldShowTooltip,
+    isWalletConnected,
+    () => props.anchor,
+    isTradingRestrictedInRegion,
+  ],
   () => tryShow(),
   { immediate: true },
 )

--- a/src/modules/trade/composables/useMarketStatus.ts
+++ b/src/modules/trade/composables/useMarketStatus.ts
@@ -187,6 +187,7 @@ export function useMarketStatus(options: UseMarketStatusOptions = {}) {
     tradingRestrictedHelpUrl: TRADING_RESTRICTED_HELP_URL,
     countdownText,
     fetchMarketStatus,
+    fetchTradingRestriction,
     formatNextOpen,
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Weekend trading announcement modal and “Weekend stock trading” tooltip no longer appear for users in regions where trading is restricted.
  * Regional trading restriction checks now block both initial display and any later attempts to open the modal, and tooltip visibility updates when restriction status changes.
* **Chores**
  * Bumped the app version to `7.0.8-hotfix.3`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->