### PR TITLE
fix: [MEW-2010] guard null sparkline price in perps market list

### DIFF
--- a/src/modules/perps/components/PerpsMarketList.vue
+++ b/src/modules/perps/components/PerpsMarketList.vue
@@ -304,8 +304,8 @@
                     {{ formatChange(contract.priceChangePercent) }}
                   </p>
                   <table-sparkline
-                    v-if="contract.sparkline?.price.length"
-                    :points="contract.sparkline.price.map(Number)"
+                    v-if="contract.sparkline?.price?.length"
+                    :points="(contract.sparkline?.price ?? []).map(Number)"
                     :width="70"
                     :height="24"
                     :max-points="34"

--- a/src/modules/perps/sdk/types.ts
+++ b/src/modules/perps/sdk/types.ts
@@ -80,7 +80,9 @@ export interface TokenConfig {
 }
 
 export interface Sparkline {
-  price: string[]
+  // Optional to match the API schema: the server may return a sparkline
+  // object with no price array (e.g. markets without recent history).
+  price?: string[]
 }
 
 export interface Contract {


### PR DESCRIPTION
## Summary

Searching the Perps Market list for `ETH` (and other queries that surface a market without sparkline history) crashed the render and made the whole market list section disappear. The browser console showed `Cannot read properties of null (reading 'length')`.

## Root cause

`PerpsMarketList.vue` guarded only the sparkline object, not its `price` array:

```vue
v-if="contract.sparkline?.price.length"   <!-- sparkline?. but price.length is unguarded -->
```

The local `Sparkline` type declared `price: string[]` (required), but the API schema marks it optional (`price?: string[]`). When the server returns a `sparkline` object with no `price`, `price.length` throws and Vue tears down the list subtree.

## Changes

- `src/modules/perps/sdk/types.ts` — make `Sparkline.price` optional to match the API schema (the real source of the wrong assumption).
- `src/modules/perps/components/PerpsMarketList.vue` — chain the access: `contract.sparkline?.price?.length` and `(contract.sparkline?.price ?? []).map(Number)`, so a market without sparkline history renders without the sparkline instead of blanking the list.

## Testing

- `pnpm vue-tsc --noEmit -p tsconfig.app.json` → clean (the now-optional type forces the safe access)
- `pnpm eslint` on changed files → clean
- Manual smoke test: searching `ETH`/`eth` (and other terms) no longer throws or hides the list — it shows matches or "No results found"; markets with sparkline data still render it, others render the row without it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the perps market list so 24H sparklines no longer fail when sparkline data is missing.
  * Made sparkline display handling more resilient by safely falling back when price data is unavailable.
* **Chores**
  * Updated data handling to reflect that sparkline price data may be omitted in some responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->