### PR TITLE
fix: [MEW-1984] drop wallet-extension provider rejections from Sentry

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -17,6 +17,7 @@ import { analytics, initAnalytics } from './analytics'
 import rippleDirective from '@/directives/ripple'
 import { autoAnimatePlugin } from '@formkit/auto-animate/vue'
 import configs from '@/configs'
+import { isExtensionOrProviderError } from '@/sentry/extensionNoise'
 
 const app = createApp(App)
 
@@ -36,6 +37,17 @@ if (dsn) {
       'TypeError: NetworkError when attempting to fetch resource',
       'TypeError: Load failed',
     ],
+    // Drop errors thrown inside browser extensions (catches events that DO
+    // carry parsed extension frames).
+    denyUrls: [/(?:chrome|moz|safari-web)-extension:\/\//i],
+    // Drop wallet-extension / EIP-1193 provider rejections (e.g. code 4900
+    // "provider disconnected"). These surface as serialized plain objects with
+    // no parsed frames, so denyUrls can't catch them — inspect the original
+    // exception instead. Genuine app errors are unaffected.
+    beforeSend(event, hint) {
+      if (isExtensionOrProviderError(hint?.originalException)) return null
+      return event
+    },
     integrations: [
       browserTracingIntegration({ router }),
       replayIntegration({

--- a/src/sentry/extensionNoise.ts
+++ b/src/sentry/extensionNoise.ts
@@ -1,0 +1,25 @@
+// Benign EIP-1193 provider error codes. These originate from the user's wallet
+// (injected extension provider), not from app code, and are pure Sentry noise:
+//  4001  user rejected the request
+//  4900  provider disconnected from all chains
+//  4901  provider disconnected from the requested chain
+// -32002 a matching request is already pending
+const BENIGN_PROVIDER_CODES = new Set<number>([4001, 4900, 4901, -32002])
+
+const EXTENSION_URL = /(?:chrome|moz|safari-web)-extension:\/\//i
+
+/**
+ * Whether an error is a wallet-extension / EIP-1193 provider rejection that
+ * should be dropped before reaching Sentry. Matches either a benign provider
+ * error code or a stack that points at a browser-extension URL. Used by the
+ * Sentry `beforeSend` hook — note the production payload is a serialized plain
+ * object (no parsed frames), so `denyUrls` alone cannot catch it.
+ */
+export function isExtensionOrProviderError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false
+  const e = err as { code?: unknown; stack?: unknown }
+  if (typeof e.code === 'number' && BENIGN_PROVIDER_CODES.has(e.code)) {
+    return true
+  }
+  return typeof e.stack === 'string' && EXTENSION_URL.test(e.stack)
+}

--- a/tests/unit/sentry/extensionNoise.spec.ts
+++ b/tests/unit/sentry/extensionNoise.spec.ts
@@ -23,6 +23,13 @@ describe('isExtensionOrProviderError', () => {
   it('is true when the stack points at any browser extension scheme', () => {
     expect(
       isExtensionOrProviderError({
+        // no benign code → forces the chrome-extension stack branch
+        message: 'boom',
+        stack: 'Error\n    at s (chrome-extension://abc/background.js:1:1)',
+      }),
+    ).toBe(true)
+    expect(
+      isExtensionOrProviderError({
         message: 'boom',
         stack: 'Error\n    at moz-extension://abc/background.js:1:1',
       }),

--- a/tests/unit/sentry/extensionNoise.spec.ts
+++ b/tests/unit/sentry/extensionNoise.spec.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { isExtensionOrProviderError } from '@/sentry/extensionNoise'
+
+describe('isExtensionOrProviderError', () => {
+  it('is true for the EIP-1193 4900 "disconnected" rejection from an extension', () => {
+    // The exact production payload (serialized plain object, no parsed frames).
+    expect(
+      isExtensionOrProviderError({
+        code: 4900,
+        message: 'The provider is disconnected from all chains.',
+        stack:
+          'Error: The provider is disconnected from all chains.\n    at s (chrome-extension://acmacodkjbdgmoleebolmdjonilkdbch/background.js:2:7674223)',
+      }),
+    ).toBe(true)
+  })
+
+  it('is true for benign EIP-1193 provider codes regardless of stack', () => {
+    expect(isExtensionOrProviderError({ code: 4001 })).toBe(true) // user rejected
+    expect(isExtensionOrProviderError({ code: 4901 })).toBe(true) // chain disconnected
+    expect(isExtensionOrProviderError({ code: -32002 })).toBe(true) // request pending
+  })
+
+  it('is true when the stack points at any browser extension scheme', () => {
+    expect(
+      isExtensionOrProviderError({
+        message: 'boom',
+        stack: 'Error\n    at moz-extension://abc/background.js:1:1',
+      }),
+    ).toBe(true)
+    expect(
+      isExtensionOrProviderError({
+        message: 'boom',
+        stack: 'Error\n    at safari-web-extension://abc/x.js:1:1',
+      }),
+    ).toBe(true)
+  })
+
+  it('is false for a genuine app error (no extension stack, non-provider code)', () => {
+    expect(
+      isExtensionOrProviderError({
+        message: "Cannot read properties of undefined (reading 'x')",
+        stack:
+          'TypeError: ...\n    at https://app.myetherwallet.com/assets/index-abc.js:1:1',
+      }),
+    ).toBe(false)
+  })
+
+  it('is false for non-benign provider-looking codes (e.g. -32603 internal)', () => {
+    expect(isExtensionOrProviderError({ code: -32603, message: 'Internal' })).toBe(
+      false,
+    )
+  })
+
+  it('is false for non-object inputs', () => {
+    expect(isExtensionOrProviderError(null)).toBe(false)
+    expect(isExtensionOrProviderError(undefined)).toBe(false)
+    expect(isExtensionOrProviderError('chrome-extension://x')).toBe(false)
+    expect(isExtensionOrProviderError(new Error('plain'))).toBe(false)
+  })
+})


### PR DESCRIPTION
## What was wrong

Sentry was filling with unhandled promise rejections that originate **inside users' wallet browser extensions**, not our app (100 events, 0 users impacted). Example payload: `{ code: 4900, message: "The provider is disconnected from all chains", stack: "…chrome-extension://…/background.js…" }` — the standard EIP-1193 "disconnected" error from an injected provider. The whole stack is in the extension; it reaches Sentry via the global `onunhandledrejection` handler.

## What changed

In the Sentry init (`src/main.ts`):
- **`beforeSend`** drops events whose original exception is a wallet-extension / EIP-1193 provider error — either a benign provider code (`4001` user rejected, `4900`/`4901` disconnected, `-32002` request pending) or a stack pointing at a `chrome-/moz-/safari-web-extension://` URL. (These arrive as serialized plain objects with no parsed frames, so `denyUrls` alone can't catch them.)
- **`denyUrls`** for extension URL schemes — belt-and-suspenders for events that do carry parsed extension frames.
- Extracted the predicate `isExtensionOrProviderError` (`src/sentry/extensionNoise.ts`) with unit tests.

Genuine app errors are unaffected.

## How to test

This is a Sentry-reporting filter — no user-visible UI change. Verify no regression:
1. App loads and runs normally (connect a wallet, browse) — nothing in the flow changes.
2. (Optional, to confirm the filter) In dev, temporarily `Promise.reject({ code: 4900, message: 'The provider is disconnected from all chains', stack: 'chrome-extension://x/background.js' })` from the console and confirm it is **not** sent to Sentry, while a normal `throw new Error('app bug')` still is.

## Sentry

https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-ED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noisy error reporting from browser wallet extensions.
  * Sentry now ignores known extension/provider-related errors and extension-originated browser URLs, while continuing to capture real app errors.
* **Tests**
  * Added coverage for common extension error codes, extension URL patterns, and non-matching inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->