### PR TITLE
fix: 🐛 add notification date

### DIFF
--- a/src/modules/notifications/components/BridgeContainer.vue
+++ b/src/modules/notifications/components/BridgeContainer.vue
@@ -140,7 +140,7 @@
             >{{ $t('common.created_at') }}</span
           >
           <p class="text-s-12">
-            {{ formatTime(bridge.createdAt) }}
+            {{ formatNotificationDate(bridge.createdAt) }}
           </p>
         </div>
 
@@ -227,6 +227,7 @@ import {
   formatFiatValue,
   formatFloatingPointValue,
 } from '@/utils/numberFormatHelper'
+import { formatNotificationDate } from '@/utils/dateFormatHelper'
 
 // Props
 const props = defineProps<{
@@ -240,12 +241,6 @@ defineEmits<{
 }>()
 
 const showMoreDetails = ref(false)
-
-// Format time
-const formatTime = (timestamp: number): string => {
-  const date = new Date(timestamp * 1000)
-  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
-}
 
 // Truncate hash
 const truncateHash = (hash: string): string => {

--- a/src/modules/notifications/components/SwapContainer.vue
+++ b/src/modules/notifications/components/SwapContainer.vue
@@ -126,7 +126,7 @@
             >{{ $t('common.created_at') }}</span
           >
           <p class="text-s-12">
-            {{ formatTime(swap.createdAt) }}
+            {{ formatNotificationDate(swap.createdAt) }}
           </p>
         </div>
 
@@ -189,6 +189,7 @@ import {
   formatFiatValue,
   formatFloatingPointValue,
 } from '@/utils/numberFormatHelper'
+import { formatNotificationDate } from '@/utils/dateFormatHelper'
 
 // Props
 const props = defineProps<{
@@ -202,12 +203,6 @@ defineEmits<{
 }>()
 
 const showMoreDetails = ref(false)
-
-// Format time
-const formatTime = (timestamp: number): string => {
-  const date = new Date(timestamp * 1000)
-  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
-}
 
 // Truncate hash
 const truncateHash = (hash: string): string => {

--- a/src/modules/notifications/components/TradeOrderContainer.vue
+++ b/src/modules/notifications/components/TradeOrderContainer.vue
@@ -183,7 +183,7 @@
             >{{ $t('common.created_at') }}</span
           >
           <p class="text-s-12">
-            {{ formatTime(order.createdAt) }}
+            {{ formatNotificationDate(order.createdAt) }}
           </p>
         </div>
 
@@ -239,6 +239,7 @@ import AppTokenSymbol from '@/components/AppTokenSymbol.vue'
 import ExpandTransition from '@/components/transitions/ExpandTransition.vue'
 import AppBtnText from '@/components/AppBtnText.vue'
 import { formatFloatingPointValue } from '@/utils/numberFormatHelper'
+import { formatNotificationDate } from '@/utils/dateFormatHelper'
 
 // Props
 const props = defineProps<{
@@ -293,12 +294,6 @@ const formatCountdown = (seconds: number): string => {
   const mins = Math.floor(seconds / 60)
   const secs = seconds % 60
   return `${mins}:${secs.toString().padStart(2, '0')}`
-}
-
-// Format time
-const formatTime = (timestamp: number): string => {
-  const date = new Date(timestamp * 1000)
-  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
 }
 
 // Truncate hash

--- a/src/modules/notifications/components/TransactionContainer.vue
+++ b/src/modules/notifications/components/TransactionContainer.vue
@@ -104,7 +104,7 @@
             >{{ $t('common.created_at') }}</span
           >
           <p class="text-s-12">
-            {{ formatTime(transaction.createdAt) }}
+            {{ formatNotificationDate(transaction.createdAt) }}
           </p>
         </div>
         <!-- Transaction -->
@@ -168,6 +168,7 @@ import {
   formatFiatValue,
   formatFloatingPointValue,
 } from '@/utils/numberFormatHelper'
+import { formatNotificationDate } from '@/utils/dateFormatHelper'
 import { useAppBreakpoints } from '@/composables/useAppBreakpoints'
 // Props
 const props = defineProps<{
@@ -183,11 +184,6 @@ defineEmits<{
 const { isXsAndUp } = useAppBreakpoints()
 
 const showMoreDetails = ref(false)
-// Format time
-const formatTime = (timestamp: number): string => {
-  const date = new Date(timestamp * 1000)
-  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
-}
 
 // Truncate hash
 const truncateHash = (hash: string): string => {

--- a/src/utils/dateFormatHelper.ts
+++ b/src/utils/dateFormatHelper.ts
@@ -1,0 +1,53 @@
+/**
+ * ---------------------------------
+ * Date Format Helper.
+ * Used to format notification timestamps in the UI
+ * ---------------------------------
+ */
+
+const MINUTE = 60
+const HOUR = 60 * MINUTE
+const DAY = 24 * HOUR
+
+/**
+ * Format a notification timestamp as a relative time.
+ *
+ * - < 1 minute:  "Just now"
+ * - < 1 hour:    "X minute(s) ago"
+ * - < 24 hours:  "X hour(s) ago"
+ * - < 3 days:    "X day(s) ago"
+ * - >= 3 days:   full date (e.g. "Jul 6, 2026, 2:30 PM")
+ *
+ * @param timestamp Unix timestamp in seconds
+ */
+export const formatNotificationDate = (timestamp: number): string => {
+  const nowSeconds = Math.floor(Date.now() / 1000)
+  const diff = Math.max(0, nowSeconds - timestamp)
+
+  if (diff < MINUTE) {
+    return 'Just now'
+  }
+
+  if (diff < HOUR) {
+    const minutes = Math.floor(diff / MINUTE)
+    return `${minutes} minute${minutes === 1 ? '' : 's'} ago`
+  }
+
+  if (diff < DAY) {
+    const hours = Math.floor(diff / HOUR)
+    return `${hours} hour${hours === 1 ? '' : 's'} ago`
+  }
+
+  if (diff < 3 * DAY) {
+    const days = Math.floor(diff / DAY)
+    return `${days} day${days === 1 ? '' : 's'} ago`
+  }
+
+  return new Date(timestamp * 1000).toLocaleString([], {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notification details now show a more readable “Created at” time format, with relative labels like “Just now,” “X minutes ago,” “X hours ago,” and “X days ago.”
  * Older timestamps now display as a localized date and time for easier scanning.

* **Bug Fixes**
  * Standardized timestamp display across multiple notification types for a consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->