### PR TITLE
fix: [MEW-1913] sync confirm modal leverage with the trade panel

### DIFF
--- a/src/modules/perps/ModulePerpsTrade.vue
+++ b/src/modules/perps/ModulePerpsTrade.vue
@@ -687,7 +687,7 @@
       :current-price="currentPrice"
       :limit-price="limitPrice"
       :input-amount="inputAmount"
-      :leverage="manageMode === 'add' ? tempLeverage : leverage"
+      :leverage="manageMode === 'add' ? localLeverage : leverage"
       :position-size-usd="positionSizeUsd"
       :order-size="orderSize"
       :estimated-liquidation="estimatedLiquidation"
@@ -854,7 +854,13 @@ const onCloseAmountInput = (e: Event) => {
 }
 
 const confirmAndSubmitAndSetLeverage = async () => {
-  if (manageMode.value === 'add' && tempLeverage.value !== leverage.value) {
+  // In add mode `localLeverage` is the authoritative, user-staged leverage
+  // (what the panel and confirm modal show). `tempLeverage` is only the
+  // leverage dialog's slider draft and can drift from the singleton via its
+  // own watcher, so sync it to `localLeverage` before saving to avoid sending
+  // a stale value to setLeverage (MEW-1913).
+  if (manageMode.value === 'add' && localLeverage.value !== leverage.value) {
+    tempLeverage.value = localLeverage.value
     await saveLeverage()
     if (!leverageError.value) await confirmAndSubmitOrder()
   } else {


### PR DESCRIPTION
## Summary

In the **Add to position** flow the leverage shown in the trade **Confirm order modal** could disagree with the leverage in the **Perpetuals side panel** (QA saw panel `6×` vs confirm modal `20×`), and confirming then failed with `leverage exceeds market maximum`.

## Root cause

Add mode carries the leverage in three refs:

| Surface | Ref |
|---|---|
| Trade panel pill | `localLeverage` (ModulePerpsTrade-local, user-staged value) |
| Confirm order modal + `setLeverage` on confirm | `tempLeverage` (composable — the leverage dialog's slider draft) |
| Order size (`createOrder`) | `leverage` (module-scope singleton) |

`tempLeverage` has a watcher in `usePerpsTradeForm.ts` that copies the singleton into it whenever the singleton changes while the dialog is closed, so it drifts away from `localLeverage`. The confirm modal displayed that drifted `tempLeverage`, and `confirmAndSubmitAndSetLeverage` compared/sent it to `setLeverage`, which the backend rejected. (Screenshot math confirms it: position size = margin × 6, i.e. everything used 6× except the modal's leverage display of 20×.)

## Fix

In add mode, read `localLeverage` — the authoritative value the panel shows — in both the confirm modal binding and the confirm handler, and sync `tempLeverage` to it before `saveLeverage` so the `setLeverage` call and the singleton (order size) stay consistent. `tempLeverage` is left as the leverage dialog's scratch value only.

A deeper cleanup (collapsing the three add-mode leverage refs into one source of truth) is logged as a follow-up and left out of this QA fix.

## Testing

- `pnpm vue-tsc --noEmit -p tsconfig.app.json` → clean
- `pnpm eslint src/modules/perps/ModulePerpsTrade.vue` → clean
- Manual smoke test: **passed** — with an open position in Add mode, the confirm modal's leverage matches the panel; confirm succeeds without "leverage exceeds market maximum"; create mode unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved leverage confirmation behavior in add mode so the value shown and submitted stays in sync with the latest staged leverage.
  * Prevented stale leverage from being saved when the draft value differs from the active staged value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->