### PR TITLE
fix: [MEW-2026] guard empty-address balance fetch and catch rejections

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -129,6 +129,11 @@ const fetchBalances = () => {
     .catch((error: unknown) => {
       if (import.meta.env.DEV) console.error('Balance fetch failed:', error)
       setIsLoadingBalances(false)
+      // Keep the retry loop alive: a transient failure shouldn't permanently
+      // stop the timer when balances are still missing from a prior load.
+      if (hasMissingBalances.value) {
+        start()
+      }
     })
 }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -99,27 +99,37 @@ const { isPending, start, stop } = useTimeoutFn(() => {
 }, 300000)
 
 const fetchBalances = () => {
+  if (!walletAddress.value) {
+    setIsLoadingBalances(false)
+    return
+  }
   setIsLoadingBalances(true)
   stop()
-  wallet.value?.getBalance().then((balances: TokenBalancesRaw) => {
-    useBalanceHandler(balances, setTokens, setIsLoadingBalances)
-    if (hasMissingBalances.value) {
-      // Refetch balances after 5 minutes if there are missing balances
-      setTimeout(() => {
-        toastStore.addToastMessage({
-          text: 'Sit tight!',
-          textSecondary:
-            "We are processing more tokens in your wallet. We'll update your balances soon.",
-          type: ToastType.Info,
-          duration: 300000,
-        })
-      }, 2000)
-      if (isPending.value) {
-        stop()
+  wallet.value
+    ?.getBalance()
+    .then((balances: TokenBalancesRaw) => {
+      useBalanceHandler(balances, setTokens, setIsLoadingBalances)
+      if (hasMissingBalances.value) {
+        // Refetch balances after 5 minutes if there are missing balances
+        setTimeout(() => {
+          toastStore.addToastMessage({
+            text: 'Sit tight!',
+            textSecondary:
+              "We are processing more tokens in your wallet. We'll update your balances soon.",
+            type: ToastType.Info,
+            duration: 300000,
+          })
+        }, 2000)
+        if (isPending.value) {
+          stop()
+        }
+        start()
       }
-      start()
-    }
-  })
+    })
+    .catch((error: unknown) => {
+      if (import.meta.env.DEV) console.error('Balance fetch failed:', error)
+      setIsLoadingBalances(false)
+    })
 }
 
 watch(

--- a/src/components/AppWalletCard.vue
+++ b/src/components/AppWalletCard.vue
@@ -203,17 +203,28 @@ const chainsStore = useChainsStore()
 const { selectedChain } = storeToRefs(chainsStore)
 
 const fetchBalances = () => {
+  if (!walletAddress.value) {
+    setIsLoadingBalances(false)
+    return
+  }
   setIsLoadingBalances(true)
-  wallet.value?.getBalance().then(balances => {
-    useBalanceHandler(balances, setTokens, setIsLoadingBalances)
-  })
+  wallet.value
+    ?.getBalance()
+    .then(balances => {
+      useBalanceHandler(balances, setTokens, setIsLoadingBalances)
+    })
+    .catch((error: unknown) => {
+      if (import.meta.env.DEV) console.error('Balance fetch failed:', error)
+      setIsLoadingBalances(false)
+    })
 }
 /**
  * Copies the wallet address to the clipboard.
  */
 const copyClick = async () => {
   try {
-    if (!walletAddress.value) throw new Error(t('common.error.no_wallet_address'))
+    if (!walletAddress.value)
+      throw new Error(t('common.error.no_wallet_address'))
     await navigator.clipboard.writeText(walletAddress.value)
     toastStore.addToastMessage({
       text: `${t('common.copied_to_clipboard')}`,
@@ -255,8 +266,11 @@ const animateMewCard = (el: HTMLElement) => {
 // composable separately requests an anonymous copy for CORS-enabled pixel
 // sampling; if mewcard.mewapi.io does not yet return CORS headers the sampler
 // fails silently and we keep the static text-shadow fallback.
-const { textColor, isDynamic: useDynamicContrast, sampleFromUrl } =
-  useImageContrastTextColor()
+const {
+  textColor,
+  isDynamic: useDynamicContrast,
+  sampleFromUrl,
+} = useImageContrastTextColor()
 
 const mewCardUrl = computed(
   () => `https://mewcard.mewapi.io/?address=${walletAddress.value ?? ''}`,

--- a/src/modules/notifications/ModuleNotifications.vue
+++ b/src/modules/notifications/ModuleNotifications.vue
@@ -248,10 +248,20 @@ const deleteAllNotifications = () => {
 }
 // Fetch balances after status changes
 const fetchBalances = () => {
+  if (!walletAddress.value) {
+    setIsLoadingBalances(false)
+    return
+  }
   setIsLoadingBalances(true)
-  wallet.value?.getBalance().then((balances: TokenBalancesRaw) => {
-    useBalanceHandler(balances, setTokens, setIsLoadingBalances)
-  })
+  wallet.value
+    ?.getBalance()
+    .then((balances: TokenBalancesRaw) => {
+      useBalanceHandler(balances, setTokens, setIsLoadingBalances)
+    })
+    .catch((error: unknown) => {
+      if (import.meta.env.DEV) console.error('Balance fetch failed:', error)
+      setIsLoadingBalances(false)
+    })
 }
 
 // Runtime state (not persisted)


### PR DESCRIPTION
## What was wrong

On the home screen, the app kept throwing a background error — `Error: Route not found. Please check the URL and try again.` — that flooded our error tracker (792 events, no visible impact to users). It happened for wallets whose active address was empty (e.g. a watch-only / injected Enkrypt wallet): the balance request was built with a missing address, the API answered "route not found", and nothing was catching that failure, so it bubbled up as an uncaught error.

## What changed

The three places that refresh wallet balances now:
1. **Skip the request entirely when there is no wallet address** (and just clear the loading spinner), so we never fire a malformed balance request.
2. **Catch any failure** from the balance request, clear the loading spinner, and log only in development — instead of letting it escape as an uncaught error. This matches the existing noise-reduction pattern used elsewhere in the app.

No user-facing behavior changes for a normal, connected wallet — balances load exactly as before.

Files: `src/App.vue`, `src/components/AppWalletCard.vue`, `src/modules/notifications/ModuleNotifications.vue`.

## How to test

1. Open the app (dev server) at the home screen.
2. Connect / view a wallet (e.g. an injected Enkrypt wallet, or add a watch-only address) and let the portfolio load.
3. Confirm balances still load normally and the balance card renders as before.
4. Confirm no `Route not found` unhandled rejection appears in the browser console / error tracker, and the loading spinner never gets stuck if a balance request fails.

## Sentry

https://myetherwallet-inc.sentry.io/issues/7482204179/ (APP-MEW-WEB-12R)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented balance loading attempts when no wallet is connected.
  * Improved loading-state handling so balance indicators clear correctly when balance retrieval fails.
  * Added resilient error handling to avoid stuck loading states after transient balance fetch issues.
  * Continued the existing balance-refresh flow when balances are unavailable, ensuring notifications remain consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->