### PR TITLE
fix: [MEW-1919] truncate submit button label to prevent panel overflow

### DIFF
--- a/src/modules/perps/ModulePerpsTrade.vue
+++ b/src/modules/perps/ModulePerpsTrade.vue
@@ -691,18 +691,18 @@
           :disabled="submitDisabled"
           @click="showConfirmation"
           :theme="orderSide === 'buy' ? 'success' : 'error'"
-          class="w-full mt-4"
+          class="w-full mt-4 min-w-0"
         >
-          {{ getMainBtnText }}
+          <span class="block truncate">{{ getMainBtnText }}</span>
         </app-base-button>
         <app-base-button
           v-if="activePosition && manageMode === 'close'"
           :theme="orderSide === 'buy' ? 'success' : 'error'"
           :disabled="closeDisabled"
           @click="showCloseConfirmation"
-          class="w-full mt-4"
+          class="w-full mt-4 min-w-0"
         >
-          {{ closeButtonLabel }}
+          <span class="block truncate">{{ closeButtonLabel }}</span>
         </app-base-button>
       </template>
     </div>


### PR DESCRIPTION
## Summary

Follow-up to #5594. That PR truncated the "Size" readout so it no longer overflowed the perps trade panel, but the **submit button** still overflowed: its label can contain a user-controlled formatted USD amount (e.g. `Not enough margin $999,999,999,999.00` from `usePerpsTradeForm`'s `submitButtonLabel`). A large amount is a single unbreakable token, and because the button is a `w-full` flex child with the default `min-width: auto`, its min-content forced the ~375px side panel wider — producing a horizontal scrollbar and breaking the layout.

## Change

`src/modules/perps/ModulePerpsTrade.vue` — for both full-width action buttons (open/add and close):
- Wrap the label in `<span class="block truncate">` so a long label clips with an ellipsis instead of forcing width (same `truncate` pattern used in #5594 for the Size line).
- Add `min-w-0` to the button so the flex child can shrink to the panel width.

Normal labels ("Long BTC", "Short ETH", "Close BTC Long", …) render unchanged and centered. Purely presentational, so no unit test is added.

## Testing

- `pnpm eslint src/modules/perps/ModulePerpsTrade.vue` → clean
- `pnpm vue-tsc --noEmit -p tsconfig.app.json` → clean
- `pnpm vitest run src/modules/perps/composables/tests/usePerpsActive.spec.ts` → 6/6
- Manual smoke test: entering a very large margin amount now clips the button label with an ellipsis inside the panel — no horizontal scroll; normal values render unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved submit and close action buttons to handle long labels more gracefully.
  * Labels now truncate cleanly to prevent overflow and preserve the surrounding layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->