### PR TITLE
fix: [MEW-1985] stop reporting transient RPC socket drops during trade quote

### DIFF
--- a/src/modules/trade/composables/transientRpcError.ts
+++ b/src/modules/trade/composables/transientRpcError.ts
@@ -1,0 +1,34 @@
+// viem error class names that represent a transient RPC/WebSocket connection
+// drop (not an app bug). viem nests these in the `cause` chain of the
+// higher-level ContractFunctionExecutionError / CallExecutionError.
+const TRANSIENT_RPC_ERROR_NAMES = new Set<string>([
+  'WebSocketRequestError',
+  'SocketClosedError',
+  'TimeoutError',
+])
+
+/**
+ * Whether an error is a transient RPC/WebSocket failure — expected flakiness of
+ * the node connection (idle disconnect / node restart), not an app bug, so it
+ * should be skipped in Sentry. Matches by viem error name or message, walking
+ * the `cause` chain since viem wraps the socket error several levels deep.
+ */
+export function isTransientRpcError(e: unknown): boolean {
+  let cur: unknown = e
+  for (let depth = 0; cur && typeof cur === 'object' && depth < 6; depth++) {
+    const err = cur as { name?: unknown; message?: unknown; cause?: unknown }
+    if (typeof err.name === 'string' && TRANSIENT_RPC_ERROR_NAMES.has(err.name)) {
+      return true
+    }
+    const msg = typeof err.message === 'string' ? err.message.toLowerCase() : ''
+    if (
+      msg.includes('websocket request failed') ||
+      msg.includes('socket has been closed') ||
+      msg.includes('socket closed')
+    ) {
+      return true
+    }
+    cur = err.cause
+  }
+  return false
+}

--- a/src/modules/trade/composables/useTradeQuote.ts
+++ b/src/modules/trade/composables/useTradeQuote.ts
@@ -7,6 +7,7 @@ import type { Chain } from '@/mew_api/types'
 import { captureException } from '@sentry/vue'
 import { SENTRY_MODULE_TAGS } from '@/sentry/constants'
 import Configs from '@/configs'
+import { isTransientRpcError } from '@/modules/trade/composables/transientRpcError'
 
 const isDevMode = Configs.IS_DEV_MODE
 
@@ -123,7 +124,10 @@ export function useTradeQuote(options: UseTradeQuoteOptions) {
       toAmount.value = '0'
       if (isDevMode) {
         console.error('Error fetching quote:', e)
-      } else {
+      } else if (!isTransientRpcError(e)) {
+        // Transient RPC/WebSocket drops (e.g. the allowance read over
+        // wss://nodes.mewapi.io) are surfaced to the user above but are pure
+        // Sentry noise — only report genuine quote failures.
         captureException(e, {
           ...SENTRY_MODULE_TAGS.TRADE,
           extra: {

--- a/tests/unit/modules/trade/transientRpcError.spec.ts
+++ b/tests/unit/modules/trade/transientRpcError.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import { isTransientRpcError } from '@/modules/trade/composables/transientRpcError'
+
+describe('isTransientRpcError', () => {
+  it('is true for the top-level viem error whose message is "WebSocket request failed"', () => {
+    // The exact production shape: ContractFunctionExecutionError carrying the
+    // WS failure in its message.
+    expect(
+      isTransientRpcError({
+        name: 'ContractFunctionExecutionError',
+        message:
+          'WebSocket request failed.\n\nURL: wss://nodes.mewapi.io/ws/eth\nVersion: viem@2.44.0',
+      }),
+    ).toBe(true)
+  })
+
+  it('is true when a transient error is nested in the cause chain', () => {
+    expect(
+      isTransientRpcError({
+        name: 'ContractFunctionExecutionError',
+        message: 'Contract call failed',
+        cause: {
+          name: 'CallExecutionError',
+          message: 'call failed',
+          cause: {
+            name: 'SocketClosedError',
+            message: 'The socket has been closed.',
+          },
+        },
+      }),
+    ).toBe(true)
+  })
+
+  it('is true for WebSocketRequestError by name', () => {
+    expect(
+      isTransientRpcError({ name: 'WebSocketRequestError', message: 'boom' }),
+    ).toBe(true)
+  })
+
+  it('is false for a genuine app error', () => {
+    expect(
+      isTransientRpcError({
+        name: 'TypeError',
+        message: "Cannot read properties of undefined (reading 'presets')",
+      }),
+    ).toBe(false)
+  })
+
+  it('is false for a 1inch client error (handled separately)', () => {
+    expect(isTransientRpcError(new Error('Bad Request'))).toBe(false)
+  })
+
+  it('is false for non-object inputs', () => {
+    expect(isTransientRpcError(null)).toBe(false)
+    expect(isTransientRpcError(undefined)).toBe(false)
+    expect(isTransientRpcError('socket has been closed')).toBe(false)
+  })
+})


### PR DESCRIPTION
## What was wrong

While fetching a trade quote, the app reads the token `allowance` (in `OneInchFusion.isApprovalRequired`) over the RPC WebSocket `wss://nodes.mewapi.io/ws/eth`. When that socket drops, viem throws `ContractFunctionExecutionError → WebSocketRequestError → SocketClosedError ("The socket has been closed")`. It's a transient connection blip (already handled — the quote falls back gracefully), but it was reported to Sentry every time (81 events, 0 users impacted).

## What changed

In `useTradeQuote`'s catch (`src/modules/trade/composables/useTradeQuote.ts`):
- Classify transient RPC/WebSocket errors and **skip** `captureException` for them; genuine quote failures are still reported.
- Added a small pure helper `isTransientRpcError` (`src/modules/trade/composables/transientRpcError.ts`) that matches viem error names (`WebSocketRequestError`, `SocketClosedError`, `TimeoutError`) or messages ("WebSocket request failed", "socket has been closed"), walking the `cause` chain — with unit tests.

## How to test

This depends on the RPC WebSocket dropping mid-quote, so it isn't deterministically reproducible. Confirm no regression on the happy path:
1. Open Trade on Ethereum, pick a token pair and enter an amount → a quote loads normally; if approval is needed the flow behaves as before.

To exercise the filter, in DevTools throttle/kill the `wss://nodes.mewapi.io/ws/eth` socket while a quote is fetching: the quote falls back to `0` (existing behavior) and **no** Sentry event is produced for the socket-closed error, while a genuine error still reports.

## Note

This touches the same `useTradeQuote` catch as MEW-1956 / PR #5567 (1inch 4xx suppression), which is not yet merged. Expect a small merge conflict in that catch between the two PRs — whichever lands second should keep **both** skip conditions (`expectedClientError` from #5567 **and** `isTransientRpcError` from here).

## Sentry

https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-ZE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noisy error reporting for temporary RPC/WebSocket connection issues during trade quote requests.
  * Improved detection of transient network-related failures, including nested error causes, so recoverable errors are handled more gracefully.

* **Tests**
  * Added unit coverage for transient error detection across direct errors, nested causes, and non-transient inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->