### PR TITLE
feat: [MEW-2023] GEO / AI-SEO foundation for the v7 app

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,42 +71,338 @@
         "mainEntity": [
           {
             "@type": "Question",
-            "name": "Is MyEtherWallet free?",
+            "name": "What is cryptocurrency?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "Yes. MyEtherWallet is free and open-source. Network (gas) fees and third-party service fees may apply to transactions."
+              "text": "Cryptocurrency is a digital currency that allows users to make payments and exchanges of value without the need for bank accounts or national currencies (aka fiat). Payments with decentralized cryptocurrency are not restricted by geographic location and do not require any personal information from the user."
             }
           },
           {
             "@type": "Question",
-            "name": "Does MyEtherWallet hold my funds or keys?",
+            "name": "What is a blockchain?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "No. MEW is a self-custody, client-side wallet. Your private keys never leave your device and MEW never has access to your funds."
+              "text": "The blockchain is a digital ledger for keeping track of cryptocurrency transactions. Think: an excel sheet that is protected by advanced cryptographic encryption, making sure that nobody can cheat by double-spending and nobody can hack the blockchain record. Data that is added to the blockchain can never be changed or erased. Your crypto assets live on the blockchain, and you manage them using a crypto wallet."
             }
           },
           {
             "@type": "Question",
-            "name": "Which wallets and devices does MEW support?",
+            "name": "Who invented crypto?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "MEW supports hardware wallets (Ledger, Trezor), the MEW mobile app, the Enkrypt browser extension, and WalletConnect."
+              "text": "Cryptographic encryption has been around since ancient times. The idea of using cryptography with electronic payments dates back to at least the 1980s. The first fully implemented cryptocurrency Bitcoin was created in 2008 by a developer, or group of developers, working under the name of Satoshi Nakamoto. The technology was open-source and available to anyone who wanted to build tools for Bitcoin or any other blockchain network. To this day, the identity of Satoshi Nakamoto remains unknown."
             }
           },
           {
             "@type": "Question",
-            "name": "What can I do with MyEtherWallet?",
+            "name": "Why are there so many different cryptocurrencies and blockchains?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "You can send and receive crypto, swap tokens, buy and sell crypto, stake, trade perpetuals, and access tokenized stocks."
+              "text": "Bitcoin was the first cryptocurrency and it’s still going strong. After Bitcoin went live and proved that crypto could work, it was only a matter of time before other developers introduced new ideas and launched new crypto networks. The most significant crypto innovation after Bitcoin was Ethereum. It was the first blockchain to have smart contracts, allowing projects to build applications and create tokens on the blockchain, opening the door to infinite crypto variety."
             }
           },
           {
             "@type": "Question",
-            "name": "Is MyEtherWallet safe?",
+            "name": "What is a crypto wallet?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "MEW is open-source and client-side, so you retain control of your keys. Always verify you are on the correct URL and never share your private key or recovery phrase."
+              "text": "A crypto wallet is a piece of software that helps you interact with cryptocurrency blockchains directly. A wallet can be a mobile app, a Chrome extension, a web application, or a hardware device with programming inside. Wallets help you buy, hold, receive, send, swap, trade, stake, lend, borrow, and sell crypto. Hundreds, if not thousands, of crypto wallets exist, but they differ widely in terms of their features and the security they provide."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Why do I need a crypto wallet?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "You need to have a crypto wallet to interact with blockchains directly. Why is that important? Even though you can get cryptocurrency through familiar apps like Venmo, Paypal, or Robinhood, you don’t really own that crypto. These companies are centralized, like regular banks. They are the ones that hold and control your assets. A self custody crypto wallet is the only thing that gives you full control over your crypto, so you can take advantage of everything the space has to offer."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What is the difference between a crypto wallet and a cryptocurrency exchange?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Most cryptocurrency exchanges are centralized and custodial. They hold your crypto assets and manage your accounts, while your account balance is essentially an IOU. Self-custody crypto wallets give you and only you complete ownership of your crypto. With a crypto wallet, nobody can freeze your account, use your assets without your knowledge, or prevent you from moving your coins when you want."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What is the best crypto wallet for me?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Different types of wallets can serve different purposes, so a lot of crypto users have more than one. The best wallet for you also depends on how you like to manage your assets (on desktop or on mobile), and on your personal crypto goals. For a crypto beginner, the easiest option is probably a mobile wallet that is quick and easy to set up."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Which crypto wallets are secure?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "When choosing a crypto wallet, you should consider several things: Has the wallet been around for a while and established a reputation for reliability? Is it a self-custody wallet? Is it open-source? Does it have an active security program or bug bounty? You want to make sure that nobody else has access to your crypto, and that even if your wallet company stops support or disappears, it will never affect your assets."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "How to create a crypto wallet?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "A good self custody wallet app or extension will guide you through several easy steps to generate your crypto account. The most important part is when you get your wallet keys in the form of a 12- or 24-word recovery phrase. After you write down your phrase in a safe place, you are ready to get started – buy, receive, and send crypto. The whole process should take about 5 minutes, and you don’t need to fill out any forms or give any personal information."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "How to find the crypto wallet address?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Your wallet address looks like a long series of letters and numbers, with some variation depending on the blockchain. Ethereum addresses all start with 0x and have 42 characters. Usually, you will see the wallet address on top of your wallet interface. To receive crypto, you can copy your address to the clipboard or open a QR code that someone else can scan. Some wallets, like MEW and Enkrypt, support multiple addresses on different blockchains, all backed up by the same key/recovery phrase."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "How to check the crypto wallet balance?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "The balance you will see in your self custody crypto wallet directly reflects the current state of the blockchain. Unlike accounts on centralized crypto exchanges, self custody wallet balances can’t be accessed or manipulated by the wallet team. If you can’t see the balance in the wallet or you think there is an error, you can always check your blockchain balance directly by using a blockchain explorer."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "How to buy crypto?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "With a good crypto wallet, you don’t need a centralized exchange or a separate account to buy crypto. Onboarding providers like Simplex, MoonPay, and Coinbase are available right inside MEW wallet app and Enkrypt. Once you’ve created your wallet, find the Buy button, review the options available to you, and use your card or bank account to purchase. Easy."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "How to keep crypto safe?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "The main aspect of keeping your crypto safe is how you store your keys, in the form of the recovery phrase. The phrase gives direct and immediate access to your wallet, so you need to make sure that it’s stored offline, that no one has ever seen it except you, and that you never type it into a website, message, or email. Start by getting a secure wallet, handle your wallet keys with care, and keep your crypto safe by following best security practices."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Can a crypto wallet be hacked?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "The cryptographic encryption involved in generating wallet keys is extremely powerful and would take a huge amount of computer resources to crack. When crypto gets stolen from wallets, it’s not because it was hacked, but because the wallet key/recovery phrase was inadvertently exposed to someone other than the owner. There are many ways this can happen – storing your keys on the computer or in the cloud, typing your phrase directly on a website, or having someone else set up the wallet for you, to name a few."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What are NFTs?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "NFTs are unique crypto tokens that prove ownership of a specific digital asset, like a certificate of authenticity for a piece of art or the title to a car. NFTs can represent images, audio or video files, collectibles, virtual real estate, fractional investments, video game objects, and much more."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "How to buy NFTs?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "There are many NFT marketplaces that offer NFTs in wide price ranges. The most popular markets are OpenSea, Rarible, and SuperRare, but there are dozens of others. Once you’ve created a wallet, you can connect to any NFT marketplace with your mobile wallet browser or your browser extension wallet, and buy your first NFT. Or, mint a free MEW Universe NFT in MEW wallet by collecting Energy."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "How to stake crypto?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Crypto staking is the simplest and most low risk way to earn rewards on crypto while staying in full control of the assets. To stake crypto, a users deposits a desired amount of the coins into a smart contract on the blockchain. The staked crypto helps maintain the operation of the network, and in return earns a percentage of newly created crypto tokens every time a new block is added to the chain. In a good crypto wallet, staking is as simple as selecting the desired amount and confirming the transaction."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "How to exchange crypto?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Exchanging or swapping your crypto for other tokens is easy when there are integrated providers right in the wallet. To start with, you should have some crypto in your wallet (ETH is the most practical as a starter currency). Then, it’s just a matter of going to the Swap section, selecting which token you are exchanging, and which token you’d like to receive in return. The wallet calculates everything for you and shows you the anticipated result of the swap."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "How to exchange crypto for cash?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Just as you can use a credit card or bank account to buy crypto for fiat (regular money), you can also cash out from crypto by exchanging your tokens for fiat and then depositing into your bank. You can do both – buy and sell crypto – directly from your crypto wallet via integrated onboarding partners. In MEW wallet and Enkrypt this service is provided by MoonPay. There are also more ways to protect your crypto gains than just cashing out."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What are tokenized stocks?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Tokenized stocks are digital tokens that represent real company shares or stocks (like Apple, Tesla, Nvidia) and ETFs (exchange traded funds that are like baskets of different stocks). Unlike regular stocks, these tokens live on the blockchain and can be held, managed, and traded directly in your MyEtherWallet (MEW) like all your crypto. Instead of having to use a traditional broker, you get stock market exposure right in your crypto wallet. The token tracks the economic value of the stock – both the price and the dividends if the stock pays them. Even better, tokenized stocks can be traded 24/5 outside regular market hours, can be held by users anywhere in the world, and can be used in DeFi like other crypto tokens."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "How do tokenized stocks work?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "MEW offers tokenized stock by Ondo Global Markets. All Ondo tokenized stocks are backed by real assets held in secure custody. Ondo holds the matching share or ETF for all of the tokens it issues, and always has more assets than needed to cover the holdings of users (this is called “overcollateralization”). When a user buys a token, a new one is created and the underlying stock is acquired by Ondo. When you sell a token, the underlying stock is sold and the token is burned. This means you get the same market availability (liquidity) as if you traded on the stock market directly."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "How to trade tokenized stocks?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Stock trades in MEW are done through third party providers like 1InchFusion, designed especially to work with stocks. They automatically find and execute the best available option for you. Simply swap between crypto and stocks right in your wallet. Trade crypto for stocks, stocks for crypto, stocks for other stocks, and cash out stocks to stablecoins. You can’t do that with a brokerage."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Is it safe to hold tokenized stock in MEW?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "You hold tokenized stock in your own wallet, just like you hold ETH and other crypto. MEW is a self-custody wallet, so you have full control of your crypto and stocks at all times. MEW can’t access or move your assets, or prevent you from moving them. If you keep your recovery phrase safe, you can always restore your wallet in MEW or any other crypto wallet app. Your crypto and stocks will be there waiting for you, safe and sound. Ondo tokenized stocks are always backed by real world assets, secured by Ondo’s custodian partners, and triple-checked by independent auditors, so you can be sure that your tokens represent real stock value and reflect true market events. For more information, see: https://docs.ondo.finance/ondo-global-markets/overview."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Who can get tokenized stocks in MEW?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Most users outside of the United States can trade tokenized stocks. In addition to the US, the following places are not eligible for stock trading due to specific local regulations: Afghanistan, Belarus, Canada, Crimea, Donetsk People’s Republic (DNR), Luhansk People’s Republic (LNR), Kherson and Zaporizhzhia regions (Ukraine), the city of Sevastopol, Cuba, Democratic Republic of Korea, Iran, Libya, Myanmar, Russia, Somalia, South Sudan, Sudan, Syria. For more information, see: https://docs.ondo.finance/ondo-global-markets/eligibility."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Where can I learn more about tokenized stocks?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "MEW offers tokenized stock by Ondo Global Markets. You can learn more about how these assets work here: https://docs.ondo.finance/ondo-global-markets."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What is crypto staking?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Crypto staking is the process of depositing a cryptocurrency like ETH onto the blockchain for the purpose of supporting decentralized network operations and receiving crypto rewards in return. Think of it as an APY-earning deposit where your assets always stay under your control while providing a public good."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What are crypto staking rewards?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "When you stake ETH, you are helping the Ethereum blockchain run smoothly and stay decentralized. In return, you get a portion of the transaction fees and of the new ETH created with every block. These rewards are not generated by lending your ETH out or using it in investment schemes, as banks do with customers’ deposits. The staking rewards come from the technical work of the blockchain itself."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "How much ETH do I need to stake on Ethereum?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "There is no minimum ETH to stake. You can choose to stake a full validator, which requires 32 ETH but also provides the highest rate of rewards, or a very small amount of ETH and still begin seeing the rewards accumulate almost immediately."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "How do I stake ETH?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "ETH is staked by depositing it to a contract on the blockchain, where it stays until you decide to withdraw it. In some cases, like with full validator staking, the ETH is locked until you withdraw, and in others, you get liquid tokens for your ETH that can be spent in other web3 applications. Staking takes just a few steps when you do it through MEW – no advanced expertise required."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "How do I receive my staking rewards?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "After you stake ETH, your staking rewards begin to accumulate automatically and are distributed directly to the wallet from which you staked, at regular intervals. The timing of rewards distribution depends on the specific staking provider, but no extra effort is required – it all happens right in your wallet."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What are the benefits of crypto staking?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Staking is a low effort and low risk way to earn passive rewards on crypto. It is much simpler than most operations with decentralized finance, doesn’t require any upkeep, and leaves you with full control of the assets even as they are earning rewards. Best of all, staking provides a public good and gives you a literal stake in the cryptocurrency space."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "How does staking help the blockchain?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Cryptocurrencies are decentralized, so there is no single source of authority for verifying transactions. Instead, users from all over the world pledge their ETH to Ethereum by staking and creating validators. These validators run software that checks and compares transaction history, so they can agree on one ‘truth’ that gets added to the blockchain. The more ETH is staked, the more validators exist, and the less chance that a group of bad actors can take over control of the blockchain and cheat by adding a ‘lie’ – or a fraudulent transaction – into the ledger."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What are the risks of crypto staking?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Any interaction with an evolving technology like the blockchain inherently involves risk. Very rarely, validators can incur penalties (known as slashing), and there can be delays in rewards distribution or staking withdrawals. As always, never risk more than you are prepared to lose."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What is partial staking?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Partial staking is staking without a minimum, where the provider collects the smaller stakes and maintains a validator structure. It’s called ‘partial’ because it does not require the full validator amount of 32 ETH. Partial ETH staking in MEW is powered by Coinbase."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What is liquid staking?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Liquid staking issues liquid tokens in place of the staked ETH so that the staker can benefit from the use of the ETH even while it is staked. Liquid staking derivatives (LSDs) can be used in various decentralized financial applications for lending, restaking, and more. Liquid ETH staking in MEW is provided by Lido."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "How do I withdraw staked ETH?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "You can withdraw your staking rewards and your full stake at any time. Depending on the staking provider, you may need to submit a request to withdraw and wait for the ETH to become available in your wallet, but there is no lock-up period with any provider in MEW."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "When does the crypto market open and close?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Cryptocurrency blockchains, self custody wallets, and decentralized exchanges never close – they are accessible 24/7. There are no weekends, holidays, or hours of operation. If you want to move your assets at 3 AM on Christmas Day, you can do so immediately, without waiting for anything to open or for the transaction to be approved."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Why do they call NFTs ‘overpriced jpegs’?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "NFTs can be created as any form of media, but so far most of them have been images. There is a misconception that owning the actual NFT is the same as copy-pasting the image of the NFT, as you would with a JPEG file, in which case it’s absurd to pay for it. In fact, the digital scarcity and uniqueness of crypto tokens is the reason why crypto works in the first place. There are ways to prove that the NFT token you own is original and unique, rather than a copy of a copy."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Is crypto bad for the environment?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "The design of Bitcoin and some other cryptocurrencies, called Proof of Work, requires mining. Mining is the constant computational work done by thousands of computers worldwide to support the blockchain, using a lot of energy. That’s why some critics say that crypto is unsustainable. However, most crypto, including Ethereum, uses a different mechanism called Proof of Stake, which uses 99.99% less energy and poses no risk to the environment."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What is HODLing?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "The expression HODL originated as a misspelling of the word ‘hold’ in a social media post by an early Bitcoin investor. Later, HODL became associated with the acronym ‘hold on for deal life’. It communicates the sentiment that if you believe in a cryptocurrency’s long term potential and remain calm in the face of market volatility, you will always hold the crypto as opposed to panic selling."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What does ‘not your keys, not your crypto’ mean?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "There are many different ways to hold crypto, but not all of them give you full control and true ownership of your crypto assets. When you use a self custody wallet, you get your wallet keys (in the form of a recovery phrase) which give you direct access and ownership. When you use a centralized exchange, you don’t get wallet keys because the exchange actually manages the assets. No keys – no real ownership of crypto."
             }
           }
         ]

--- a/index.html
+++ b/index.html
@@ -12,7 +12,8 @@
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="MyEtherWallet.com: Your Key to Ethereum" />
   <meta property="og:image" content="https://www.myetherwallet.com/icons/icon192.png" />
-  <meta property="og:url" content="https://www.myetherwallet.com" />
+  <meta property="og:url" content="https://app.myetherwallet.com/" />
+  <link rel="canonical" href="https://app.myetherwallet.com/" />
   <meta property="og:description"
     content="Free, open-source, client-side Ethereum wallet. Enabling you to interact with the blockchain easily & securely." />
   <meta name="twitter:title" content="MyEtherWallet.com: Your Key to Ethereum" />
@@ -51,6 +52,63 @@
           "https://medium.com/myetherwallet",
           "https://help.myetherwallet.com/en/",
           "https://github.com/MyEtherWallet"
+        ]
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        "name": "MyEtherWallet",
+        "url": "https://app.myetherwallet.com/",
+        "description": "Free, open-source, client-side Ethereum wallet: send, swap, stake, buy and sell crypto, trade perpetuals, and access tokenized stocks."
+      }
+    </script>
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "Is MyEtherWallet free?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes. MyEtherWallet is free and open-source. Network (gas) fees and third-party service fees may apply to transactions."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Does MyEtherWallet hold my funds or keys?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "No. MEW is a self-custody, client-side wallet. Your private keys never leave your device and MEW never has access to your funds."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Which wallets and devices does MEW support?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "MEW supports hardware wallets (Ledger, Trezor), the MEW mobile app, the Enkrypt browser extension, and WalletConnect."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What can I do with MyEtherWallet?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "You can send and receive crypto, swap tokens, buy and sell crypto, stake, trade perpetuals, and access tokenized stocks."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Is MyEtherWallet safe?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "MEW is open-source and client-side, so you retain control of your keys. Always verify you are on the correct URL and never share your private key or recovery phrase."
+            }
+          }
         ]
       }
     </script>

--- a/public/.well-known/ai.txt
+++ b/public/.well-known/ai.txt
@@ -1,0 +1,8 @@
+# ai.txt — AI usage policy for app.myetherwallet.com
+# MyEtherWallet welcomes AI/LLM crawlers and citation.
+
+User-Agent: *
+Allow: *
+Citation: preferred
+Attribution-URL: https://www.myetherwallet.com/
+Contact: support@myetherwallet.com

--- a/public/.well-known/ai.txt
+++ b/public/.well-known/ai.txt
@@ -4,5 +4,5 @@
 User-Agent: *
 Allow: *
 Citation: preferred
-Attribution-URL: https://www.myetherwallet.com/
+Attribution-URL: https://app.myetherwallet.com/
 Contact: support@myetherwallet.com

--- a/public/ai/faq.json
+++ b/public/ai/faq.json
@@ -1,24 +1,214 @@
 {
   "faqs": [
     {
-      "question": "Is MyEtherWallet free?",
-      "answer": "Yes. MyEtherWallet is free and open-source. Network (gas) fees and third-party service fees may apply to transactions."
+      "category": "Crypto 101",
+      "question": "What is cryptocurrency?",
+      "answer": "Cryptocurrency is a digital currency that allows users to make payments and exchanges of value without the need for bank accounts or national currencies (aka fiat). Payments with decentralized cryptocurrency are not restricted by geographic location and do not require any personal information from the user."
     },
     {
-      "question": "Does MyEtherWallet hold my funds or keys?",
-      "answer": "No. MEW is a self-custody, client-side wallet. Your private keys never leave your device and MEW never has access to your funds."
+      "category": "Crypto 101",
+      "question": "What is a blockchain?",
+      "answer": "The blockchain is a digital ledger for keeping track of cryptocurrency transactions. Think: an excel sheet that is protected by advanced cryptographic encryption, making sure that nobody can cheat by double-spending and nobody can hack the blockchain record. Data that is added to the blockchain can never be changed or erased. Your crypto assets live on the blockchain, and you manage them using a crypto wallet."
     },
     {
-      "question": "Which wallets and devices does MEW support?",
-      "answer": "MEW supports hardware wallets (Ledger, Trezor), the MEW mobile app, the Enkrypt browser extension, and WalletConnect."
+      "category": "Crypto 101",
+      "question": "Who invented crypto?",
+      "answer": "Cryptographic encryption has been around since ancient times. The idea of using cryptography with electronic payments dates back to at least the 1980s. The first fully implemented cryptocurrency Bitcoin was created in 2008 by a developer, or group of developers, working under the name of Satoshi Nakamoto. The technology was open-source and available to anyone who wanted to build tools for Bitcoin or any other blockchain network. To this day, the identity of Satoshi Nakamoto remains unknown."
     },
     {
-      "question": "What can I do with MyEtherWallet?",
-      "answer": "You can send and receive crypto, swap tokens, buy and sell crypto, stake, trade perpetuals, and access tokenized stocks."
+      "category": "Crypto 101",
+      "question": "Why are there so many different cryptocurrencies and blockchains?",
+      "answer": "Bitcoin was the first cryptocurrency and it’s still going strong. After Bitcoin went live and proved that crypto could work, it was only a matter of time before other developers introduced new ideas and launched new crypto networks. The most significant crypto innovation after Bitcoin was Ethereum. It was the first blockchain to have smart contracts, allowing projects to build applications and create tokens on the blockchain, opening the door to infinite crypto variety."
     },
     {
-      "question": "Is MyEtherWallet safe?",
-      "answer": "MEW is open-source and client-side, so you retain control of your keys. Always verify you are on the correct URL and never share your private key or recovery phrase."
+      "category": "Crypto Wallet Basics",
+      "question": "What is a crypto wallet?",
+      "answer": "A crypto wallet is a piece of software that helps you interact with cryptocurrency blockchains directly. A wallet can be a mobile app, a Chrome extension, a web application, or a hardware device with programming inside. Wallets help you buy, hold, receive, send, swap, trade, stake, lend, borrow, and sell crypto. Hundreds, if not thousands, of crypto wallets exist, but they differ widely in terms of their features and the security they provide."
+    },
+    {
+      "category": "Crypto Wallet Basics",
+      "question": "Why do I need a crypto wallet?",
+      "answer": "You need to have a crypto wallet to interact with blockchains directly. Why is that important? Even though you can get cryptocurrency through familiar apps like Venmo, Paypal, or Robinhood, you don’t really own that crypto. These companies are centralized, like regular banks. They are the ones that hold and control your assets. A self custody crypto wallet is the only thing that gives you full control over your crypto, so you can take advantage of everything the space has to offer."
+    },
+    {
+      "category": "Crypto Wallet Basics",
+      "question": "What is the difference between a crypto wallet and a cryptocurrency exchange?",
+      "answer": "Most cryptocurrency exchanges are centralized and custodial. They hold your crypto assets and manage your accounts, while your account balance is essentially an IOU. Self-custody crypto wallets give you and only you complete ownership of your crypto. With a crypto wallet, nobody can freeze your account, use your assets without your knowledge, or prevent you from moving your coins when you want."
+    },
+    {
+      "category": "Crypto Wallet Basics",
+      "question": "What is the best crypto wallet for me?",
+      "answer": "Different types of wallets can serve different purposes, so a lot of crypto users have more than one. The best wallet for you also depends on how you like to manage your assets (on desktop or on mobile), and on your personal crypto goals. For a crypto beginner, the easiest option is probably a mobile wallet that is quick and easy to set up."
+    },
+    {
+      "category": "Crypto Wallet Basics",
+      "question": "Which crypto wallets are secure?",
+      "answer": "When choosing a crypto wallet, you should consider several things: Has the wallet been around for a while and established a reputation for reliability? Is it a self-custody wallet? Is it open-source? Does it have an active security program or bug bounty? You want to make sure that nobody else has access to your crypto, and that even if your wallet company stops support or disappears, it will never affect your assets."
+    },
+    {
+      "category": "Crypto Wallet Basics",
+      "question": "How to create a crypto wallet?",
+      "answer": "A good self custody wallet app or extension will guide you through several easy steps to generate your crypto account. The most important part is when you get your wallet keys in the form of a 12- or 24-word recovery phrase. After you write down your phrase in a safe place, you are ready to get started – buy, receive, and send crypto. The whole process should take about 5 minutes, and you don’t need to fill out any forms or give any personal information."
+    },
+    {
+      "category": "Crypto Wallet Basics",
+      "question": "How to find the crypto wallet address?",
+      "answer": "Your wallet address looks like a long series of letters and numbers, with some variation depending on the blockchain. Ethereum addresses all start with 0x and have 42 characters. Usually, you will see the wallet address on top of your wallet interface. To receive crypto, you can copy your address to the clipboard or open a QR code that someone else can scan. Some wallets, like MEW and Enkrypt, support multiple addresses on different blockchains, all backed up by the same key/recovery phrase."
+    },
+    {
+      "category": "Crypto Wallet Basics",
+      "question": "How to check the crypto wallet balance?",
+      "answer": "The balance you will see in your self custody crypto wallet directly reflects the current state of the blockchain. Unlike accounts on centralized crypto exchanges, self custody wallet balances can’t be accessed or manipulated by the wallet team. If you can’t see the balance in the wallet or you think there is an error, you can always check your blockchain balance directly by using a blockchain explorer."
+    },
+    {
+      "category": "Crypto Wallet Basics",
+      "question": "How to buy crypto?",
+      "answer": "With a good crypto wallet, you don’t need a centralized exchange or a separate account to buy crypto. Onboarding providers like Simplex, MoonPay, and Coinbase are available right inside MEW wallet app and Enkrypt. Once you’ve created your wallet, find the Buy button, review the options available to you, and use your card or bank account to purchase. Easy."
+    },
+    {
+      "category": "Crypto Wallet Basics",
+      "question": "How to keep crypto safe?",
+      "answer": "The main aspect of keeping your crypto safe is how you store your keys, in the form of the recovery phrase. The phrase gives direct and immediate access to your wallet, so you need to make sure that it’s stored offline, that no one has ever seen it except you, and that you never type it into a website, message, or email. Start by getting a secure wallet, handle your wallet keys with care, and keep your crypto safe by following best security practices."
+    },
+    {
+      "category": "Crypto Wallet Basics",
+      "question": "Can a crypto wallet be hacked?",
+      "answer": "The cryptographic encryption involved in generating wallet keys is extremely powerful and would take a huge amount of computer resources to crack. When crypto gets stolen from wallets, it’s not because it was hacked, but because the wallet key/recovery phrase was inadvertently exposed to someone other than the owner. There are many ways this can happen – storing your keys on the computer or in the cloud, typing your phrase directly on a website, or having someone else set up the wallet for you, to name a few."
+    },
+    {
+      "category": "Use Your Crypto",
+      "question": "What are NFTs?",
+      "answer": "NFTs are unique crypto tokens that prove ownership of a specific digital asset, like a certificate of authenticity for a piece of art or the title to a car. NFTs can represent images, audio or video files, collectibles, virtual real estate, fractional investments, video game objects, and much more."
+    },
+    {
+      "category": "Use Your Crypto",
+      "question": "How to buy NFTs?",
+      "answer": "There are many NFT marketplaces that offer NFTs in wide price ranges. The most popular markets are OpenSea, Rarible, and SuperRare, but there are dozens of others. Once you’ve created a wallet, you can connect to any NFT marketplace with your mobile wallet browser or your browser extension wallet, and buy your first NFT. Or, mint a free MEW Universe NFT in MEW wallet by collecting Energy."
+    },
+    {
+      "category": "Use Your Crypto",
+      "question": "How to stake crypto?",
+      "answer": "Crypto staking is the simplest and most low risk way to earn rewards on crypto while staying in full control of the assets. To stake crypto, a users deposits a desired amount of the coins into a smart contract on the blockchain. The staked crypto helps maintain the operation of the network, and in return earns a percentage of newly created crypto tokens every time a new block is added to the chain. In a good crypto wallet, staking is as simple as selecting the desired amount and confirming the transaction."
+    },
+    {
+      "category": "Use Your Crypto",
+      "question": "How to exchange crypto?",
+      "answer": "Exchanging or swapping your crypto for other tokens is easy when there are integrated providers right in the wallet. To start with, you should have some crypto in your wallet (ETH is the most practical as a starter currency). Then, it’s just a matter of going to the Swap section, selecting which token you are exchanging, and which token you’d like to receive in return. The wallet calculates everything for you and shows you the anticipated result of the swap."
+    },
+    {
+      "category": "Use Your Crypto",
+      "question": "How to exchange crypto for cash?",
+      "answer": "Just as you can use a credit card or bank account to buy crypto for fiat (regular money), you can also cash out from crypto by exchanging your tokens for fiat and then depositing into your bank. You can do both – buy and sell crypto – directly from your crypto wallet via integrated onboarding partners. In MEW wallet and Enkrypt this service is provided by MoonPay. There are also more ways to protect your crypto gains than just cashing out."
+    },
+    {
+      "category": "Tokenized Stocks",
+      "question": "What are tokenized stocks?",
+      "answer": "Tokenized stocks are digital tokens that represent real company shares or stocks (like Apple, Tesla, Nvidia) and ETFs (exchange traded funds that are like baskets of different stocks). Unlike regular stocks, these tokens live on the blockchain and can be held, managed, and traded directly in your MyEtherWallet (MEW) like all your crypto. Instead of having to use a traditional broker, you get stock market exposure right in your crypto wallet. The token tracks the economic value of the stock – both the price and the dividends if the stock pays them. Even better, tokenized stocks can be traded 24/5 outside regular market hours, can be held by users anywhere in the world, and can be used in DeFi like other crypto tokens."
+    },
+    {
+      "category": "Tokenized Stocks",
+      "question": "How do tokenized stocks work?",
+      "answer": "MEW offers tokenized stock by Ondo Global Markets. All Ondo tokenized stocks are backed by real assets held in secure custody. Ondo holds the matching share or ETF for all of the tokens it issues, and always has more assets than needed to cover the holdings of users (this is called “overcollateralization”). When a user buys a token, a new one is created and the underlying stock is acquired by Ondo. When you sell a token, the underlying stock is sold and the token is burned. This means you get the same market availability (liquidity) as if you traded on the stock market directly."
+    },
+    {
+      "category": "Tokenized Stocks",
+      "question": "How to trade tokenized stocks?",
+      "answer": "Stock trades in MEW are done through third party providers like 1InchFusion, designed especially to work with stocks. They automatically find and execute the best available option for you. Simply swap between crypto and stocks right in your wallet. Trade crypto for stocks, stocks for crypto, stocks for other stocks, and cash out stocks to stablecoins. You can’t do that with a brokerage."
+    },
+    {
+      "category": "Tokenized Stocks",
+      "question": "Is it safe to hold tokenized stock in MEW?",
+      "answer": "You hold tokenized stock in your own wallet, just like you hold ETH and other crypto. MEW is a self-custody wallet, so you have full control of your crypto and stocks at all times. MEW can’t access or move your assets, or prevent you from moving them. If you keep your recovery phrase safe, you can always restore your wallet in MEW or any other crypto wallet app. Your crypto and stocks will be there waiting for you, safe and sound. Ondo tokenized stocks are always backed by real world assets, secured by Ondo’s custodian partners, and triple-checked by independent auditors, so you can be sure that your tokens represent real stock value and reflect true market events. For more information, see: https://docs.ondo.finance/ondo-global-markets/overview."
+    },
+    {
+      "category": "Tokenized Stocks",
+      "question": "Who can get tokenized stocks in MEW?",
+      "answer": "Most users outside of the United States can trade tokenized stocks. In addition to the US, the following places are not eligible for stock trading due to specific local regulations: Afghanistan, Belarus, Canada, Crimea, Donetsk People’s Republic (DNR), Luhansk People’s Republic (LNR), Kherson and Zaporizhzhia regions (Ukraine), the city of Sevastopol, Cuba, Democratic Republic of Korea, Iran, Libya, Myanmar, Russia, Somalia, South Sudan, Sudan, Syria. For more information, see: https://docs.ondo.finance/ondo-global-markets/eligibility."
+    },
+    {
+      "category": "Tokenized Stocks",
+      "question": "Where can I learn more about tokenized stocks?",
+      "answer": "MEW offers tokenized stock by Ondo Global Markets. You can learn more about how these assets work here: https://docs.ondo.finance/ondo-global-markets."
+    },
+    {
+      "category": "Staking",
+      "question": "What is crypto staking?",
+      "answer": "Crypto staking is the process of depositing a cryptocurrency like ETH onto the blockchain for the purpose of supporting decentralized network operations and receiving crypto rewards in return. Think of it as an APY-earning deposit where your assets always stay under your control while providing a public good."
+    },
+    {
+      "category": "Staking",
+      "question": "What are crypto staking rewards?",
+      "answer": "When you stake ETH, you are helping the Ethereum blockchain run smoothly and stay decentralized. In return, you get a portion of the transaction fees and of the new ETH created with every block. These rewards are not generated by lending your ETH out or using it in investment schemes, as banks do with customers’ deposits. The staking rewards come from the technical work of the blockchain itself."
+    },
+    {
+      "category": "Staking",
+      "question": "How much ETH do I need to stake on Ethereum?",
+      "answer": "There is no minimum ETH to stake. You can choose to stake a full validator, which requires 32 ETH but also provides the highest rate of rewards, or a very small amount of ETH and still begin seeing the rewards accumulate almost immediately."
+    },
+    {
+      "category": "Staking",
+      "question": "How do I stake ETH?",
+      "answer": "ETH is staked by depositing it to a contract on the blockchain, where it stays until you decide to withdraw it. In some cases, like with full validator staking, the ETH is locked until you withdraw, and in others, you get liquid tokens for your ETH that can be spent in other web3 applications. Staking takes just a few steps when you do it through MEW – no advanced expertise required."
+    },
+    {
+      "category": "Staking",
+      "question": "How do I receive my staking rewards?",
+      "answer": "After you stake ETH, your staking rewards begin to accumulate automatically and are distributed directly to the wallet from which you staked, at regular intervals. The timing of rewards distribution depends on the specific staking provider, but no extra effort is required – it all happens right in your wallet."
+    },
+    {
+      "category": "Staking",
+      "question": "What are the benefits of crypto staking?",
+      "answer": "Staking is a low effort and low risk way to earn passive rewards on crypto. It is much simpler than most operations with decentralized finance, doesn’t require any upkeep, and leaves you with full control of the assets even as they are earning rewards. Best of all, staking provides a public good and gives you a literal stake in the cryptocurrency space."
+    },
+    {
+      "category": "Staking",
+      "question": "How does staking help the blockchain?",
+      "answer": "Cryptocurrencies are decentralized, so there is no single source of authority for verifying transactions. Instead, users from all over the world pledge their ETH to Ethereum by staking and creating validators. These validators run software that checks and compares transaction history, so they can agree on one ‘truth’ that gets added to the blockchain. The more ETH is staked, the more validators exist, and the less chance that a group of bad actors can take over control of the blockchain and cheat by adding a ‘lie’ – or a fraudulent transaction – into the ledger."
+    },
+    {
+      "category": "Staking",
+      "question": "What are the risks of crypto staking?",
+      "answer": "Any interaction with an evolving technology like the blockchain inherently involves risk. Very rarely, validators can incur penalties (known as slashing), and there can be delays in rewards distribution or staking withdrawals. As always, never risk more than you are prepared to lose."
+    },
+    {
+      "category": "Staking",
+      "question": "What is partial staking?",
+      "answer": "Partial staking is staking without a minimum, where the provider collects the smaller stakes and maintains a validator structure. It’s called ‘partial’ because it does not require the full validator amount of 32 ETH. Partial ETH staking in MEW is powered by Coinbase."
+    },
+    {
+      "category": "Staking",
+      "question": "What is liquid staking?",
+      "answer": "Liquid staking issues liquid tokens in place of the staked ETH so that the staker can benefit from the use of the ETH even while it is staked. Liquid staking derivatives (LSDs) can be used in various decentralized financial applications for lending, restaking, and more. Liquid ETH staking in MEW is provided by Lido."
+    },
+    {
+      "category": "Staking",
+      "question": "How do I withdraw staked ETH?",
+      "answer": "You can withdraw your staking rewards and your full stake at any time. Depending on the staking provider, you may need to submit a request to withdraw and wait for the ETH to become available in your wallet, but there is no lock-up period with any provider in MEW."
+    },
+    {
+      "category": "Other Important Questions",
+      "question": "When does the crypto market open and close?",
+      "answer": "Cryptocurrency blockchains, self custody wallets, and decentralized exchanges never close – they are accessible 24/7. There are no weekends, holidays, or hours of operation. If you want to move your assets at 3 AM on Christmas Day, you can do so immediately, without waiting for anything to open or for the transaction to be approved."
+    },
+    {
+      "category": "Other Important Questions",
+      "question": "Why do they call NFTs ‘overpriced jpegs’?",
+      "answer": "NFTs can be created as any form of media, but so far most of them have been images. There is a misconception that owning the actual NFT is the same as copy-pasting the image of the NFT, as you would with a JPEG file, in which case it’s absurd to pay for it. In fact, the digital scarcity and uniqueness of crypto tokens is the reason why crypto works in the first place. There are ways to prove that the NFT token you own is original and unique, rather than a copy of a copy."
+    },
+    {
+      "category": "Other Important Questions",
+      "question": "Is crypto bad for the environment?",
+      "answer": "The design of Bitcoin and some other cryptocurrencies, called Proof of Work, requires mining. Mining is the constant computational work done by thousands of computers worldwide to support the blockchain, using a lot of energy. That’s why some critics say that crypto is unsustainable. However, most crypto, including Ethereum, uses a different mechanism called Proof of Stake, which uses 99.99% less energy and poses no risk to the environment."
+    },
+    {
+      "category": "Other Important Questions",
+      "question": "What is HODLing?",
+      "answer": "The expression HODL originated as a misspelling of the word ‘hold’ in a social media post by an early Bitcoin investor. Later, HODL became associated with the acronym ‘hold on for deal life’. It communicates the sentiment that if you believe in a cryptocurrency’s long term potential and remain calm in the face of market volatility, you will always hold the crypto as opposed to panic selling."
+    },
+    {
+      "category": "Other Important Questions",
+      "question": "What does ‘not your keys, not your crypto’ mean?",
+      "answer": "There are many different ways to hold crypto, but not all of them give you full control and true ownership of your crypto assets. When you use a self custody wallet, you get your wallet keys (in the form of a recovery phrase) which give you direct access and ownership. When you use a centralized exchange, you don’t get wallet keys because the exchange actually manages the assets. No keys – no real ownership of crypto."
     }
   ]
 }

--- a/public/ai/faq.json
+++ b/public/ai/faq.json
@@ -1,0 +1,24 @@
+{
+  "faqs": [
+    {
+      "question": "Is MyEtherWallet free?",
+      "answer": "Yes. MyEtherWallet is free and open-source. Network (gas) fees and third-party service fees may apply to transactions."
+    },
+    {
+      "question": "Does MyEtherWallet hold my funds or keys?",
+      "answer": "No. MEW is a self-custody, client-side wallet. Your private keys never leave your device and MEW never has access to your funds."
+    },
+    {
+      "question": "Which wallets and devices does MEW support?",
+      "answer": "MEW supports hardware wallets (Ledger, Trezor), the MEW mobile app, the Enkrypt browser extension, and WalletConnect."
+    },
+    {
+      "question": "What can I do with MyEtherWallet?",
+      "answer": "You can send and receive crypto, swap tokens, buy and sell crypto, stake, trade perpetuals, and access tokenized stocks."
+    },
+    {
+      "question": "Is MyEtherWallet safe?",
+      "answer": "MEW is open-source and client-side, so you retain control of your keys. Always verify you are on the correct URL and never share your private key or recovery phrase."
+    }
+  ]
+}

--- a/public/ai/service.json
+++ b/public/ai/service.json
@@ -1,0 +1,17 @@
+{
+  "name": "MyEtherWallet",
+  "serviceType": "Self-custody cryptocurrency wallet",
+  "provider": "MyEtherWallet Inc",
+  "areaServed": "Worldwide",
+  "url": "https://app.myetherwallet.com/",
+  "features": [
+    "Buy and sell crypto",
+    "Token swaps",
+    "Send and receive",
+    "Staking",
+    "Perpetuals trading",
+    "Tokenized stocks",
+    "Hardware wallet support",
+    "WalletConnect"
+  ]
+}

--- a/public/ai/summary.json
+++ b/public/ai/summary.json
@@ -1,0 +1,8 @@
+{
+  "name": "MyEtherWallet",
+  "legalName": "MyEtherWallet Inc",
+  "url": "https://app.myetherwallet.com/",
+  "description": "MyEtherWallet (MEW) is a free, open-source, client-side wallet for Ethereum and EVM chains: send, swap, stake, buy and sell crypto, trade perpetuals, and access tokenized stocks while holding your own keys.",
+  "categories": ["cryptocurrency", "ethereum wallet", "web3", "defi", "self-custody"],
+  "contact": "support@myetherwallet.com"
+}

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,32 @@
+# MyEtherWallet (MEW)
+
+> MyEtherWallet is a free, open-source, client-side wallet for Ethereum and EVM chains — send, swap, stake, buy and sell crypto, trade perpetuals, and access tokenized stocks, all while holding your own keys.
+
+## Overview
+
+MyEtherWallet (MEW) is a self-custody web wallet. Private keys never leave the client and MEW never holds user funds. It supports hardware wallets (Ledger, Trezor), the MEW mobile app, the Enkrypt browser extension, and WalletConnect.
+
+## Features
+
+- Buy and sell crypto
+- Swap tokens across supported networks
+- Send and receive assets
+- Staking
+- Perpetuals trading
+- Tokenized stocks
+
+## Documentation
+
+- [Help center](https://help.myetherwallet.com/en/)
+- [GitHub](https://github.com/MyEtherWallet)
+
+## Security
+
+MEW is client-side and open-source, so users retain control of their private keys. Always confirm the correct URL and never share a private key or recovery phrase. See the [help center](https://help.myetherwallet.com/en/) for guidance.
+
+## Links
+
+- [Website](https://www.myetherwallet.com/)
+- [Enkrypt browser wallet](https://www.enkrypt.com)
+- [X / Twitter](https://twitter.com/myetherwallet)
+- [Medium](https://medium.com/myetherwallet)

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -26,7 +26,8 @@ MEW is client-side and open-source, so users retain control of their private key
 
 ## Links
 
-- [Website](https://www.myetherwallet.com/)
+- [MyEtherWallet app](https://app.myetherwallet.com/)
+- [Website (myetherwallet.com)](https://www.myetherwallet.com/)
 - [Enkrypt browser wallet](https://www.enkrypt.com)
 - [X / Twitter](https://twitter.com/myetherwallet)
 - [Medium](https://medium.com/myetherwallet)

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,51 @@
+# MyEtherWallet — app.myetherwallet.com
+# All crawlers, including AI/LLM citation bots, are welcome.
+
+User-agent: *
+Allow: /
+
+# AI / LLM citation bots (explicit for clarity and audit tooling)
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: anthropic-ai
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-SearchBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: Bingbot
+Allow: /
+
+User-agent: Applebot-Extended
+Allow: /
+
+User-agent: cohere-ai
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: Amazonbot
+Allow: /
+
+User-agent: meta-externalagent
+Allow: /

--- a/tests/unit/seo/geoAssets.spec.ts
+++ b/tests/unit/seo/geoAssets.spec.ts
@@ -44,3 +44,38 @@ describe('public/llms.txt', () => {
     expect((txt.match(/\[[^\]]+\]\(https?:\/\/[^)]+\)/g) ?? []).length).toBeGreaterThanOrEqual(5)
   })
 })
+
+describe('public/.well-known/ai.txt', () => {
+  it('exists and mentions the site', () => {
+    const txt = read('public/.well-known/ai.txt')
+    expect(txt.trim().length).toBeGreaterThan(0)
+    expect(txt).toMatch(/myetherwallet\.com/i)
+  })
+})
+
+describe('public/ai/*.json', () => {
+  it('summary.json parses and has required keys', () => {
+    const j = JSON.parse(read('public/ai/summary.json'))
+    expect(j.name).toBeTruthy()
+    expect(j.description).toBeTruthy()
+    expect(j.url).toBeTruthy()
+    expect(Array.isArray(j.categories)).toBe(true)
+  })
+
+  it('faq.json parses and has a non-empty Q&A array', () => {
+    const j = JSON.parse(read('public/ai/faq.json'))
+    expect(Array.isArray(j.faqs)).toBe(true)
+    expect(j.faqs.length).toBeGreaterThanOrEqual(3)
+    for (const f of j.faqs) {
+      expect(f.question).toBeTruthy()
+      expect(f.answer).toBeTruthy()
+    }
+  })
+
+  it('service.json parses and has features', () => {
+    const j = JSON.parse(read('public/ai/service.json'))
+    expect(j.name).toBeTruthy()
+    expect(Array.isArray(j.features)).toBe(true)
+    expect(j.features.length).toBeGreaterThan(0)
+  })
+})

--- a/tests/unit/seo/geoAssets.spec.ts
+++ b/tests/unit/seo/geoAssets.spec.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const root = process.cwd()
+const read = (p: string): string => readFileSync(resolve(root, p), 'utf-8')
+
+describe('public/robots.txt', () => {
+  const txt = read('public/robots.txt')
+
+  it('allows all crawlers', () => {
+    expect(txt).toMatch(/User-agent:\s*\*/)
+    expect(txt).toMatch(/Allow:\s*\//)
+  })
+
+  it('explicitly allows the key AI citation bots', () => {
+    for (const bot of [
+      'GPTBot', 'OAI-SearchBot', 'ChatGPT-User', 'anthropic-ai', 'ClaudeBot',
+      'Claude-SearchBot', 'PerplexityBot', 'Google-Extended', 'Bingbot', 'CCBot',
+    ]) {
+      expect(txt).toContain(`User-agent: ${bot}`)
+    }
+  })
+})

--- a/tests/unit/seo/geoAssets.spec.ts
+++ b/tests/unit/seo/geoAssets.spec.ts
@@ -22,3 +22,25 @@ describe('public/robots.txt', () => {
     }
   })
 })
+
+describe('public/llms.txt', () => {
+  const txt = read('public/llms.txt')
+
+  it('has exactly one H1 and it is the first non-empty line', () => {
+    const firstNonEmpty = txt.split('\n').map(l => l.trim()).find(l => l !== '')
+    expect(firstNonEmpty).toMatch(/^# \S/)
+    expect((txt.match(/^# /gm) ?? []).length).toBe(1)
+  })
+
+  it('has a blockquote description', () => {
+    expect(txt).toMatch(/^> .+/m)
+  })
+
+  it('has at least 3 section headings', () => {
+    expect((txt.match(/^## /gm) ?? []).length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('has at least 5 markdown links to real URLs', () => {
+    expect((txt.match(/\[[^\]]+\]\(https?:\/\/[^)]+\)/g) ?? []).length).toBeGreaterThanOrEqual(5)
+  })
+})

--- a/tests/unit/seo/geoAssets.spec.ts
+++ b/tests/unit/seo/geoAssets.spec.ts
@@ -79,3 +79,43 @@ describe('public/ai/*.json', () => {
     expect(j.features.length).toBeGreaterThan(0)
   })
 })
+
+describe('index.html structured data', () => {
+  const html = read('index.html')
+  const blocks = [...html.matchAll(/<script type="application\/ld\+json">([\s\S]*?)<\/script>/g)]
+    .map(m => JSON.parse(m[1]))
+  const types = blocks.map(b => b['@type'])
+
+  it('has Organization, WebSite and FAQPage JSON-LD that all parse', () => {
+    expect(types).toContain('Organization')
+    expect(types).toContain('WebSite')
+    expect(types).toContain('FAQPage')
+  })
+
+  it('FAQPage has a mainEntity Q&A list', () => {
+    const faq = blocks.find(b => b['@type'] === 'FAQPage')
+    expect(Array.isArray(faq.mainEntity)).toBe(true)
+    expect(faq.mainEntity.length).toBeGreaterThanOrEqual(3)
+    for (const q of faq.mainEntity) {
+      expect(q['@type']).toBe('Question')
+      expect(q.name).toBeTruthy()
+      expect(q.acceptedAnswer?.text).toBeTruthy()
+    }
+  })
+
+  it('WebSite points at the app domain', () => {
+    const site = blocks.find(b => b['@type'] === 'WebSite')
+    expect(site.url).toBe('https://app.myetherwallet.com/')
+  })
+
+  it('Organization keeps a non-empty sameAs array', () => {
+    const org = blocks.find(b => b['@type'] === 'Organization')
+    expect(Array.isArray(org.sameAs)).toBe(true)
+    expect(org.sameAs.length).toBeGreaterThan(0)
+  })
+
+  it('declares a self-canonical and og:url to the app domain', () => {
+    expect(html).toMatch(/<link rel="canonical" href="https:\/\/app\.myetherwallet\.com\/"\s*\/?>/)
+    expect(html).toMatch(/property="og:url" content="https:\/\/app\.myetherwallet\.com\/"/)
+  })
+})


### PR DESCRIPTION
## Summary

Adds the GEO (Generative Engine Optimization) / AI-SEO **foundation** to the v7 app (`app.myetherwallet.com`) so AI engines (ChatGPT, Perplexity, Google AI, Claude) can discover and cite it. The app previously shipped none of the AI-discovery files and only a partial `Organization` JSON-LD.

Source: a GEO audit of the site. Two findings shaped the scope — the app had zero AI-discovery files, and because the SPA serves `index.html` for any unknown path, these must be **real static files** in `public/` (or the fallback masks them).

## Changes

- `public/robots.txt` — allow-all + explicit `Allow: /` groups for AI citation bots (GPTBot, OAI-SearchBot, ChatGPT-User, anthropic-ai, ClaudeBot, Claude-SearchBot, PerplexityBot, Google-Extended, Bingbot, CCBot, …).
- `public/llms.txt` — single H1 + `>` blockquote + `##` topic sections + markdown links to real MEW pages.
- `public/.well-known/ai.txt` — AI usage / citation policy.
- `public/ai/{summary,faq,service}.json` — structured AI-discovery endpoints.
- `index.html` — added `WebSite` and `FAQPage` JSON-LD; added `<link rel="canonical">` and aligned `og:url` to `https://app.myetherwallet.com/` (self-canonical).
- `tests/unit/seo/geoAssets.spec.ts` — validates all of the above (15 tests).

## Testing

- `pnpm vitest run tests/unit/seo/geoAssets.spec.ts` → **15/15** green.
- `pnpm vue-tsc --noEmit -p tsconfig.app.json` → **0 errors**.
- Manual: dev-server `curl` of all 6 files → 200 + correct `Content-Type` + real content (not the SPA shell); 3 JSON-LD blocks present at `/`; `canonical` and `og:url` verified as the app domain.

## Scope notes / deferred (logged as follow-ups)

- **`SearchAction` omitted** from the `WebSite` JSON-LD — the app has in-app global search but no URL-addressable `/search?q=` route, so a SearchAction target would 404.
- **`Organization.sameAs` not expanded** — candidate external profiles could not be verified (Wikipedia 404, Crunchbase 403); no URLs were fabricated.
- **Content/accessibility audit items** (hidden-text/cloaking, keyword density, image alt-text, form `aria-label`s, RSS feed, WebMCP) were measured against the landing-page content, not the app — deferred to app-specific tickets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **SEO & Discoverability**
  * Updated canonical and Open Graph URLs to use the app domain.
  * Added structured data in the homepage head, including website and FAQ markup.
  * Expanded site crawl rules via `robots.txt` for major AI/LLM and search bots.
* **Documentation**
  * Published AI/LLM crawler usage guidance in `/.well-known/ai.txt`.
  * Added machine-readable AI/LLM content files for brand summary, service details, and a multi-topic FAQ.
  * Added an `llms.txt` overview with features, links, and basic security guidance.
* **Testing**
  * Added unit tests covering the crawl rules, AI/LLM public files, and homepage structured data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->