### PR TITLE
fix: guard undefined market in perps getBase (MEW-2038)

### DIFF
--- a/src/modules/perps/utils/market.ts
+++ b/src/modules/perps/utils/market.ts
@@ -8,7 +8,7 @@ export function getLogoUrl(base: string): string {
 }
 
 export function getBase(market: string): string {
-  return market.split('-')[0] ?? market
+  return market?.split('-')?.[0] ?? market ?? ''
 }
 
 export function midPrice(contract: Contract): number {

--- a/tests/unit/specs/modules/perps/utils/market.spec.ts
+++ b/tests/unit/specs/modules/perps/utils/market.spec.ts
@@ -1,5 +1,29 @@
 import { describe, it, expect } from 'vitest'
-import { resolveEffectivePrice } from '@/modules/perps/utils/market'
+import { getBase, resolveEffectivePrice } from '@/modules/perps/utils/market'
+
+describe('getBase', () => {
+  it('returns the base symbol for a well-formed market', () => {
+    expect(getBase('BTC-USD')).toBe('BTC')
+  })
+
+  it('returns the whole string when there is no separator', () => {
+    expect(getBase('BTC')).toBe('BTC')
+  })
+
+  it('returns an empty string for an empty market', () => {
+    expect(getBase('')).toBe('')
+  })
+
+  it('returns an empty string when market is undefined (no crash)', () => {
+    // Positions/orders can carry an undefined market before data loads —
+    // getBase must not throw a TypeError reading .split (Sentry APP-MEW-WEB-16D).
+    expect(getBase(undefined as unknown as string)).toBe('')
+  })
+
+  it('returns an empty string when market is null (no crash)', () => {
+    expect(getBase(null as unknown as string)).toBe('')
+  })
+})
 
 describe('resolveEffectivePrice', () => {
   describe('market orders', () => {


### PR DESCRIPTION
## Summary

`getBase()` in the perps module could throw `TypeError: Cannot read properties of undefined (reading 'split')` when a position/order/fill carried an `undefined` (or `null`) `market`. Because these helpers render inside `PerpsPositionsTable` / `PerpsFillDetailsDialog` (mounted in `<AppSheet>`), the throw crashed the positions/orders view. This guards the input so the helper degrades gracefully.

## Root cause

```ts
export function getBase(market: string): string {
  return market.split('-')[0] ?? market
}
```

The `?? market` fallback guarded the *result* of `.split()`, not the *input*. `String.prototype.split` never returns `undefined` for index `[0]` on a valid string, so the nullish fallback never triggered — and when `market` itself was `undefined`/`null`, `.split` was called on it and threw before any fallback could run.

## Changes

- `src/modules/perps/utils/market.ts` — `getBase` now guards the input:
  ```ts
  return market?.split('-')?.[0] ?? market ?? ''
  ```
  Returns `''` when `market` is `undefined`/`null`, otherwise unchanged behavior. `getBase` is the only split-based helper in `market.ts`; the sibling helpers (`midPrice`, `hasTag`, `getCategory`, `resolveEffectivePrice`) do not parse the market string, so no other guard was needed.

## Testing

- Added `describe('getBase', ...)` to `tests/unit/specs/modules/perps/utils/market.spec.ts` covering `'BTC-USD'` → `'BTC'`, no-separator, empty string, and the previously-crashing `undefined` / `null` cases. The undefined/null cases reproduced the exact Sentry `TypeError` before the fix.
- `pnpm vitest run tests/unit/specs/modules/perps/utils/market.spec.ts` → **19 passed**.
- `pnpm vue-tsc --noEmit -p tsconfig.app.json` → **clean** (0 errors).

## Sentry

Fixes APP-MEW-WEB-16D (~102 events) — `TypeError: ...reading 'split'` from `getBase`.
