### PR TITLE
fix: [MEW-1919] truncate order Size to prevent panel overflow

### DIFF
--- a/src/modules/perps/ModulePerpsTrade.vue
+++ b/src/modules/perps/ModulePerpsTrade.vue
@@ -346,7 +346,7 @@
                 <ChevronDownIcon class="w-3 h-3" />
               </button>
             </div>
-            <p class="text-info text-s-12 -mt-2 mb-2">
+            <p class="text-info text-s-12 -mt-2 mb-2 truncate">
               Size
               {{ positionSizeUsd ? formatUsd(positionSizeUsd) : '$0.00' }}
             </p>


### PR DESCRIPTION
## Summary

The "Size" readout under the margin input in the perps trade panel rendered the full USD position size on a single, unwrapped line. With large leverage/amount values the number overflowed the trade panel horizontally and broke the layout.

## Change

- `src/modules/perps/ModulePerpsTrade.vue` — add `truncate` to the Size `<p>` so the line clips with an ellipsis (`text-ellipsis` + `overflow-hidden` + `whitespace-nowrap`) instead of overflowing the panel. Same utility already used for market names in `PerpsPositionsTable`.

Purely presentational (one Tailwind class), so no unit test is added; verified via type-check, lint, and manual smoke test.

## Testing

- `pnpm vue-tsc --noEmit -p tsconfig.app.json` → clean
- `pnpm eslint src/modules/perps/ModulePerpsTrade.vue` → clean
- Manual smoke test: entering a very large margin amount now clips the "Size $…" line inside the panel with an ellipsis; normal values render unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how the “Size” label is displayed when space is limited, preventing overflow and keeping the layout tidy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->