### PR TITLE
[MEW-2025] Hide disabled tokens from perps market list and trade selector

### DIFF
--- a/src/modules/perps/components/PerpsMarketList.vue
+++ b/src/modules/perps/components/PerpsMarketList.vue
@@ -795,15 +795,20 @@ const enrichedContracts = computed<EnrichedContract[]>(() => {
   for (const m of markets.value) {
     marketMap.set(m.market, m)
   }
-  return contracts.value.map(c => {
-    const pair = marketMap.get(c.market)
-    return {
-      ...c,
-      displayName: pair?.displayName ?? c.baseCurrency,
-      longName: pair?.longName ?? pair?.displayName ?? c.baseCurrency,
-      defaultLeverage: pair?.defaultLeverage ?? '',
-    }
-  })
+  // Contracts flagged `disabled` by the API must not appear in the market
+  // list (MEW-2025). Filtered here (display source) rather than at the shared
+  // `contracts` ref so an active/held disabled market still resolves elsewhere.
+  return contracts.value
+    .filter(c => !c.disabled)
+    .map(c => {
+      const pair = marketMap.get(c.market)
+      return {
+        ...c,
+        displayName: pair?.displayName ?? c.baseCurrency,
+        longName: pair?.longName ?? pair?.displayName ?? c.baseCurrency,
+        defaultLeverage: pair?.defaultLeverage ?? '',
+      }
+    })
 })
 
 const filteredContracts = computed(() => {

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -789,7 +789,10 @@ export function usePerpsTradeForm() {
   }
 
   const filteredMarketList = computed(() => {
-    let list = [...contracts.value]
+    // Hide API-disabled contracts from the trade-module market selector
+    // (MEW-2025). Filtered off the display list, not the shared `contracts`
+    // ref, so the active-market lookups (find by market) keep resolving.
+    let list = contracts.value.filter(c => !c.disabled)
     if (marketFilter.value !== 'all') {
       list = list.filter(c => getCategory(c) === marketFilter.value)
     }

--- a/tests/unit/specs/modules/perps/composables/usePerpsTradeForm.spec.ts
+++ b/tests/unit/specs/modules/perps/composables/usePerpsTradeForm.spec.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { ref, reactive } from 'vue'
+import type { Ref } from 'vue'
+import type { Contract } from '@/modules/perps/sdk/types'
 
 // ── Mocks ────────────────────────────────────────────────────
 // usePerpsTradeForm pulls in the whole perps stack (auth, markets,
@@ -62,10 +64,20 @@ vi.mock('@/modules/perps/composables/usePerpsAuth', () => ({
   usePerpsBalance: () => ({ balance: ref(null) }),
 }))
 
-vi.mock('@/modules/perps/composables/usePerpsMarkets', () => ({
-  usePerpsMarkets: () => ({ markets: ref([]), isLoading: ref(false) }),
-  usePerpsContracts: () => ({ contracts: ref([]) }),
-}))
+// A settable contracts ref so tests can drive the market list (MEW-2025).
+// The holder is hoisted (plain object, no vue); the real ref is created inside
+// the mock factory — which runs at require time, when the top-level `ref`
+// import is already initialized — so `filteredMarketList` recomputes on change.
+const mockContracts = vi.hoisted(
+  () => ({ contracts: null as unknown as Ref<Contract[]> }),
+)
+vi.mock('@/modules/perps/composables/usePerpsMarkets', () => {
+  mockContracts.contracts = ref<Contract[]>([])
+  return {
+    usePerpsMarkets: () => ({ markets: ref([]), isLoading: ref(false) }),
+    usePerpsContracts: () => ({ contracts: mockContracts.contracts }),
+  }
+})
 
 vi.mock('@/modules/perps/composables/usePerpsPositions', () => ({
   usePerpsPositions: () => ({
@@ -140,5 +152,54 @@ describe('usePerpsTradeForm — target price required (MEW-1915)', () => {
     form.orderType.value = 'limit'
     form.limitPrice.value = ''
     expect(form.submitDisabled.value).toBe(true)
+  })
+})
+
+describe('usePerpsTradeForm — hide disabled tokens (MEW-2025)', () => {
+  const makeContract = (market: string, disabled: boolean) =>
+    ({
+      market,
+      baseCurrency: market.split('-')[0],
+      quoteCurrency: 'USD',
+      disabled,
+      usdVolume: '0',
+      priceChangePercent: '0',
+      bid: '1',
+      ask: '1',
+      indexPrice: '1',
+      tags: [],
+    }) as unknown as Contract
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    walletMenuState.selectedTradeOrderSide = 'buy'
+    walletMenuState.selectedTradeManageMode = null
+    walletMenuState.selectedTradeTokenSymbol = 'AAA-USD'
+  })
+
+  afterEach(() => {
+    mockContracts.contracts.value = []
+  })
+
+  it('excludes contracts flagged disabled from the market selector list', () => {
+    mockContracts.contracts.value = [
+      makeContract('AAA-USD', false),
+      makeContract('BBB-USD', true),
+      makeContract('CCC-USD', false),
+    ]
+    const form = usePerpsTradeForm()
+    const markets = form.filteredMarketList.value.map(c => c.market)
+    expect(markets).toContain('AAA-USD')
+    expect(markets).toContain('CCC-USD')
+    expect(markets).not.toContain('BBB-USD')
+  })
+
+  it('keeps every contract when none are disabled', () => {
+    mockContracts.contracts.value = [
+      makeContract('AAA-USD', false),
+      makeContract('BBB-USD', false),
+    ]
+    const form = usePerpsTradeForm()
+    expect(form.filteredMarketList.value).toHaveLength(2)
   })
 })


### PR DESCRIPTION
## Summary

Contracts the API flags as `disabled` must not be tradable, so this hides them from the two places a user can pick a market:

- **Perps Market List** (`PerpsMarketList.vue`) — filtered in `enrichedContracts`, so disabled tokens are gone across every filter tab and search.
- **Trade module token selector** (`PerpsSelectMarketDialog.vue`, fed by `usePerpsTradeForm`'s `filteredMarketList`) — same filter on the selector's list.

## Why filter on the display lists, not the shared source

`disabled` is filtered on each display list rather than on the shared `contracts` ref (`usePerpsMarkets`). The trade form looks up the *active* market by `contracts.value.find(...)` (order size, current price, panel state); filtering at the source would make an already-selected or held market that becomes `disabled` vanish from those lookups. Filtering at the list level hides it from selection while keeping its metadata resolvable everywhere else.

`Contract.disabled` already exists in `src/modules/perps/sdk/types.ts` — no type change needed.

## Tests

- Added `usePerpsTradeForm — hide disabled tokens (MEW-2025)` to `usePerpsTradeForm.spec.ts`: asserts `filteredMarketList` excludes a `disabled` contract and keeps all when none are disabled (drove the mock's `contracts` via a settable ref). 9/9 in that spec.
- `pnpm vitest run tests/unit/specs/modules/perps` — no regression. (The 3 failures in `usePerpsAuth.spec.ts` are a pre-existing, unrelated `@enkryptcom/hw-wallets` → `@ledgerhq/hw-app-eth` module-resolution issue in the local pnpm store, present on the clean base.)
- `pnpm vue-tsc --noEmit -p tsconfig.app.json` exit 0; `pnpm eslint` clean on changed files.
- Manual smoke: market list + trade selector list/search show no disabled token; all enabled tokens still list, filter and select normally.

Sub-task of MEW-1904 (Perps QA Review 6).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled perpetual markets are now excluded from market lists and selectors.
  * Enabled markets continue to appear normally when no markets are disabled.

* **Tests**
  * Added coverage confirming disabled-market filtering and standard market-list behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->