### PR TITLE
fix: [MEW-2037] guard getSessionDisabledAddresses against null assets

### DIFF
--- a/src/modules/trade/composables/tradeSession.ts
+++ b/src/modules/trade/composables/tradeSession.ts
@@ -44,6 +44,11 @@ export const getSessionDisabledAddresses = (
     }
   }
   for (const asset of assets) {
+    // Defensive: the Ondo assets API has been observed returning null/malformed
+    // elements (Sentry APP-MEW-WEB-1CE). Skip them so this pure utility never
+    // dereferences a null asset, independent of upstream filtering.
+    if (!asset) continue
+
     // Off-hours override: an asset that EXPLICITLY lists `offhours` stays
     // tradable during off-hours even if globally paused. Must be an explicit
     // membership (not the missing-field fallback in isAssetTradableInSession)

--- a/src/modules/trade/composables/tradeSession.ts
+++ b/src/modules/trade/composables/tradeSession.ts
@@ -40,7 +40,10 @@ export const getSessionDisabledAddresses = (
   if (!assets) return disabled
   const addAll = (asset: TradableAsset) => {
     for (const addr of asset.addresses) {
-      if (addr.address) disabled.add(addr.address.toLowerCase())
+      // Defensive: address members can be null or have a non-string `address`
+      // in malformed payloads; only lowercase real, non-empty strings.
+      if (typeof addr?.address === 'string' && addr.address)
+        disabled.add(addr.address.toLowerCase())
     }
   }
   for (const asset of assets) {

--- a/src/modules/trade/composables/tradeSession.ts
+++ b/src/modules/trade/composables/tradeSession.ts
@@ -45,9 +45,10 @@ export const getSessionDisabledAddresses = (
   }
   for (const asset of assets) {
     // Defensive: the Ondo assets API has been observed returning null/malformed
-    // elements (Sentry APP-MEW-WEB-1CE). Skip them so this pure utility never
-    // dereferences a null asset, independent of upstream filtering.
-    if (!asset) continue
+    // elements (Sentry APP-MEW-WEB-1CE). Skip anything that is not a shaped
+    // asset with an addresses array, so this pure utility never dereferences a
+    // bad entry, independent of upstream filtering.
+    if (!asset || !Array.isArray(asset.addresses)) continue
 
     // Off-hours override: an asset that EXPLICITLY lists `offhours` stays
     // tradable during off-hours even if globally paused. Must be an explicit

--- a/tests/unit/modules/trade/tradeSession.spec.ts
+++ b/tests/unit/modules/trade/tradeSession.spec.ts
@@ -114,6 +114,18 @@ describe('getSessionDisabledAddresses', () => {
     expect(disabled?.has('0xaaa')).toBe(true)
   })
 
+  it('skips non-null malformed assets (missing addresses) and still processes valid ones', () => {
+    const assets = [
+      { tradable: false } as unknown as TradableAsset, // no addresses array
+      asset({ symbol: 'A', tradable: false, sessions: ['regular'], address: '0xAaA' }),
+    ]
+    let disabled: Set<string> | undefined
+    expect(() => {
+      disabled = getSessionDisabledAddresses(assets, 'regular')
+    }).not.toThrow()
+    expect(disabled?.has('0xaaa')).toBe(true)
+  })
+
   it('skips null asset elements during offhours without throwing', () => {
     const assets = [
       null,

--- a/tests/unit/modules/trade/tradeSession.spec.ts
+++ b/tests/unit/modules/trade/tradeSession.spec.ts
@@ -126,6 +126,31 @@ describe('getSessionDisabledAddresses', () => {
     expect(disabled?.has('0xaaa')).toBe(true)
   })
 
+  it('skips malformed address members (null / non-string) without throwing', () => {
+    const assets = [
+      // paused asset whose addresses array has a null member and a
+      // non-string address alongside one valid string address
+      {
+        symbol: 'M',
+        tradable: false,
+        pause: null,
+        primaryMarket: { price: '1', sharesMultiplier: '1' },
+        underlyingMarket: { name: 'x', price: '1' },
+        addresses: [
+          null,
+          { chainName: 'ETHEREUM', address: 123 },
+          { chainName: 'ETHEREUM', address: '0xVaLiD' },
+        ],
+      } as unknown as TradableAsset,
+    ]
+    let disabled: Set<string> | undefined
+    expect(() => {
+      disabled = getSessionDisabledAddresses(assets, 'regular')
+    }).not.toThrow()
+    expect(disabled?.has('0xvalid')).toBe(true)
+    expect(disabled?.size).toBe(1) // null + non-string members ignored
+  })
+
   it('skips null asset elements during offhours and still disables valid paused assets', () => {
     const assets = [
       null,

--- a/tests/unit/modules/trade/tradeSession.spec.ts
+++ b/tests/unit/modules/trade/tradeSession.spec.ts
@@ -98,4 +98,29 @@ describe('getSessionDisabledAddresses', () => {
     const assets = [asset({ sessions: ['regular'], address: '0xAaA' })]
     expect(getSessionDisabledAddresses(assets, null).has('0xaaa')).toBe(true)
   })
+
+  // Regression: Sentry APP-MEW-WEB-1CE — the Ondo assets API can return an
+  // array containing a null element; reading `.tradable` off it threw
+  // "Cannot read properties of null (reading 'tradable')" and crashed <ModuleTrade>.
+  it('skips null asset elements without throwing and still processes valid ones', () => {
+    const assets = [
+      null,
+      asset({ symbol: 'A', tradable: false, sessions: ['regular'], address: '0xAaA' }),
+    ] as unknown as TradableAsset[]
+    let disabled: Set<string> | undefined
+    expect(() => {
+      disabled = getSessionDisabledAddresses(assets, 'regular')
+    }).not.toThrow()
+    expect(disabled?.has('0xaaa')).toBe(true)
+  })
+
+  it('skips null asset elements during offhours without throwing', () => {
+    const assets = [
+      null,
+      asset({ symbol: 'A', sessions: ['offhours'], address: '0xAaA' }),
+    ] as unknown as TradableAsset[]
+    expect(() =>
+      getSessionDisabledAddresses(assets, 'offhours'),
+    ).not.toThrow()
+  })
 })

--- a/tests/unit/modules/trade/tradeSession.spec.ts
+++ b/tests/unit/modules/trade/tradeSession.spec.ts
@@ -126,13 +126,16 @@ describe('getSessionDisabledAddresses', () => {
     expect(disabled?.has('0xaaa')).toBe(true)
   })
 
-  it('skips null asset elements during offhours without throwing', () => {
+  it('skips null asset elements during offhours and still disables valid paused assets', () => {
     const assets = [
       null,
-      asset({ symbol: 'A', sessions: ['offhours'], address: '0xAaA' }),
+      asset({ symbol: 'A', tradable: false, sessions: ['regular'], address: '0xAaA' }),
     ] as unknown as TradableAsset[]
-    expect(() =>
-      getSessionDisabledAddresses(assets, 'offhours'),
-    ).not.toThrow()
+    let disabled: Set<string> | undefined
+    expect(() => {
+      disabled = getSessionDisabledAddresses(assets, 'offhours')
+    }).not.toThrow()
+    // Paused asset that does not opt into offhours must still be disabled.
+    expect(disabled?.has('0xaaa')).toBe(true)
   })
 })


### PR DESCRIPTION
### What was wrong

The Trade screen could crash on load with `TypeError: Cannot read properties of null (reading 'tradable')`, taking down the `<ModuleTrade>` view. The Ondo tradable-assets API occasionally returns a list that contains a `null` item, and the code that decides which tokens to grey out ("Trading paused for this session") walked that list and tried to read properties off the `null` entry.

Captured in Sentry as **APP-MEW-WEB-1CE** (30 events on a QA preview build). The underlying "API returns a null asset" condition was already fixed at the source (the loader now filters bad items before they reach this code, shipped in `v7.0.9`), so this is **defense-in-depth**: it hardens the exact function that appeared in the crash stack so it can never crash again even if a bad item slips through in the future.

### What changed

- Added a one-line guard in `getSessionDisabledAddresses` (`src/modules/trade/composables/tradeSession.ts`) that skips any `null`/missing item in the assets list instead of reading properties off it.
- Added regression tests covering both crash paths (regular session and off-hours session).
- No user-visible behavior change: with a clean list the output is identical; with a corrupt list the Trade screen keeps working instead of crashing.

### How to test

1. Open the app, connect any wallet (e.g. Enkrypt), Ethereum network.
2. Go to the **Trade** screen (stock/token trading) from Home.
3. Confirm the token selector opens, tokens load, and the "Trading paused for this session" grouping still renders correctly — no blank screen / crash.

Because the corrupt-list condition can't be reproduced from the UI, the main check is a regression smoke: the Trade module loads and behaves exactly as before.

### Sentry

https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-1CE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trade session disablement to safely handle asset lists that include `null` or malformed entries.
  * Valid assets continue to be disabled or allowed according to their trading status and the current session rules (including off-hours behavior).

* **Tests**
  * Added regression tests to ensure the disablement logic skips unexpected asset shapes without throwing.
  * Verified behavior for both regular and off-hours sessions with mixed valid and invalid asset entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->