### PR TITLE
fix: [MEW-1983] retry transient swap init and stop reporting it as noise

### DIFF
--- a/src/composables/swapInitError.ts
+++ b/src/composables/swapInitError.ts
@@ -1,0 +1,20 @@
+/**
+ * Whether a swap-init failure is transient/external — worth retrying and not
+ * worth reporting to Sentry.
+ *
+ * The `@enkryptcom/swap` SDK fetches token lists from a remote (GitHub raw).
+ * Transient upstream failures (e.g. a 400/HTML body the SDK then `JSON.parse`s,
+ * or a dropped connection) surface as a `SyntaxError` or a network error. These
+ * are expected external flakiness, not bugs.
+ */
+export function isTransientSwapInitError(e: unknown): boolean {
+  if (e instanceof SyntaxError) return true
+  const msg = e instanceof Error ? e.message.toLowerCase() : ''
+  return (
+    msg.includes('network') ||
+    msg.includes('failed to fetch') ||
+    msg.includes('fetch failed') ||
+    msg.includes('timeout') ||
+    msg.includes('load failed')
+  )
+}

--- a/src/composables/swapInitError.ts
+++ b/src/composables/swapInitError.ts
@@ -8,8 +8,12 @@
  * are expected external flakiness, not bugs.
  */
 export function isTransientSwapInitError(e: unknown): boolean {
-  if (e instanceof SyntaxError) return true
   const msg = e instanceof Error ? e.message.toLowerCase() : ''
+  // Only a JSON-parse SyntaxError counts as the transient upstream case (the
+  // SDK JSON.parse'd a non-JSON body). Every JSON.parse error mentions "json"
+  // across V8/Firefox/Safari, so this excludes unrelated SyntaxErrors that
+  // would otherwise be retried and silently dropped from Sentry.
+  if (e instanceof SyntaxError) return msg.includes('json')
   return (
     msg.includes('network') ||
     msg.includes('failed to fetch') ||

--- a/src/composables/useSwap.ts
+++ b/src/composables/useSwap.ts
@@ -29,6 +29,7 @@ import {
   getRestrictedTokenAddresses,
 } from '@/modules/trade/providers/ondoHelpers'
 import * as Sentry from '@sentry/vue'
+import { isTransientSwapInitError } from '@/composables/swapInitError'
 
 // TODO: Import types from @enkryptcom/swap
 
@@ -55,6 +56,11 @@ export interface QuoteParam {
 const NetworkNotSupportedError = new Error(
   'Selected network is not supported for swap',
 )
+
+// The swap SDK fetches token lists from a remote (GitHub raw) that can return
+// transient errors; retry a couple of times before surfacing to the user.
+const SWAP_INIT_RETRIES = 2
+const SWAP_INIT_RETRY_DELAY_MS = 800
 
 export const useSwap = (): {
   initSwapper: () => Promise<void>
@@ -86,7 +92,7 @@ export const useSwap = (): {
 
   // Initialize the Swapper instance
   // parses tokens and to networks available for swapping
-  const initSwapper = async () => {
+  const initSwapper = async (retriesLeft = SWAP_INIT_RETRIES) => {
     try {
       swapLoaded.value = false
       const rpc = selectedChain.value?.rpcUrls?.[0] || ''
@@ -224,15 +230,28 @@ export const useSwap = (): {
       ) {
         supportedNetwork.value = false
         swapLoaded.value = true
-      } else {
-        toastStore.addToastMessage({
-          type: ToastType.Error,
-          text: 'Something went wrong',
-          textSecondary: t('swap.error.initializing-swap-failed'),
-        })
+        return
+      }
+      // Transient upstream failure (the swaplist fetch returned a non-JSON
+      // body / dropped) — these recover on their own, so retry before
+      // surfacing anything.
+      if (isTransientSwapInitError(e) && retriesLeft > 0) {
+        await new Promise(resolve =>
+          setTimeout(resolve, SWAP_INIT_RETRY_DELAY_MS),
+        )
+        return initSwapper(retriesLeft - 1)
+      }
+      toastStore.addToastMessage({
+        type: ToastType.Error,
+        text: 'Something went wrong',
+        textSecondary: t('swap.error.initializing-swap-failed'),
+      })
+      // Expected external flakiness (transient fetch / JSON parse of a non-JSON
+      // upstream body) is surfaced via the toast above but is pure Sentry noise
+      // — only report genuinely unexpected init failures.
+      if (!isTransientSwapInitError(e)) {
         Sentry.withScope(function (scope) {
           scope.setTag('swap', 'initSwapper failed')
-          // will be tagged with my-tag="my value"
           Sentry.captureException(e)
         })
       }

--- a/tests/unit/composables/swapInitError.spec.ts
+++ b/tests/unit/composables/swapInitError.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { isTransientSwapInitError } from '@/composables/swapInitError'
 
 describe('isTransientSwapInitError', () => {
-  it('is true for a JSON SyntaxError (SDK parsed a non-JSON upstream body)', () => {
+  it('is true for a JSON-parse SyntaxError (SDK parsed a non-JSON upstream body)', () => {
     // The exact production case: JSON.parse("400: Invalid request")
     expect(
       isTransientSwapInitError(
@@ -11,6 +11,18 @@ describe('isTransientSwapInitError', () => {
         ),
       ),
     ).toBe(true)
+    // Firefox / Safari phrasings also mention "JSON"
+    expect(
+      isTransientSwapInitError(
+        new SyntaxError('JSON.parse: unexpected character at line 1 column 1'),
+      ),
+    ).toBe(true)
+  })
+
+  it('is false for a SyntaxError unrelated to JSON parsing', () => {
+    expect(
+      isTransientSwapInitError(new SyntaxError('Unexpected token <')),
+    ).toBe(false)
   })
 
   it('is true for network errors (various phrasings)', () => {

--- a/tests/unit/composables/swapInitError.spec.ts
+++ b/tests/unit/composables/swapInitError.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { isTransientSwapInitError } from '@/composables/swapInitError'
+
+describe('isTransientSwapInitError', () => {
+  it('is true for a JSON SyntaxError (SDK parsed a non-JSON upstream body)', () => {
+    // The exact production case: JSON.parse("400: Invalid request")
+    expect(
+      isTransientSwapInitError(
+        new SyntaxError(
+          'Unexpected non-whitespace character after JSON at position 3',
+        ),
+      ),
+    ).toBe(true)
+  })
+
+  it('is true for network errors (various phrasings)', () => {
+    expect(isTransientSwapInitError(new Error('Network Error'))).toBe(true)
+    expect(isTransientSwapInitError(new TypeError('Failed to fetch'))).toBe(
+      true,
+    )
+    expect(isTransientSwapInitError(new Error('fetch failed'))).toBe(true)
+    expect(isTransientSwapInitError(new Error('Request timeout'))).toBe(true)
+    expect(isTransientSwapInitError(new Error('Load failed'))).toBe(true)
+  })
+
+  it('is false for a genuine, unexpected error', () => {
+    expect(
+      isTransientSwapInitError(
+        new TypeError("Cannot read properties of undefined (reading 'all')"),
+      ),
+    ).toBe(false)
+  })
+
+  it('is false for non-Error values', () => {
+    expect(isTransientSwapInitError('boom')).toBe(false)
+    expect(isTransientSwapInitError(null)).toBe(false)
+    expect(isTransientSwapInitError(undefined)).toBe(false)
+  })
+})


### PR DESCRIPTION
## What was wrong

On app load (and when opening Trade/Swap), swap initialization occasionally failed with `SyntaxError: Unexpected non-whitespace character after JSON at position 3`, showing the user a "Error initializing swap. Please try again." toast and reporting the error to Sentry every time (117 events, 0 users impacted).

Root cause (confirmed from a session replay): the `@enkryptcom/swap` SDK fetches token lists from GitHub raw, which intermittently returns **HTTP 400** with a plain-text body `400: Invalid request`. The SDK `JSON.parse`s that body, which throws the `SyntaxError`. It's transient external flakiness, not an app bug — but it was both surfaced and reported unconditionally.

## What changed

In `initSwapper` (`src/composables/useSwap.ts`):
- **Retry:** transient init failures (JSON `SyntaxError` / network errors) now retry up to 2 times with a short backoff before giving up — GitHub-raw 400s are intermittent and usually recover on retry.
- **Less noise:** transient failures are no longer sent to Sentry (the user still gets the toast). Genuine, unexpected init failures are still reported.
- Extracted a small pure classifier `isTransientSwapInitError` (`src/composables/swapInitError.ts`) with unit tests.

## How to test

This depends on an external transient (GitHub raw returning 400), so it's not deterministically reproducible. To exercise the happy path and confirm no regression:
1. Open the app / Trade / Swap on Ethereum mainnet → swap tokens load normally (no error toast).
2. Switch networks a couple of times → swap re-inits cleanly each time.

To exercise the failure path, block/`throw` in the swaplist fetch (e.g. DevTools network block on `raw.githubusercontent.com/enkryptcom/dynamic-data/main/swaplists/*`): you should see a brief retry, then (if still failing) the "Error initializing swap" toast — and **no** Sentry event for the transient case.

## Sentry

https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-7N

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap initialization reliability by automatically retrying certain temporary upstream/network failures.
  * Reduced unnecessary error reporting for short-lived network/loading issues, while still showing the existing initializing-failed message when retries are exhausted.
  * Continued to handle unsupported network conditions gracefully during swap setup.
* **Tests**
  * Added unit test coverage for identifying transient swap initialization errors and the related retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->