### PR TITLE
Feat/v7 250 rewards

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,4 +51,21 @@ jobs:
         run: |
           VERSION=$(node -p "require('./package.json').version")
           TAG="v$VERSION"
-          gh release edit "$TAG" --draft=false
+
+          if gh release view "$TAG" > /dev/null 2>&1; then
+            # A draft already exists (PR came through feat/v7-develop) — publish it.
+            gh release edit "$TAG" --draft=false
+          else
+            # PR was merged directly into feat/v7 from another branch — usually a
+            # hotfix. No draft was ever created, so draft one with generated notes.
+            gh api repos/${{ github.repository }}/releases/generate-notes \
+              -f tag_name="$TAG" \
+              -f target_commitish="feat/v7" \
+              --jq .body > release-notes.md
+
+            gh release create "$TAG" \
+              --draft \
+              --target feat/v7 \
+              --notes-file release-notes.md \
+              --title "$TAG"
+          fi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "myetherwallet",
-  "version": "7.0.9",
+  "version": "7.0.9-hotfix.1",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/modules/rewards/RewardsLearnMore.vue
+++ b/src/modules/rewards/RewardsLearnMore.vue
@@ -177,11 +177,15 @@ const infoItems = computed(() => [
   },
   {
     icon: 'calendar',
-    text: 'Up to one reward per wallet per 7 day campaign period, sent directly to your wallet',
+    text: 'Up to one reward per wallet per 7 day campaign period, sent directly to your wallet.',
   },
   {
     icon: 'wallet-icon',
     text: 'The wallet must be at least 2 weeks old (relative to the current date) and hold a minimum balance of 0.001 ETH.',
+  },
+  {
+    icon: 'currency-dollar-gray',
+    text: 'Cash out transactions do not qualify.',
   },
   {
     icon: 'face-frown',

--- a/src/modules/rewards/RewardsLearnMore.vue
+++ b/src/modules/rewards/RewardsLearnMore.vue
@@ -181,7 +181,7 @@ const infoItems = computed(() => [
   },
   {
     icon: 'wallet-icon',
-    text: 'The wallet must be at least 2 weeks old (relative to the current date) and hold a minimum balance of 0.001 ETH.',
+    text: 'The wallet must be at least 3 weeks old (relative to the current date) and hold a minimum balance of 0.005 ETH.',
   },
   {
     icon: 'currency-dollar-gray',

--- a/src/modules/trade/composables/useTradeExecution.ts
+++ b/src/modules/trade/composables/useTradeExecution.ts
@@ -98,8 +98,8 @@ export function useTradeExecution(options: UseTradeExecutionOptions) {
       holdCampaignStatus: holdingsStore.status,
       qualifyingTradeAmount: reward?.qualifying_amount
         ? new BigNumber(reward.qualifying_amount)
-            .shiftedBy(-decimals)
-            .toString()
+          .shiftedBy(-decimals)
+          .toString()
         : undefined,
       qualifyingTradeToken: meta?.symbol,
       qualifiedSince: reward?.qualification_timestamp,
@@ -230,7 +230,7 @@ export function useTradeExecution(options: UseTradeExecutionOptions) {
       let canEarnReward: undefined | boolean = undefined
       const fromUsdValue =
         parseFloat(fromAmount.value) * (fromTokenSelected.value?.price || 0)
-      if (fromUsdValue > 100) {
+      if (fromUsdValue > 250) {
         const canEarn = await rewardsStore.checkAvailabilityAfterTransaction('trade')
         canEarnReward = canEarn ? true : undefined
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated trade reward eligibility so qualifying trades must exceed **$250** in value.
  * Refreshed rewards eligibility details shown in the learn-more dialog (updated wallet age/balance requirements and clarified that cash-out transactions do not qualify).

* **Release Updates**
  * Bumped the package version to **7.0.9-hotfix.1**.
  * Improved automated release publishing to handle tag existence more reliably and generate draft releases with notes when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->