### PR TITLE
fix: [MEW-1914] confirm before cancelling orders on Market info page

### DIFF
--- a/src/modules/perps/ModulePerpInfo.vue
+++ b/src/modules/perps/ModulePerpInfo.vue
@@ -662,7 +662,7 @@
                                 class="p-2 flex items-center hoverBGWhite rounded-12 text-error"
                                 @click.stop="[
                                   toggleMenu(),
-                                  cancelInfoOrder(order),
+                                  openCancelConfirmation(order),
                                 ]"
                               >
                                 {{
@@ -902,7 +902,15 @@
     :order="selectedOrder"
     :cancelling="cancellingOrderId === selectedOrder.orderId"
     @close="showOrderDialog = false"
-    @cancel="cancelInfoOrder"
+    @cancel="openCancelConfirmation"
+  />
+  <perps-cancel-order-confirmation-dialog
+    v-if="orderPendingCancel"
+    v-model:is-open="showCancelConfirmation"
+    :order="orderPendingCancel"
+    :display-symbol="baseCurrency"
+    :is-cancelling="cancellingOrderId === orderPendingCancel.orderId"
+    @confirm="confirmCancelOrder"
   />
   <perps-fill-details-dialog
     v-if="selectedFill"
@@ -923,6 +931,7 @@ import AppTableSkeleton, {
   type SkeletonColumn,
 } from '@/components/AppTableSkeleton.vue'
 import PerpsOrderDialog from './components/PerpsOrderDialog.vue'
+import PerpsCancelOrderConfirmationDialog from './components/PerpsCancelOrderConfirmationDialog.vue'
 import PerpsFillDetailsDialog from './components/PerpsFillDetailsDialog.vue'
 import PerpsSelectLeverageDialog from './components/PerpsSelectLeverageDialog.vue'
 import PerpsPagination from './components/PerpsPagination.vue'
@@ -1232,6 +1241,24 @@ const cancelInfoOrder = async (order: ApiOrder) => {
   } finally {
     cancellingOrderId.value = null
   }
+}
+
+const orderPendingCancel = ref<ApiOrder | null>(null)
+const showCancelConfirmation = ref(false)
+
+const openCancelConfirmation = (order: ApiOrder) => {
+  orderPendingCancel.value = order
+  showCancelConfirmation.value = true
+}
+
+watch(showCancelConfirmation, isOpen => {
+  if (isOpen) showOrderDialog.value = false
+})
+
+const confirmCancelOrder = async () => {
+  if (!orderPendingCancel.value) return
+  await cancelInfoOrder(orderPendingCancel.value)
+  showCancelConfirmation.value = false
 }
 
 const ordersSkeletonColumns: SkeletonColumn[] = [

--- a/src/modules/perps/ModulePerpInfo.vue
+++ b/src/modules/perps/ModulePerpInfo.vue
@@ -1209,8 +1209,8 @@ const showCancelButton = (order: ApiOrder) => {
   )
 }
 
-const cancelInfoOrder = async (order: ApiOrder) => {
-  if (cancellingOrderId.value === order.orderId) return
+const cancelInfoOrder = async (order: ApiOrder): Promise<boolean> => {
+  if (cancellingOrderId.value === order.orderId) return false
   cancellingOrderId.value = order.orderId
   const market = markets.value.find(m => m.market === order.market)
   const displayMarket = market?.longName ?? market?.displayName ?? order.market
@@ -1225,6 +1225,7 @@ const cancelInfoOrder = async (order: ApiOrder) => {
     })
     showOrderDialog.value = false
     await Promise.all([ordersPagination.refetch(), fetchOpenOrdersCount()])
+    return true
   } catch (e) {
     console.error('Failed to cancel order:', e)
     const msg = (e instanceof Error ? e.message : String(e)).toLowerCase()
@@ -1238,6 +1239,7 @@ const cancelInfoOrder = async (order: ApiOrder) => {
     } else {
       perpsToasts.toastCancelFailedGeneric()
     }
+    return false
   } finally {
     cancellingOrderId.value = null
   }
@@ -1257,8 +1259,8 @@ watch(showCancelConfirmation, isOpen => {
 
 const confirmCancelOrder = async () => {
   if (!orderPendingCancel.value) return
-  await cancelInfoOrder(orderPendingCancel.value)
-  showCancelConfirmation.value = false
+  const succeeded = await cancelInfoOrder(orderPendingCancel.value)
+  if (succeeded) showCancelConfirmation.value = false
 }
 
 const ordersSkeletonColumns: SkeletonColumn[] = [

--- a/src/modules/perps/components/PerpsCancelOrderConfirmationDialog.vue
+++ b/src/modules/perps/components/PerpsCancelOrderConfirmationDialog.vue
@@ -2,8 +2,8 @@
   <app-dialog
     v-model:is-open="isOpen"
     class="w-full max-w-[440px]"
-    z-index-container="200"
-    z-index-overlay="201"
+    z-index-container="z-[201]"
+    z-index-overlay="z-[200]"
   >
     <template #title>
       <div class="flex items-center gap-2.5 mr-8 pt-5 pl-6">


### PR DESCRIPTION
## Summary

On the per-market **Market info** page (opened as a drawer via `AppViewAsDialog`), cancelling an open order from the row action menu or the order details dialog cancelled it immediately, with no confirmation step. This wires in the existing `PerpsCancelOrderConfirmationDialog` (already used by `PerpsPositionsTable` and `PerpsOrderDialog`) and fixes a z-index bug that kept that dialog hidden behind the drawer.

## Changes

- `src/modules/perps/ModulePerpInfo.vue`
  - Import `PerpsCancelOrderConfirmationDialog` and add `orderPendingCancel` / `showCancelConfirmation` state plus `openCancelConfirmation` / `confirmCancelOrder` handlers, mirroring the pattern in `PerpsPositionsTable`.
  - The row menu **Cancel** and the order dialog's `@cancel` now open the confirmation dialog; the actual cancel (`cancelInfoOrder`) runs only on confirm. A watcher closes the order details dialog when the confirmation opens.
- `src/modules/perps/components/PerpsCancelOrderConfirmationDialog.vue`
  - The z-index props were passed as bare numbers (`"200"`/`"201"`) instead of Tailwind arbitrary classes, so they were inert and the dialog fell back to `z-index: auto`. Inside the market info drawer (`AppViewAsDialog`, `z-[51]`) it rendered behind the drawer and was invisible. Use valid `z-[201]`/`z-[200]` (container above overlay, both above the drawer and `PerpsOrderDialog`'s `z-[111]`).

## Testing

- `pnpm vue-tsc --noEmit -p tsconfig.app.json` → clean
- `pnpm eslint` on changed files → clean
- Manual smoke test: from the Market info drawer, cancelling via the ⋮ menu and via the order details dialog now opens the confirmation modal on top of the drawer; Confirm Cancel cancels + refreshes, Close dismisses without cancelling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a confirmation step before canceling a perps order.
  * Cancel actions from both the orders menu and the order dialog now use the same confirmation flow.
  * Improved the cancellation prompt’s overlay layering so it appears above other dialogs.

* **Bug Fixes**
  * When the cancellation confirmation opens, the main order dialog now closes automatically to prevent overlapping dialogs.
  * Cancel handling now reports success/failure consistently and only dismisses the confirmation after a successful cancel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->