### PR TITLE
fix: [MEW-1912] validate take-profit / stop-loss before saving

### DIFF
--- a/src/modules/perps/ModulePerpsTrade.vue
+++ b/src/modules/perps/ModulePerpsTrade.vue
@@ -758,9 +758,8 @@
       :temp-projected-loss="tempProjectedLoss"
       :active-tp-pill="activeTpPill"
       :active-sl-pill="activeSlPill"
-      :take-profit-error="takeProfitPrecisionError"
-      :stop-loss-error="stopLossPrecisionError"
-      :quote-decimals="quoteDecimals"
+      :take-profit-error="takeProfitErrorMessage"
+      :stop-loss-error="stopLossErrorMessage"
       :has-edits="hasAutoCloseEdits"
       @clear-take-profit="clearTempTakeProfit"
       @clear-stop-loss="clearTempStopLoss"
@@ -940,8 +939,8 @@ const {
   limitPricePrecisionError,
   marginPrecisionError,
   closeAmountPrecisionError,
-  takeProfitPrecisionError,
-  stopLossPrecisionError,
+  takeProfitErrorMessage,
+  stopLossErrorMessage,
   quoteDecimals,
   orderError,
   showConfirmModal,

--- a/src/modules/perps/components/PerpsTakeProfitStopLossDialog.vue
+++ b/src/modules/perps/components/PerpsTakeProfitStopLossDialog.vue
@@ -50,7 +50,7 @@
             </div>
             <perps-amount
               v-model:amount="takeProfitPrice"
-              :error="takeProfitError ? precisionMessage : ''"
+              :error="takeProfitError || ''"
               :validate-input="() => {}"
             >
               <template #footer>
@@ -74,7 +74,7 @@
                 v-if="takeProfitError"
                 class="text-error text-s-12 mt-1 pl-3"
               >
-                {{ precisionMessage }}
+                {{ takeProfitError }}
               </div>
             </transition>
             <div class="text-right text-s-12 sm:text-s-13 mt-2 mr-2">
@@ -120,7 +120,7 @@
             </div>
             <perps-amount
               v-model:amount="stopLossPrice"
-              :error="stopLossError ? precisionMessage : ''"
+              :error="stopLossError || ''"
               :validate-input="() => {}"
             >
               <template #footer>
@@ -141,7 +141,7 @@
             </perps-amount>
             <transition name="fade" mode="out-in">
               <div v-if="stopLossError" class="text-error text-s-12 mt-1 pl-3">
-                {{ precisionMessage }}
+                {{ stopLossError }}
               </div>
             </transition>
             <div class="text-right text-s-12 sm:text-s-13 mt-2 mr-2">
@@ -170,7 +170,7 @@
         <!-- Actions -->
         <div class="flex flex-col gap-1">
           <app-base-button
-            :disabled="!hasEdits"
+            :disabled="!hasEdits || !!takeProfitError || !!stopLossError"
             class="w-full"
             @click="$emit('confirm')"
           >
@@ -190,7 +190,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch, computed, type PropType } from 'vue'
+import { ref, watch, type PropType } from 'vue'
 import AppDialog from '@/components/AppDialog.vue'
 import AppTokenLogo from '@/components/AppTokenLogo.vue'
 import AppBaseButton from '@/components/AppBaseButton.vue'
@@ -203,24 +203,17 @@ import { analytics, PerpsTpSlEvent } from '@/analytics'
 
 const isOpen = defineModel<boolean>('isOpen', { default: false })
 
-const props = defineProps<{
+defineProps<{
   displaySymbol: string
   currentPrice: number
   tempProjectedProfit: number | null
   tempProjectedLoss: number | null
   activeTpPill: number | null
   activeSlPill: number | null
-  takeProfitError?: boolean
-  stopLossError?: boolean
-  quoteDecimals?: number
+  takeProfitError?: string
+  stopLossError?: string
   hasEdits?: boolean
 }>()
-
-const precisionMessage = computed(() => {
-  const dec = props.quoteDecimals ?? 2
-  if (dec === 0) return 'Price must be a whole number'
-  return `Price supports up to ${dec} decimal place${dec === 1 ? '' : 's'}`
-})
 
 const emit = defineEmits<{
   clearTakeProfit: []

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -1112,6 +1112,13 @@ export function usePerpsTradeForm() {
         justSavedAutoClose = false
         return
       }
+      // Discard the unsaved draft on dismiss. submitDisabled keys off the
+      // temp TP/SL, so an invalid draft left behind would otherwise keep the
+      // main Long/Short button disabled even though the committed TP/SL is fine.
+      tempTakeProfitPrice.value = takeProfitPrice.value
+      tempStopLossPrice.value = stopLossPrice.value
+      activeTpPill.value = null
+      activeSlPill.value = null
       void analytics.trackPerpsTpSlEvent(PerpsTpSlEvent.CLICKED_CANCEL)
     }
   })

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -594,9 +594,10 @@ export function usePerpsTradeForm() {
 
   // Take-profit / stop-loss direction: long → TP above mark, SL below; short
   // inverts both. Mirrors the isLong used by the +/-% pill helpers below.
-  const isTpSlLong = computed(
-    () =>
-      activePosition.value?.direction === 'long' || orderSide.value === 'buy',
+  const isTpSlLong = computed(() =>
+    activePosition.value
+      ? activePosition.value.direction === 'long'
+      : orderSide.value === 'buy',
   )
 
   // Full validation messages for the Auto Close dialog (precision + positivity

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -26,6 +26,7 @@ import { usePerpsMarkPrices } from './usePerpsMarkPrices'
 import { usePerpsToasts } from './usePerpsToasts'
 import { formatUsd, hasInvalidPrecision, decimalPlaces } from '../utils/formatters'
 import { getCategory, midPrice, resolveEffectivePrice } from '../utils/market'
+import { takeProfitError, stopLossError } from '../utils/tpSlValidation'
 
 type OrderSide = 'buy' | 'sell'
 type OrderType = 'market' | 'limit'
@@ -591,21 +592,34 @@ export function usePerpsTradeForm() {
     hasInvalidPrecision(closeAmount.value, COLLATERAL_DECIMALS),
   )
 
-  const takeProfitPrecisionError = computed(() => {
-    if (tempTakeProfitPrice.value == null) return false
-    return hasInvalidPrecision(
-      String(tempTakeProfitPrice.value),
-      quoteDecimals.value,
-    )
-  })
+  // Take-profit / stop-loss direction: long → TP above mark, SL below; short
+  // inverts both. Mirrors the isLong used by the +/-% pill helpers below.
+  const isTpSlLong = computed(
+    () =>
+      activePosition.value?.direction === 'long' || orderSide.value === 'buy',
+  )
 
-  const stopLossPrecisionError = computed(() => {
-    if (tempStopLossPrice.value == null) return false
-    return hasInvalidPrecision(
-      String(tempStopLossPrice.value),
+  // Full validation messages for the Auto Close dialog (precision + positivity
+  // + correct side of mark + max price). Empty string means valid. These also
+  // gate submitDisabled so an invalid TP/SL can't be sent and rejected by the
+  // backend after confirm.
+  const takeProfitErrorMessage = computed(() =>
+    takeProfitError(
+      tempTakeProfitPrice.value,
+      currentPrice.value,
+      isTpSlLong.value,
       quoteDecimals.value,
-    )
-  })
+    ),
+  )
+
+  const stopLossErrorMessage = computed(() =>
+    stopLossError(
+      tempStopLossPrice.value,
+      currentPrice.value,
+      isTpSlLong.value,
+      quoteDecimals.value,
+    ),
+  )
 
   // ── Limit price validation ─────────────────────────────────
   // Backend rejects orders whose price drifts more than 10% from mid; mirror
@@ -641,8 +655,7 @@ export function usePerpsTradeForm() {
     if (!amt || amt <= 0 || isSubmitting.value) return true
     if (limitPriceHasError.value) return true
     if (marginPrecisionError.value) return true
-    if (takeProfitPrecisionError.value || stopLossPrecisionError.value)
-      return true
+    if (takeProfitErrorMessage.value || stopLossErrorMessage.value) return true
     if (availableMargin.value * leverage.value < minOrderAmount.value)
       return true
     if (amt > availableMargin.value) return true
@@ -1023,9 +1036,7 @@ export function usePerpsTradeForm() {
 
   function setTakeProfitPct(pct: number) {
     if (!currentPrice.value) return
-    const isLong =
-      activePosition.value?.direction === 'long' || orderSide.value === 'buy'
-    tempTakeProfitPrice.value = isLong
+    tempTakeProfitPrice.value = isTpSlLong.value
       ? Number((currentPrice.value * (1 + pct / 100)).toFixed(2))
       : Number((currentPrice.value * (1 - pct / 100)).toFixed(2))
 
@@ -1034,9 +1045,7 @@ export function usePerpsTradeForm() {
 
   function setStopLossPct(pct: number) {
     if (!currentPrice.value) return
-    const isLong =
-      activePosition.value?.direction === 'long' || orderSide.value === 'buy'
-    tempStopLossPrice.value = isLong
+    tempStopLossPrice.value = isTpSlLong.value
       ? Number((currentPrice.value * (1 - pct / 100)).toFixed(2))
       : Number((currentPrice.value * (1 + pct / 100)).toFixed(2))
     activeSlPill.value = pct
@@ -1575,8 +1584,8 @@ export function usePerpsTradeForm() {
     limitPricePrecisionError,
     marginPrecisionError,
     closeAmountPrecisionError,
-    takeProfitPrecisionError,
-    stopLossPrecisionError,
+    takeProfitErrorMessage,
+    stopLossErrorMessage,
     quoteDecimals,
     newMarginRatio,
     orderError,

--- a/src/modules/perps/utils/tpSlValidation.ts
+++ b/src/modules/perps/utils/tpSlValidation.ts
@@ -1,0 +1,60 @@
+// Take-Profit / Stop-Loss trigger-price validation for the Auto Close dialog.
+//
+// The backend rejects trigger prices that are non-positive, on the wrong side
+// of the mark price, or absurdly large. Mirror those rules on the client so the
+// Save button can be disabled and the error surfaced before submit instead of
+// after a rejected order (MEW-1912).
+//
+// Direction depends on the position side: for a LONG, take profit sits ABOVE
+// the mark and stop loss BELOW; for a SHORT it is inverted.
+import { hasInvalidPrecision } from './formatters'
+
+// Matches the ceiling already enforced on the limit price input.
+export const MAX_TRIGGER_PRICE = 10_000_000
+
+function precisionMessage(quoteDecimals: number): string {
+  if (quoteDecimals === 0) return 'Price must be a whole number'
+  return `Price supports up to ${quoteDecimals} decimal place${quoteDecimals === 1 ? '' : 's'}`
+}
+
+// Returns an error message for an invalid take-profit price, or '' when valid.
+// A null price means "not set" and is always valid (the field is optional).
+export function takeProfitError(
+  price: number | null,
+  markPrice: number,
+  isLong: boolean,
+  quoteDecimals: number,
+): string {
+  if (price == null) return ''
+  if (hasInvalidPrecision(String(price), quoteDecimals))
+    return precisionMessage(quoteDecimals)
+  if (price >= MAX_TRIGGER_PRICE)
+    return 'Take Profit must be less than $10,000,000'
+  if (isLong) {
+    // For a long, take profit above the mark also guarantees it is positive.
+    if (price <= markPrice) return 'Take Profit must be above mark price'
+  } else {
+    if (price <= 0) return 'Take Profit must be above 0'
+    if (price >= markPrice) return 'Take Profit must be below mark price'
+  }
+  return ''
+}
+
+// Returns an error message for an invalid stop-loss price, or '' when valid.
+export function stopLossError(
+  price: number | null,
+  markPrice: number,
+  isLong: boolean,
+  quoteDecimals: number,
+): string {
+  if (price == null) return ''
+  if (hasInvalidPrecision(String(price), quoteDecimals))
+    return precisionMessage(quoteDecimals)
+  if (price <= 0) return 'Stop Loss must be above 0'
+  if (isLong) {
+    if (price >= markPrice) return 'Stop Loss must be below mark price'
+  } else {
+    if (price <= markPrice) return 'Stop Loss must be above mark price'
+  }
+  return ''
+}

--- a/tests/unit/specs/modules/perps/utils/tpSlValidation.spec.ts
+++ b/tests/unit/specs/modules/perps/utils/tpSlValidation.spec.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest'
+import {
+  takeProfitError,
+  stopLossError,
+} from '@/modules/perps/utils/tpSlValidation'
+
+const MARK = 100
+const DEC = 2
+
+describe('takeProfitError (MEW-1912)', () => {
+  it('returns no error when price is null (not set)', () => {
+    expect(takeProfitError(null, MARK, true, DEC)).toBe('')
+  })
+
+  describe('long position (TP must be above mark)', () => {
+    it('accepts a price above mark', () => {
+      expect(takeProfitError(110, MARK, true, DEC)).toBe('')
+    })
+    it('rejects a price at or below mark', () => {
+      expect(takeProfitError(100, MARK, true, DEC)).toBe(
+        'Take Profit must be above mark price',
+      )
+      expect(takeProfitError(90, MARK, true, DEC)).toBe(
+        'Take Profit must be above mark price',
+      )
+    })
+    it('rejects zero as below mark', () => {
+      expect(takeProfitError(0, MARK, true, DEC)).toBe(
+        'Take Profit must be above mark price',
+      )
+    })
+  })
+
+  describe('short position (TP must be below mark and positive)', () => {
+    it('accepts a positive price below mark', () => {
+      expect(takeProfitError(90, MARK, false, DEC)).toBe('')
+    })
+    it('rejects zero as non-positive (the HOOD +100% case)', () => {
+      expect(takeProfitError(0, MARK, false, DEC)).toBe(
+        'Take Profit must be above 0',
+      )
+    })
+    it('rejects a price at or above mark', () => {
+      expect(takeProfitError(100, MARK, false, DEC)).toBe(
+        'Take Profit must be below mark price',
+      )
+      expect(takeProfitError(110, MARK, false, DEC)).toBe(
+        'Take Profit must be below mark price',
+      )
+    })
+  })
+
+  it('rejects prices at or above $10,000,000', () => {
+    expect(takeProfitError(10_000_000, MARK, true, DEC)).toBe(
+      'Take Profit must be less than $10,000,000',
+    )
+  })
+
+  it('reports precision errors first', () => {
+    expect(takeProfitError(110.123, MARK, true, 2)).toBe(
+      'Price supports up to 2 decimal places',
+    )
+    expect(takeProfitError(110.1, MARK, true, 0)).toBe(
+      'Price must be a whole number',
+    )
+  })
+})
+
+describe('stopLossError (MEW-1912)', () => {
+  it('returns no error when price is null (not set)', () => {
+    expect(stopLossError(null, MARK, true, DEC)).toBe('')
+  })
+
+  it('rejects a non-positive price', () => {
+    expect(stopLossError(0, MARK, true, DEC)).toBe('Stop Loss must be above 0')
+    expect(stopLossError(0, MARK, false, DEC)).toBe('Stop Loss must be above 0')
+  })
+
+  describe('long position (SL must be below mark)', () => {
+    it('accepts a positive price below mark', () => {
+      expect(stopLossError(90, MARK, true, DEC)).toBe('')
+    })
+    it('rejects a price at or above mark', () => {
+      expect(stopLossError(100, MARK, true, DEC)).toBe(
+        'Stop Loss must be below mark price',
+      )
+      expect(stopLossError(110, MARK, true, DEC)).toBe(
+        'Stop Loss must be below mark price',
+      )
+    })
+  })
+
+  describe('short position (SL must be above mark)', () => {
+    it('accepts a price above mark', () => {
+      expect(stopLossError(110, MARK, false, DEC)).toBe('')
+    })
+    it('rejects a price at or below mark', () => {
+      expect(stopLossError(100, MARK, false, DEC)).toBe(
+        'Stop Loss must be above mark price',
+      )
+      expect(stopLossError(90, MARK, false, DEC)).toBe(
+        'Stop Loss must be above mark price',
+      )
+    })
+  })
+
+  it('reports precision errors first', () => {
+    expect(stopLossError(90.123, MARK, true, 2)).toBe(
+      'Price supports up to 2 decimal places',
+    )
+  })
+})


### PR DESCRIPTION
## Summary

The Auto Close (Take Profit / Stop Loss) dialog only validated price precision, so a user could set a take-profit of `0` (e.g. the HOOD `+100%` pill on a short computes to `mark * (1 - 1) = 0`), or a TP/SL on the wrong side of the mark price, and still hit **Save**. The backend then rejected the order only at confirm time (`take profit trigger price '0' is invalid – must be positive`).

## Changes

- **`src/modules/perps/utils/tpSlValidation.ts`** (new): pure, side-aware validators returning an error message (or `''` when valid):
  - **TP** — must be positive, `< $10,000,000`, and above the mark for a **long** / below the mark for a **short**.
  - **SL** — must be positive, and below the mark for a **long** / above the mark for a **short**.
  - Precision errors take priority (message preserved).
- **`src/modules/perps/composables/usePerpsTradeForm.ts`**: adds `isTpSlLong` and `takeProfitErrorMessage` / `stopLossErrorMessage` (replacing the precision-only booleans); `submitDisabled` now gates on these so an invalid TP/SL can't be submitted at all. The `+/-%` pill setters reuse `isTpSlLong`.
- **`src/modules/perps/components/PerpsTakeProfitStopLossDialog.vue`**: displays the real error message per field and disables **Save** while either TP or SL is invalid.

### Note on long vs short direction

The ticket lists the long-side messages (TP above mark, SL below mark). Since the reported case is a **short** position, the direction is implemented **side-aware** (short inverts to: TP below mark, SL above mark) — a "TP above mark" on a short would lock in a loss, so the literal long-only messages would be incorrect there.

## Testing

- `pnpm vitest run tests/unit/specs/modules/perps/utils/tpSlValidation.spec.ts` → 16/16 pass (long/short, zero, wrong-side, `$10M`, precision)
- `pnpm vue-tsc --noEmit -p tsconfig.app.json` → clean
- `pnpm eslint` on changed files → clean
- Manual smoke test on long and short: TP=0 / wrong-side / `≥ $10M` and SL wrong-side / `≤ 0` each show the error and disable Save; valid values save and confirm without a backend rejection.

_(Pre-existing, unrelated: `usePerpsAuth.spec.ts` fails to load locally due to a missing `@ledgerhq/hw-app-eth` module in the pnpm store — fails identically on clean HEAD.)_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added client-side TP/SL trigger validation for Auto Close in perps trading, producing precise, user-facing error messages.
* **Bug Fixes**
  * Updated the TP/SL dialog to display validation messages directly and disable saving when either TP or SL is invalid.
  * Improved long/short TP/SL placement rules and prevented invalid TP/SL drafts from affecting the main submission state.
* **Tests**
  * Added unit tests covering TP/SL validation, including precision handling and boundary cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->