### PR TITLE
feat: ✨ manually set amp to prod, everything else checks vite prod

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "test:unit": "vitest",
     "test:e2e": "nightwatch --config ./nightwatch.conf.cjs tests/e2e/*",
     "build:preview": "vite preview",
-    "build:prod": "VITE_AMPLITUDE=prod vite build",
     "build:only": "vite build",
     "build:watchonly": "vite build --watch",
     "type-check": "vue-tsc -p tsconfig.app.json",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:unit": "vitest",
     "test:e2e": "nightwatch --config ./nightwatch.conf.cjs tests/e2e/*",
     "build:preview": "vite preview",
+    "build:prod": "VITE_AMPLITUDE=prod vite build",
     "build:only": "vite build",
     "build:watchonly": "vite build --watch",
     "type-check": "vue-tsc -p tsconfig.app.json",

--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -60,18 +60,20 @@ export const initAnalytics = async (): Promise<void> => {
   }
 
   const consentToTrack = getConsentToTrack()
+  const isProd = configs.AMPLITUDE === 'prod'
+  const serverUrl = isProd
+    ? 'https://analytics-web-v7.mewwallet.dev'
+    : 'https://analytics-web-development-v7.mewwallet.dev'
 
-  const serverUrl = process.env.NODE_ENV === 'production'
-    ? 'https://analytics-web-v7.mewwallet.dev/record'
-    : 'https://analytics-web-development-v7.mewwallet.dev/record'
+  const analyticsUrl = `${serverUrl}/record`
 
   amplitude.add(pageUrlEnrichmentPlugin())
   amplitude.add(pageViewedEnrichmentPlugin())
   amplitude.init(__TMP_HASHED_VERSION__, {
     instanceName:
-      process.env.NODE_ENV === 'production' ? 'mew-web-prod' : 'mew-web-dev',
+      isProd ? 'mew-web-prod' : 'mew-web-dev',
     optOut: !consentToTrack,
-    serverUrl: serverUrl,
+    serverUrl: analyticsUrl,
     appVersion: __TMP_VERSION__,
     identityStorage: 'none',
     logLevel: Types.LogLevel.None,
@@ -81,17 +83,15 @@ export const initAnalytics = async (): Promise<void> => {
   })
 
   const inEU = await isEU();
-  const prodConfigUrl = inEU ? 'https://analytics-web-v7.mewwallet.dev/config-eu' : 'https://analytics-web-v7.mewwallet.dev/config'
-  const devConfigUrl = inEU ? 'https://analytics-web-development-v7.mewwallet.dev/config-eu' : 'https://analytics-web-development-v7.mewwallet.dev/config'
-  const prodSessionReplayUrl = inEU ? 'https://analytics-web-v7.mewwallet.dev/session-replay-eu' : 'https://analytics-web-v7.mewwallet.dev/session-replay'
-  const devSessionReplayUrl = inEU ? 'https://analytics-web-development-v7.mewwallet.dev/session-replay-eu' : 'https://analytics-web-development-v7.mewwallet.dev/session-replay'
+  const configUrl = inEU ? `${serverUrl}/config-eu` : `${serverUrl}/config`
+  const sessionReplayUrl = inEU ? `${serverUrl}/session-replay-eu` : `${serverUrl}/session-replay`
 
   const sessionId = amplitude.getSessionId()
   const deviceId = amplitude.getDeviceId()
 
   sessionReplay.init(__TMP_HASHED_VERSION__, {
-    configServerUrl: process.env.NODE_ENV === 'production' ? prodConfigUrl : devConfigUrl,
-    trackServerUrl: process.env.NODE_ENV === 'production' ? prodSessionReplayUrl : devSessionReplayUrl,
+    configServerUrl: configUrl,
+    trackServerUrl: sessionReplayUrl,
     optOut: !consentToTrack,
     sessionId: sessionId,
     deviceId: deviceId,

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -27,6 +27,7 @@ const configs = {
   VINATGE: 'https://www.myetherwallet.com/wallet/access',
   APP_VERSION: import.meta.env.VITE_APP_VERSION || '0.0.0',
   INTERCOM_APP_ID: import.meta.env.VITE_INTERCOM_ID || undefined,
+  AMPLITUDE: import.meta.env.VITE_AMPLITUDE || 'dev'
 }
 
 export default configs


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a production build command that uses the production Amplitude setting automatically.

* **Bug Fixes**
  * Updated analytics initialization so production and non-production environments use the correct tracking endpoints.
  * Improved session replay configuration to pick the right regional endpoints consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->