### PR TITLE
fix: [MEW-1915] require target price for limit orders

### DIFF
--- a/src/modules/perps/ModulePerpsTrade.vue
+++ b/src/modules/perps/ModulePerpsTrade.vue
@@ -250,9 +250,14 @@
 
           <transition name="fade" mode="out-in">
             <div
-              v-if="
-                limitPrice &&
-                (isNaN(parseFloat(limitPrice)) || parseFloat(limitPrice) <= 0)
+              v-if="!limitPrice || parseFloat(limitPrice) === 0"
+              class="text-error text-s-12 mb-1"
+            >
+              Target price required
+            </div>
+            <div
+              v-else-if="
+                isNaN(parseFloat(limitPrice)) || parseFloat(limitPrice) < 0
               "
               class="text-error text-s-12 mb-1"
             >

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -624,7 +624,10 @@ export function usePerpsTradeForm() {
   })
 
   const limitPriceHasError = computed(() => {
-    if (orderType.value !== 'limit' || !limitPrice.value) return false
+    if (orderType.value !== 'limit') return false
+    // A limit order requires a target price; treat empty as an error so the
+    // input surfaces "Target price required" and the submit button disables.
+    if (!limitPrice.value) return true
     const price = parseFloat(limitPrice.value)
     if (isNaN(price) || price <= 0 || price >= 10_000_000) return true
     if (limitPricePrecisionError.value) return true
@@ -653,6 +656,12 @@ export function usePerpsTradeForm() {
   })
 
   const submitButtonLabel = computed(() => {
+    if (
+      orderType.value === 'limit' &&
+      (!limitPrice.value || parseFloat(limitPrice.value) <= 0)
+    ) {
+      return 'Enter target price'
+    }
     const amt = parseFloat(inputAmount.value)
     if (availableMargin.value * leverage.value < minOrderAmount.value) {
       return `Min. margin required ${formatUsd(minOrderAmount.value)}`

--- a/tests/unit/specs/modules/perps/composables/usePerpsTradeForm.spec.ts
+++ b/tests/unit/specs/modules/perps/composables/usePerpsTradeForm.spec.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ref, reactive } from 'vue'
+
+// ── Mocks ────────────────────────────────────────────────────
+// usePerpsTradeForm pulls in the whole perps stack (auth, markets,
+// positions, mark prices, toasts, analytics, router, wallet-menu store).
+// For the limit-price validation (MEW-1915) we only drive `orderType` and
+// `limitPrice`, so every dependency is stubbed just enough to instantiate.
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+const walletMenuState = reactive<Record<string, unknown>>({
+  selectedTradeOrderSide: 'buy',
+  selectedTradeManageMode: null,
+  selectedTradeTokenSymbol: 'AAPL-USD',
+})
+vi.mock('@/stores/walletMenuStore', () => ({
+  useWalletMenuStore: () =>
+    ({
+      get selectedTradeOrderSide() {
+        return walletMenuState.selectedTradeOrderSide
+      },
+      setSelectedTradeOrderSide: (v: unknown) => {
+        walletMenuState.selectedTradeOrderSide = v
+      },
+      get selectedTradeManageMode() {
+        return walletMenuState.selectedTradeManageMode
+      },
+      setSelectedTradeManageMode: (v: unknown) => {
+        walletMenuState.selectedTradeManageMode = v
+      },
+      get selectedTradeTokenSymbol() {
+        return walletMenuState.selectedTradeTokenSymbol
+      },
+      setSelectedTradeTokenSymbol: (v: unknown) => {
+        walletMenuState.selectedTradeTokenSymbol = v
+      },
+    }) as unknown,
+}))
+
+vi.mock('@/analytics', () => ({
+  analytics: new Proxy({}, { get: () => vi.fn() }),
+  PerpsTradeOrderEvent: {},
+  PerpsTpSlEvent: {},
+  PerpsChangeLeverageEvent: {},
+  PerpsClosePositionEvent: {},
+}))
+
+vi.mock('@/modules/perps/configs', () => ({
+  perpsClient: new Proxy({}, { get: () => vi.fn() }),
+  BUILDER_CODE: 'BC',
+}))
+
+vi.mock('@/modules/perps/composables/usePerpsAuth', () => ({
+  usePerpsAuth: () => ({
+    token: ref(null),
+    login: vi.fn(),
+    triggerRefresh: vi.fn(),
+  }),
+  usePerpsBalance: () => ({ balance: ref(null) }),
+}))
+
+vi.mock('@/modules/perps/composables/usePerpsMarkets', () => ({
+  usePerpsMarkets: () => ({ markets: ref([]), isLoading: ref(false) }),
+  usePerpsContracts: () => ({ contracts: ref([]) }),
+}))
+
+vi.mock('@/modules/perps/composables/usePerpsPositions', () => ({
+  usePerpsPositions: () => ({
+    positions: ref([]),
+    hasLoaded: ref(true),
+    closePosition: vi.fn(),
+  }),
+}))
+
+vi.mock('@/modules/perps/composables/usePerpsMarkPrices', () => ({
+  usePerpsMarkPrices: () => ({ markPriceData: ref({}) }),
+}))
+
+vi.mock('@/modules/perps/composables/usePerpsToasts', () => ({
+  usePerpsToasts: () => new Proxy({}, { get: () => vi.fn() }),
+}))
+
+import { usePerpsTradeForm } from '@/modules/perps/composables/usePerpsTradeForm'
+
+describe('usePerpsTradeForm — target price required (MEW-1915)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    walletMenuState.selectedTradeOrderSide = 'buy'
+    walletMenuState.selectedTradeManageMode = null
+    walletMenuState.selectedTradeTokenSymbol = 'AAPL-USD'
+  })
+
+  it('flags an empty limit price as an error on the limit tab', () => {
+    const form = usePerpsTradeForm()
+    form.orderType.value = 'limit'
+    form.limitPrice.value = ''
+    expect(form.limitPriceHasError.value).toBe(true)
+  })
+
+  it('flags a zero limit price as an error on the limit tab', () => {
+    const form = usePerpsTradeForm()
+    form.orderType.value = 'limit'
+    form.limitPrice.value = '0'
+    expect(form.limitPriceHasError.value).toBe(true)
+  })
+
+  it('does not flag an empty price on the market tab', () => {
+    const form = usePerpsTradeForm()
+    form.orderType.value = 'market'
+    form.limitPrice.value = ''
+    expect(form.limitPriceHasError.value).toBe(false)
+  })
+
+  it('shows "Enter target price" in the submit button when limit price is empty', () => {
+    const form = usePerpsTradeForm()
+    form.orderType.value = 'limit'
+    form.limitPrice.value = ''
+    expect(form.submitButtonLabel.value).toBe('Enter target price')
+  })
+
+  it('shows "Enter target price" in the submit button when limit price is zero', () => {
+    const form = usePerpsTradeForm()
+    form.orderType.value = 'limit'
+    form.limitPrice.value = '0'
+    expect(form.submitButtonLabel.value).toBe('Enter target price')
+  })
+
+  it('does not show "Enter target price" on the market tab', () => {
+    const form = usePerpsTradeForm()
+    form.orderType.value = 'market'
+    form.limitPrice.value = ''
+    expect(form.submitButtonLabel.value).not.toBe('Enter target price')
+  })
+
+  it('disables submit when limit price is empty', () => {
+    const form = usePerpsTradeForm()
+    form.orderType.value = 'limit'
+    form.limitPrice.value = ''
+    expect(form.submitDisabled.value).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

Limit orders could be submitted with an empty or zero target price. This adds the missing validation so a target price is required before an order can be placed.

- **Submit button**: disabled with the label **"Enter target price"** when the limit target price is empty or ≤ 0.
- **Target price input**: shows a **"Target price required"** error (red state) when empty or 0, ahead of the existing "Invalid price" branch.
- `limitPriceHasError` now treats an empty limit price as an error (previously only non-empty invalid values), which drives both the red input state and `submitDisabled`.

## Changes

- `src/modules/perps/composables/usePerpsTradeForm.ts` — empty limit price is now an error in `limitPriceHasError`; `submitButtonLabel` returns "Enter target price" for empty/≤0.
- `src/modules/perps/ModulePerpsTrade.vue` — new "Target price required" error branch on the target price input.
- `tests/unit/specs/modules/perps/composables/usePerpsTradeForm.spec.ts` — new spec (7 tests) covering empty/zero/market-tab cases for the error state and button label.

## Testing

- `pnpm vitest run tests/unit/specs/modules/perps/composables/usePerpsTradeForm.spec.ts` → 7/7 pass
- `pnpm vue-tsc --noEmit -p tsconfig.app.json` → clean
- `pnpm eslint` on changed files → clean
- Manual smoke test on the Limit tab: empty and `0` disable the button ("Enter target price") and show "Target price required"; valid price clears both; Market tab unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Limit order pricing validation now clearly distinguishes between a missing target price and an invalid price.
  * Empty or zero target prices now show a “Target price required” message and prevent submission.
  * The submit button now prompts users to “Enter target price” when a limit order is missing a valid price.

* **Tests**
  * Added coverage for limit order validation and submit-state behavior across limit and market modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->