### PR TITLE
fix: [MEW-1726] hide withdraw MAX button when user has open positions

### DIFF
--- a/src/modules/perps/components/PerpsWithdrawDialog.vue
+++ b/src/modules/perps/components/PerpsWithdrawDialog.vue
@@ -31,7 +31,7 @@
 
                   <div class="flex justify-start justify-between mt-3">
                     <button
-                      v-if="hasOpenPositions"
+                      v-if="!hasOpenPositions"
                       class="px-3 sm:px-4 py-1 text-s-9 sm:text-s-11 leading-p-120 font-semibold bg-white hoverBGWhite rounded-full transition-all duration-150 shadow-button shadow-button-elevated"
                       @click="setMax"
                     >


### PR DESCRIPTION
## What changed
The **MAX** button in the Withdraw USDC dialog is now hidden while the user has open positions. It only shows when the account has no open positions.

## Why
With open positions, PnL fluctuations make the MAX-clicked amount drift, so the withdraw request is built against a moving target. This produced inconsistent responses reported in MEW-1726:
- Insufficient-balance error message
- The **Withdraw** button flashing between active and inactive
- The **Withdraw** button becoming unresponsive

Hiding MAX when positions are open removes the moving-target amount and forces a deliberate manual entry.

## Behavior
- **No open positions:** MAX button shown, fills the withdrawable amount (unchanged behavior).
- **Open positions:** MAX button hidden; the user enters the withdrawal amount manually.

## How to test
1. Open **Withdraw USDC** with **no** open positions → the **MAX** button is visible and fills the withdrawable amount.
2. Open a position, then open **Withdraw USDC** → the **MAX** button is **not** shown.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the visibility of the “MAX” button in the withdrawal dialog.
  * The button now appears only when there are no open positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->