### PR TITLE
fix: [MEW-1986] ignore stale-deploy chunk preload errors in Sentry

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -35,6 +35,11 @@ if (dsn) {
       'TypeError: Failed to fetch',
       'TypeError: NetworkError when attempting to fetch resource',
       'TypeError: Load failed',
+      // Stale-deploy lazy-chunk errors: a cached index.html requests hashed
+      // assets that no longer exist after a redeploy. These are already
+      // auto-recovered by router.onError (reload once), so they are noise.
+      'Unable to preload CSS',
+      'Failed to fetch dynamically imported module',
     ],
     integrations: [
       browserTracingIntegration({ router }),


### PR DESCRIPTION
## What was wrong

After a redeploy, users on a cached `index.html` navigate to a lazy-loaded route whose hashed asset no longer exists on the CDN, producing `Error: Unable to preload CSS for /assets/ViewPortfolio-*.css` (and the sibling `Failed to fetch dynamically imported module`). The app **already auto-recovers** — `router.onError` reloads once — but the error was still reported to Sentry (253 events, 0 users impacted), so it was pure noise.

## What changed

Added the two stale-deploy chunk-error patterns to the Sentry `ignoreErrors` list in `src/main.ts`:
- `Unable to preload CSS`
- `Failed to fetch dynamically imported module`

These are benign deploy-cache mismatches already handled by the existing `router.onError` reload. Genuine errors are unaffected.

## How to test

No user-visible change — this only stops Sentry from recording the already-recovered chunk errors. Sanity check: app loads and navigates between routes (Portfolio / Trade / Swap) normally; lazy routes still load.

## Sentry

https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-BW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced noisy error reporting by ignoring a couple of known, self-recovering loading failures.
  * This should help keep error tracking focused on issues that affect users more directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->