### PR TITLE
feat: ✨ buy and sell analytics implementation

### DIFF
--- a/src/analytics/amplitude.ts
+++ b/src/analytics/amplitude.ts
@@ -51,6 +51,18 @@ import type {
   GlobalSearchSelectTokenPayload,
   GlobalSearchTokenNotFoundPayload,
   WeekendTradingAnnouncementEvent,
+  BuyEvent,
+  BuyOfferEvent,
+  BuyPayloadShared,
+  BuyOfferPayloadShared,
+  BuyEventError,
+  BuyErrorPayload,
+  SellEvent,
+  SellOfferEvent,
+  SellPayloadShared,
+  SellOfferPayload,
+  SellEventError,
+  SellErrorPayload,
 } from './events'
 import {
   type BalanceBracket,
@@ -645,6 +657,70 @@ export class Analytics {
   readonly trackGlobalSearchTokenNotFoundEvent = (
     event: typeof GlobalSearchEvent.TOKEN_NOT_FOUND,
     payload: GlobalSearchTokenNotFoundPayload,
+  ): Promise<void> => {
+    return this._track(event, { ...payload })
+  }
+
+  // =============================================================================
+  // BUY
+  // =============================================================================
+
+  /**
+   * Send a Buy analytics event to Amplitude
+   *
+   * @param event     Type of Buy event
+   * @param payload   Event properties (shared, or offer payload for offer events)
+   * @returns         Promise that resolves when the event is tracked
+   */
+  readonly trackBuyEvent = (
+    event: BuyEvent | BuyOfferEvent,
+    payload: BuyPayloadShared | BuyOfferPayloadShared,
+  ): Promise<void> => {
+    return this._track(event, { ...payload })
+  }
+
+  /**
+   * Send a Buy Error analytics event to Amplitude
+   *
+   * @param event     Type of BuyEventError
+   * @param payload   Event properties
+   * @returns         Promise that resolves when the event is tracked
+   */
+  readonly trackBuyEventError = (
+    event: BuyEventError,
+    payload: BuyErrorPayload,
+  ): Promise<void> => {
+    return this._track(event, { ...payload })
+  }
+
+  // =============================================================================
+  // SELL
+  // =============================================================================
+
+  /**
+   * Send a Sell analytics event to Amplitude
+   *
+   * @param event     Type of Sell event
+   * @param payload   Event properties (shared, or offer payload for offer events)
+   * @returns         Promise that resolves when the event is tracked
+   */
+  readonly trackSellEvent = (
+    event: SellEvent | SellOfferEvent,
+    payload: SellPayloadShared | SellOfferPayload,
+  ): Promise<void> => {
+    return this._track(event, { ...payload })
+  }
+
+  /**
+   * Send a Sell Error analytics event to Amplitude
+   *
+   * @param event     Type of SellEventError
+   * @param payload   Event properties
+   * @returns         Promise that resolves when the event is tracked
+   */
+  readonly trackSellEventError = (
+    event: SellEventError,
+    payload: SellErrorPayload,
   ): Promise<void> => {
     return this._track(event, { ...payload })
   }

--- a/src/analytics/events.ts
+++ b/src/analytics/events.ts
@@ -413,3 +413,100 @@ export const WeekendTradingAnnouncementEvent = {
 
 export type WeekendTradingAnnouncementEvent =
   (typeof WeekendTradingAnnouncementEvent)[keyof typeof WeekendTradingAnnouncementEvent]
+
+// =============================================================================
+// BUY (Fiat Onramp)
+// =============================================================================
+
+export const BuyEvent = {
+  SHOWN: 'Buy_Shown',
+  PRELIMINARY_SHOWN: 'Buy_Preliminary_Rate_Shown',
+  CLICK_CONTINUE: 'Buy_Clicked_Continue',
+} as const
+export type BuyEvent = (typeof BuyEvent)[keyof typeof BuyEvent]
+
+export type BuyPayloadShared = {
+  network?: string
+  token: string
+  currency: string
+  amountUSD: string
+  amountOriginalCurrency: string
+}
+
+export const BuyOfferEvent = {
+  OFFER_SHOWN: 'Buy_Offer_Shown',
+  OFFER_CANCELED: 'Buy_Offer_Canceled',
+  OFFER_PROCEED: 'Buy_Offer_Clicked_Continue',
+} as const
+export type BuyOfferEvent = (typeof BuyOfferEvent)[keyof typeof BuyOfferEvent]
+
+export const PROVIDER_NAMES = [
+  'moonpay',
+  'simplex',
+  'topper',
+  'coinbase',
+] as const
+export type ProviderName = (typeof PROVIDER_NAMES)[number]
+
+export type BuyOfferPayloadShared = BuyPayloadShared & {
+  MoonpayRate?: string
+  SimplexRate?: string
+  TopperRate?: string
+  CoinbaseRate?: string
+  bestProviderRate: string
+  selectedRate: string
+  selectedProvider: ProviderName
+}
+
+export const BuyEventError = {
+  PRELIMINARY_ERROR: 'Buy_Preliminary_Rate_Error',
+  OFFER_ERROR: 'Buy_Offer_Error',
+} as const
+export type BuyEventError = (typeof BuyEventError)[keyof typeof BuyEventError]
+
+export type BuyErrorPayload = BuyPayloadShared & {
+  errorMsg: string
+}
+
+// =============================================================================
+// SELL (Fiat Offramp)
+// =============================================================================
+
+export const SellEvent = {
+  SHOWN: 'Sell_Shown',
+  PRELIMINARY_SHOWN: 'Sell_Preliminary_Rate_Shown',
+  CLICK_CONTINUE: 'Sell_Clicked_Continue',
+} as const
+export type SellEvent = (typeof SellEvent)[keyof typeof SellEvent]
+
+export type SellPayloadShared = {
+  network?: string
+  token: string
+  currency: string
+  amountToken: string
+  amountUSD?: string
+  amountOriginalCurrency?: string
+  networkFeeUSD?: string
+}
+
+export const SellOfferEvent = {
+  OFFER_SHOWN: 'Sell_Offer_Shown',
+  OFFER_CANCELED: 'Sell_Offer_Canceled',
+  OFFER_PROCEED: 'Sell_Offer_Clicked_Continue',
+} as const
+export type SellOfferEvent = (typeof SellOfferEvent)[keyof typeof SellOfferEvent]
+
+export type SellOfferPayload = SellPayloadShared & {
+  moonpayRate: string
+}
+
+export const SellEventError = {
+  PRELIMINARY_ERROR: 'Sell_Preliminary_Rate_Error',
+  OFFER_ERROR: 'Sell_Offer_Error',
+} as const
+export type SellEventError =
+  (typeof SellEventError)[keyof typeof SellEventError]
+
+export type SellErrorPayload = SellPayloadShared & {
+  errorMsg: string
+}

--- a/src/modules/purchase/ModuleBuy.vue
+++ b/src/modules/purchase/ModuleBuy.vue
@@ -91,6 +91,7 @@
       :crypto-currency="tokenSymbol"
       :is-loading="isFetchingQuotes"
       :error="buyQuotesError"
+      :analytics-payload="buyPayload"
     />
   </div>
 </template>
@@ -127,6 +128,8 @@ import { usePurchaseCompatibility } from './composables/usePurchaseCompatibility
 
 import { type PurchaseAsset } from '@/types/buyToken'
 import type { Chain } from '@/mew_api/types'
+import { analytics, BuyEvent, BuyEventError } from '@/analytics'
+import type { BuyPayloadShared } from '@/analytics'
 
 const { t } = useI18n()
 
@@ -247,6 +250,7 @@ const applyPreselectedToken = () => {
 onMounted(() => {
   fetchPurchaseInfo()
   applyPreselectedToken()
+  analytics.trackBuyEvent(BuyEvent.SHOWN, buyPayload.value)
 })
 
 watch([() => walletMenu.selectedPurchaseCoinId, buyNetworks], applyPreselectedToken)
@@ -299,6 +303,19 @@ const quickButtons = computed(() => {
 const formattedCryptoEstimate = computed(() => {
   if (!cryptoEstimate.value) return `0.00 ${tokenSymbol.value}`.trim()
   return `${formatFloatingPointValue(cryptoEstimate.value).value} ${tokenSymbol.value}`.trim()
+})
+
+const buyPayload = computed<BuyPayloadShared>(() => {
+  const rate = currencyRate.value
+  const amountUSD =
+    rate && rate > 0 ? (Number(fiatAmount.value) / rate).toFixed(2) : fiatAmount.value
+  return {
+    network: displayChain.value?.name,
+    token: tokenSymbol.value,
+    currency: selectedFiat.value,
+    amountUSD,
+    amountOriginalCurrency: fiatAmount.value,
+  }
 })
 
 const limitText = (value: number) =>
@@ -373,6 +390,15 @@ const fetchEstimate = async () => {
     cryptoCurrency: tokenSymbol.value,
     chain: purchaseChainCode.value,
   })
+  if (!amountIsValid.value) return
+  if (cryptoEstimate.value) {
+    analytics.trackBuyEvent(BuyEvent.PRELIMINARY_SHOWN, buyPayload.value)
+  } else {
+    analytics.trackBuyEventError(BuyEventError.PRELIMINARY_ERROR, {
+      ...buyPayload.value,
+      errorMsg: 'no_quotes',
+    })
+  }
 }
 
 const debouncedFetchEstimate = useDebounceFn(fetchEstimate, 500)
@@ -441,6 +467,8 @@ const onSubmit = async () => {
     return
   }
   if (!amountIsValid.value) return
+
+  analytics.trackBuyEvent(BuyEvent.CLICK_CONTINUE, buyPayload.value)
 
   clearBuyQuotes()
   showProviderModal.value = true

--- a/src/modules/purchase/ModuleSell.vue
+++ b/src/modules/purchase/ModuleSell.vue
@@ -141,6 +141,7 @@
       :crypto-symbol="tokenSymbol"
       :is-loading="isFetchingSellQuote"
       :error="sellQuoteError"
+      :analytics-payload="sellPayload"
     />
   </div>
 </template>
@@ -176,6 +177,8 @@ import { usePurchaseCompatibility } from './composables/usePurchaseCompatibility
 
 import { type PurchaseAsset } from '@/types/buyToken'
 import type { Chain } from '@/mew_api/types'
+import { analytics, SellEvent, SellEventError } from '@/analytics'
+import type { SellPayloadShared } from '@/analytics'
 
 const { t } = useI18n()
 
@@ -274,6 +277,7 @@ const tokenSymbol = computed<string>(
 
 onMounted(() => {
   fetchPurchaseInfo()
+  analytics.trackSellEvent(SellEvent.SHOWN, sellPayload.value)
 })
 
 const currencyOptions = computed(() => Array.from(sellFiats.value.keys()))
@@ -444,6 +448,32 @@ const formattedFiatEstimate = computed(() => {
   return `${symbol}${formatFiatValue(amount).value}`
 })
 
+const sellPayload = computed<SellPayloadShared>(() => {
+  const price = tokenPrice.value
+  const rate = fiatRate.value
+  const amountUSD =
+    price > 0 ? (Number(cryptoAmount.value) * price).toFixed(2) : ''
+  const amountOriginalCurrency =
+    sellQuote.value?.fiat_amount ??
+    (price > 0 && rate
+      ? (Number(cryptoAmount.value) * price * rate).toFixed(2)
+      : '')
+  const fee = feeSelector.value
+  const networkFeeUSD =
+    fee?.hasFees && fee?.hasFiatEstimates
+      ? (fee.selectedFeeFiat as string).replace(/[^0-9.]/g, '') || undefined
+      : undefined
+  return {
+    network: displayChain.value?.name,
+    token: tokenSymbol.value,
+    currency: selectedFiat.value,
+    amountToken: cryptoAmount.value,
+    amountUSD,
+    amountOriginalCurrency,
+    networkFeeUSD,
+  }
+})
+
 const ESTIMATE_FALLBACK_ADDRESS = '0x0000000000000000000000000000000000000000'
 
 const fetchEstimate = async () => {
@@ -458,6 +488,15 @@ const fetchEstimate = async () => {
     cryptoCurrency: tokenSymbol.value,
     chain: purchaseChainCode.value,
   })
+  if (!amountIsValid.value) return
+  if (sellQuote.value) {
+    analytics.trackSellEvent(SellEvent.PRELIMINARY_SHOWN, sellPayload.value)
+  } else {
+    analytics.trackSellEventError(SellEventError.PRELIMINARY_ERROR, {
+      ...sellPayload.value,
+      errorMsg: sellQuoteError.value || 'no_quote',
+    })
+  }
 }
 
 const debouncedFetchEstimate = useDebounceFn(fetchEstimate, 500)
@@ -537,6 +576,7 @@ const onSubmit = () => {
     return
   }
   if (!amountIsValid.value) return
+  analytics.trackSellEvent(SellEvent.CLICK_CONTINUE, sellPayload.value)
   showProviderModal.value = true
 }
 </script>

--- a/src/modules/purchase/components/BuyProviderModal.vue
+++ b/src/modules/purchase/components/BuyProviderModal.vue
@@ -183,6 +183,12 @@ import {
   getPaymentMethodIcons,
 } from '../helpers/purchaseProviders'
 import type { BuyQuote } from '@/types/buyToken'
+import { analytics, BuyOfferEvent, BuyEventError } from '@/analytics'
+import type {
+  BuyPayloadShared,
+  BuyOfferPayloadShared,
+  ProviderName,
+} from '@/analytics'
 
 const props = defineProps<{
   quotes: BuyQuote[]
@@ -191,6 +197,7 @@ const props = defineProps<{
   cryptoCurrency: string
   isLoading: boolean
   error: string
+  analyticsPayload: BuyPayloadShared
 }>()
 
 const isOpen = defineModel('isOpen', { type: Boolean, required: true })
@@ -204,6 +211,56 @@ watch(
     selectedIndex.value = 0
   },
 )
+
+const buildOfferPayload = (): BuyOfferPayloadShared => {
+  const rateOf = (name: string) =>
+    props.quotes.find(q => q.provider.toLowerCase() === name)?.crypto_amount
+  const best = props.quotes[0]
+  const selected = selectedQuote.value
+  return {
+    ...props.analyticsPayload,
+    MoonpayRate: rateOf('moonpay'),
+    SimplexRate: rateOf('simplex'),
+    TopperRate: rateOf('topper'),
+    CoinbaseRate: rateOf('coinbase'),
+    bestProviderRate: best?.provider.toLowerCase() ?? '',
+    selectedRate: selected?.crypto_amount ?? '',
+    selectedProvider: (selected?.provider.toLowerCase() ??
+      'moonpay') as ProviderName,
+  }
+}
+
+const offerShown = ref(false)
+const errorTracked = ref(false)
+const proceeded = ref(false)
+
+watch(
+  () => [isOpen.value, props.isLoading, props.quotes.length, props.error],
+  () => {
+    if (!isOpen.value || props.isLoading) return
+    if (props.quotes.length && !offerShown.value) {
+      offerShown.value = true
+      analytics.trackBuyEvent(BuyOfferEvent.OFFER_SHOWN, buildOfferPayload())
+    } else if (props.error && !errorTracked.value) {
+      errorTracked.value = true
+      analytics.trackBuyEventError(BuyEventError.OFFER_ERROR, {
+        ...props.analyticsPayload,
+        errorMsg: props.error,
+      })
+    }
+  },
+)
+
+watch(isOpen, (open, wasOpen) => {
+  if (wasOpen && !open) {
+    if (offerShown.value && !proceeded.value) {
+      analytics.trackBuyEvent(BuyOfferEvent.OFFER_CANCELED, buildOfferPayload())
+    }
+    offerShown.value = false
+    errorTracked.value = false
+    proceeded.value = false
+  }
+})
 
 const selectedQuote = computed(() =>
   props.quotes.length ? props.quotes[selectedIndex.value] : null,
@@ -224,6 +281,8 @@ const formattedFiatReceive = (quote: BuyQuote) => {
 
 const onContinue = () => {
   if (!selectedQuote.value?.url) return
+  proceeded.value = true
+  analytics.trackBuyEvent(BuyOfferEvent.OFFER_PROCEED, buildOfferPayload())
   window.open(selectedQuote.value.url, '_blank')
   isOpen.value = false
 }

--- a/src/modules/purchase/components/SellProviderModal.vue
+++ b/src/modules/purchase/components/SellProviderModal.vue
@@ -107,7 +107,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { ArrowTopRightOnSquareIcon } from '@heroicons/vue/24/solid'
 import AppDialog from '@/components/AppDialog.vue'
@@ -118,6 +118,8 @@ import {
 import { getCurrencySymbol } from '@/utils/currencySymbols'
 import { getProviderLogo } from '../helpers/purchaseProviders'
 import type { SellQuote } from '@/types/buyToken'
+import { analytics, SellOfferEvent, SellEventError } from '@/analytics'
+import type { SellPayloadShared, SellOfferPayload } from '@/analytics'
 
 const props = defineProps<{
   quote: SellQuote | null
@@ -125,11 +127,49 @@ const props = defineProps<{
   cryptoSymbol: string
   isLoading: boolean
   error: string
+  analyticsPayload: SellPayloadShared
 }>()
 
 const isOpen = defineModel('isOpen', { type: Boolean, required: true })
 
 const { t } = useI18n()
+
+const buildOfferPayload = (): SellOfferPayload => ({
+  ...props.analyticsPayload,
+  moonpayRate: props.quote?.fiat_amount ?? '',
+})
+
+const offerShown = ref(false)
+const errorTracked = ref(false)
+const proceeded = ref(false)
+
+watch(
+  () => [isOpen.value, props.isLoading, props.quote, props.error],
+  () => {
+    if (!isOpen.value || props.isLoading) return
+    if (props.quote && !offerShown.value) {
+      offerShown.value = true
+      analytics.trackSellEvent(SellOfferEvent.OFFER_SHOWN, buildOfferPayload())
+    } else if (props.error && !errorTracked.value) {
+      errorTracked.value = true
+      analytics.trackSellEventError(SellEventError.OFFER_ERROR, {
+        ...props.analyticsPayload,
+        errorMsg: props.error,
+      })
+    }
+  },
+)
+
+watch(isOpen, (open, wasOpen) => {
+  if (wasOpen && !open) {
+    if (offerShown.value && !proceeded.value) {
+      analytics.trackSellEvent(SellOfferEvent.OFFER_CANCELED, buildOfferPayload())
+    }
+    offerShown.value = false
+    errorTracked.value = false
+    proceeded.value = false
+  }
+})
 
 const formattedCrypto = computed(() => {
   const amount = props.quote?.crypto_amount ?? props.cryptoAmount
@@ -149,6 +189,8 @@ const providerLogo = computed(() =>
 
 const onContinue = () => {
   if (!props.quote?.url) return
+  proceeded.value = true
+  analytics.trackSellEvent(SellOfferEvent.OFFER_PROCEED, buildOfferPayload())
   window.open(props.quote.url, '_blank')
   isOpen.value = false
 }


### PR DESCRIPTION
### Feature

## What
Adds Amplitude analytics tracking to the Buy (fiat onramp) and Sell (fiat offramp) flows, covering screen views, preliminary rate results, continue clicks, provider offers, and errors.

## Why
We had no visibility into user behavior across the buy/sell funnels, making it impossible to measure conversion, drop-off, and provider selection. This instrumentation enables that analysis (MEW-1753).

## How
- Define Buy/Sell event enums, shared payloads, and error types in `src/analytics/events.ts`, exposed via `src/analytics/amplitude.ts`.
- Track `Shown`, `Preliminary_Rate_Shown/Error`, and `Clicked_Continue` events in `ModuleBuy.vue` and `ModuleSell.vue` with computed analytics payloads.
- Track `Offer_Shown`, `Offer_Canceled`, `Offer_Clicked_Continue`, and `Offer_Error` events in `BuyProviderModal.vue` and `SellProviderModal.vue`.
- Capture per-provider rates (Moonpay, Simplex, Topper, Coinbase) and selected provider/rate in the buy offer payload.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added analytics tracking for buy and sell flows, including key steps like view, quote loading, continue, and offer completion.
  * Expanded offer tracking to capture provider details and rate information for selected options.
* **Bug Fixes**
  * Added error tracking for missing quotes and other offer-load issues in buy and sell flows.
  * Improved tracking accuracy by only recording offer events once per session and handling cancel/proceed actions consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->