### PR TITLE
release: :fire: v7.0.8-hotfix.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "myetherwallet",
-  "version": "7.0.8-hotfix.4",
+  "version": "7.0.8-hotfix.5",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/i18n/locales/rewards/en.json
+++ b/src/i18n/locales/rewards/en.json
@@ -16,7 +16,7 @@
     "try_again_later": "Sorry, try again later!",
     "learn_more": "Learn More",
     "earn_rewards_title": "Earn rewards",
-    "earn_rewards_description": "First 10 trades of $35+ and swaps of $50+ earn 5 USDC each hour.",
+    "earn_rewards_description": "First 15 trades of $100+ and swaps of $50+ earn 5 USDC each hour.",
     "not_eligible_at_this_time": "You are not eligible for rewards at this time",
     "switched_to_ethereum": "Switched app network to Ethereum",
     "congratulations": "Congratulations!",

--- a/src/modules/rewards/RewardsLearnMore.vue
+++ b/src/modules/rewards/RewardsLearnMore.vue
@@ -160,7 +160,7 @@ watch(isOpenModel, val => {
 const infoItems = [
   {
     icon: 'swap',
-    text: 'Make a trade over $35.',
+    text: 'Make a trade over $100.',
   },
   // {
   //   icon: 'trophy',

--- a/src/modules/rewards/RewardsPortfolio.vue
+++ b/src/modules/rewards/RewardsPortfolio.vue
@@ -17,7 +17,7 @@
         <div class="flex flex-col pt-5">
           <h3 class="text-s-20 font-bold leading-none">Earn rewards</h3>
           <p class="text-s-16 text-[#575757] leading-[22px] mt-2 max-w-[295px]">
-            The first 15 trades over $35 every hour receive $5 in USDC in
+            The first 15 trades over $100 every hour receive $5 in USDC in
             rewards. Once per week per wallet.
           </p>
           <button

--- a/src/modules/rewards/RewardsRows.vue
+++ b/src/modules/rewards/RewardsRows.vue
@@ -156,7 +156,7 @@
         class="grow max-w-[150px]"
         @click="$emit('trade')"
       >
-        Trade $35+
+        Trade $100+
       </app-base-button>
       <button
         v-else

--- a/src/modules/rewards/RewardsSmallBanner.vue
+++ b/src/modules/rewards/RewardsSmallBanner.vue
@@ -7,7 +7,7 @@
       <div class="flex-1 min-w-0">
         <p class="text-s-11 font-semibold text-black leading-tight">
           {{
-            props.location === 'small-banner-swap' ? 'Swap $50+' : 'Trade $35+'
+            props.location === 'small-banner-swap' ? 'Swap $50+' : 'Trade $100+'
           }}
           on Ethereum and
           <span class="text-primary"> Earn 5 USDC</span>

--- a/src/modules/trade/composables/useTradeExecution.ts
+++ b/src/modules/trade/composables/useTradeExecution.ts
@@ -195,7 +195,7 @@ export function useTradeExecution(options: UseTradeExecutionOptions) {
       let canEarnReward: undefined | boolean = undefined
       const fromUsdValue =
         parseFloat(fromAmount.value) * (fromTokenSelected.value?.price || 0)
-      if (fromUsdValue > 25) {
+      if (fromUsdValue > 100) {
         const canEarn = await rewardsStore.checkAvailabilityAfterTransaction('trade')
         canEarnReward = canEarn ? true : undefined
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped the app version to `7.0.8-hotfix.5`.
* **Updates**
  * Updated rewards eligibility messaging throughout the app to use a **$100+** trade threshold (instead of **$35+**), including banners, descriptions, and trade button labels.
  * Adjusted the rewards eligibility evaluation for trade-related analytics so reward-earned status is only considered for trades above **$100**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->