### PR TITLE
fix: gate Trezor connect on chrome capability for non-Chromium (MEW-2041)

### DIFF
--- a/src/i18n/locales/access_wallet/en.json
+++ b/src/i18n/locales/access_wallet/en.json
@@ -72,7 +72,8 @@
         "title": "Select address and network"
       }
     },
-    "connect": "Connect your Trezor"
+    "connect": "Connect your Trezor",
+    "not_supported": "Trezor is not supported on this browser. Please use a Chromium-based browser (such as Chrome, Brave, or Edge) on desktop to connect your Trezor."
   },
   "access_wallet_ledger": {
     "title": "Access Wallet with Ledger",

--- a/src/modules/access/ModuleAccessHardwareWallet.vue
+++ b/src/modules/access/ModuleAccessHardwareWallet.vue
@@ -140,6 +140,7 @@ import type { WalletConfig } from '@/modules/access/common/walletConfigs'
 import { NetworkNames } from '@enkryptcom/types'
 import { useAccessStore } from '@/stores/accessStore'
 import { useGlobalStore } from '@/stores/globalStore'
+import { isTrezorSupported } from '@/utils/walletUtils'
 import { formatUnits } from 'viem'
 import BtcHardwareWallet from '@/providers/bitcoin/btcHardwareWallet'
 import { analytics, ConnectWalletEvent } from '@/analytics'
@@ -294,6 +295,18 @@ const backStep = () => {
 const connectingWallet = ref(false)
 
 const unlockWallet = async () => {
+  // Gate Trezor on browser capability: @enkryptcom/hw-wallets `getTrezorConnect`
+  // references the bare `chrome` global, which is undefined on non-Chromium
+  // browsers (e.g. iOS Safari) and throws an uncaught ReferenceError. Fail
+  // gracefully with a friendly message instead. See MEW-2041.
+  if (currentView.value === 'trezor' && !isTrezorSupported()) {
+    toastStore.addToastMessage({
+      type: ToastType.Error,
+      text: t('access_wallet_trezor.not_supported'),
+    })
+    return
+  }
+
   connectingWallet.value = true
   const networkName = chainToEnum[
     selectedChain.value?.name as string

--- a/src/utils/walletUtils.ts
+++ b/src/utils/walletUtils.ts
@@ -12,6 +12,20 @@ export const isSignableWallet = (wallet: WalletInterface) => {
 }
 
 /**
+ * Whether the current browser can safely initiate a Trezor connection.
+ *
+ * `@enkryptcom/hw-wallets` `getTrezorConnect` references the bare `chrome`
+ * global (`if (chrome && chrome.runtime && ...)`). On non-Chromium browsers
+ * such as iOS Safari the `chrome` global does not exist, so that reference
+ * throws `ReferenceError: Can't find variable: chrome` before it can fall back
+ * to `@trezor/connect-web`. Gate the Trezor connect entry point on this
+ * capability so unsupported browsers fail gracefully with a friendly message
+ * instead of an uncaught ReferenceError. See MEW-2041.
+ */
+export const isTrezorSupported = (): boolean =>
+  typeof (globalThis as { chrome?: unknown }).chrome !== 'undefined'
+
+/**
  * Checks if an error is a user rejection (e.g. user cancelled transaction in wallet).
  * Detects EIP-1193 code 4001 and common rejection message patterns.
  */

--- a/tests/unit/utils/walletUtils.spec.ts
+++ b/tests/unit/utils/walletUtils.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { isTrezorSupported } from '@/utils/walletUtils'
+
+// ---------------------------------------------------------------------------
+// isTrezorSupported — MEW-2041
+//
+// `@enkryptcom/hw-wallets` `getTrezorConnect` references the bare `chrome`
+// global, which is undefined on non-Chromium browsers (e.g. iOS Safari) and
+// throws `ReferenceError: Can't find variable: chrome`. The connect entry point
+// must gate on this capability so unsupported browsers fail gracefully instead
+// of crashing.
+// ---------------------------------------------------------------------------
+
+describe('isTrezorSupported', () => {
+  const globalObj = globalThis as { chrome?: unknown }
+  const hadChrome = Object.prototype.hasOwnProperty.call(globalObj, 'chrome')
+  const originalChrome = globalObj.chrome
+
+  afterEach(() => {
+    if (hadChrome) {
+      globalObj.chrome = originalChrome
+    } else {
+      delete globalObj.chrome
+    }
+  })
+
+  it('returns false without throwing when `chrome` is undefined (non-Chromium, e.g. iOS Safari)', () => {
+    delete globalObj.chrome
+
+    let result: boolean | undefined
+    expect(() => {
+      result = isTrezorSupported()
+    }).not.toThrow()
+    expect(result).toBe(false)
+  })
+
+  it('returns true on a Chromium browser where the `chrome` global exists', () => {
+    globalObj.chrome = { runtime: {} }
+    expect(isTrezorSupported()).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

Guards the Trezor hardware-wallet connect entry point on browser capability so non-Chromium browsers (e.g. iOS Safari) fail gracefully with a friendly message instead of crashing with an uncaught `ReferenceError`.

## Root cause

The Trezor init path lives inside the dependency `@enkryptcom/hw-wallets` (`getTrezorConnect`), which branches on the **bare** `chrome` global:

```js
if (chrome && chrome.runtime && chrome.runtime.getPlatformInfo) { ... }
```

On non-Chromium browsers such as iOS Safari there is no `chrome` global, so referencing the bare identifier throws `ReferenceError: Can't find variable: chrome` **before** the code can fall back to `@trezor/connect-web`. Because the throw originates in first-party app stack (not an extension), it is not caught by the existing extension-noise Sentry filters.

The throw is in the dependency, so the fix is applied app-side at the connect entry point.

## Changes

- **`src/utils/walletUtils.ts`** — new `isTrezorSupported()` capability helper: `typeof globalThis.chrome !== 'undefined'` (never throws; safe property access instead of a bare reference).
- **`src/modules/access/ModuleAccessHardwareWallet.vue`** — `unlockWallet()` now short-circuits when the current view is Trezor and `isTrezorSupported()` is `false`, surfacing a friendly error toast and returning early (no dep call, no `ReferenceError`).
- **`src/i18n/locales/access_wallet/en.json`** — new `access_wallet_trezor.not_supported` string: "Trezor is not supported on this browser. Please use a Chromium-based browser (such as Chrome, Brave, or Edge) on desktop to connect your Trezor."

Scope is limited to the browser-capability gate for the `chrome` `ReferenceError`. Trezor re-init is handled by a separate ticket and is intentionally untouched here.

## Testing

- New focused unit test `tests/unit/utils/walletUtils.spec.ts` simulates the no-`chrome` (non-Chromium) environment and asserts `isTrezorSupported()` returns `false` without throwing, plus the Chromium (`chrome` present) case returning `true`.
- `pnpm vitest run tests/unit/utils/walletUtils.spec.ts` → 2 passed.
- `pnpm vue-tsc --noEmit -p tsconfig.app.json` → clean (0 errors).

## Sentry

Fixes APP-MEW-WEB-BE (~20 events, iOS Safari — `ReferenceError: Can't find variable: chrome`).
