### PR TITLE
fix: guard localStorage access at bootstrap with safe-storage helper (MEW-2044)

### DIFF
--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -8,6 +8,7 @@ import * as sessionReplay from '@amplitude/session-replay-browser'
 import { pageUrlEnrichmentPlugin } from "@amplitude/plugin-page-url-enrichment-browser";
 import { pageViewedEnrichmentPlugin } from './pageViewedEnrichment';
 import configs from '@/configs';
+import { safeLocalStorage } from '@/utils/safeStorage';
 
 const __TMP_VERSION__ = configs.APP_VERSION
 const __TMP_HASHED_VERSION__ = `tmp_local_mew_web_${__TMP_VERSION__}`
@@ -22,7 +23,7 @@ const amplitude = createInstance()
  * Reads the persisted consent state from localStorage.
  */
 const getConsentToTrack = (): boolean => {
-  const initialPopupStateJson = localStorage.getItem(
+  const initialPopupStateJson = safeLocalStorage.getItem(
     StoreConfigs.LOCAL_STORAGE_KEYS.analytics,
   )
   if (!initialPopupStateJson) {

--- a/src/stores/globalStore.ts
+++ b/src/stores/globalStore.ts
@@ -1,9 +1,10 @@
 import { ref, computed } from 'vue'
 import { defineStore } from 'pinia'
-import { useLocalStorage } from '@vueuse/core'
+import { useStorage } from '@vueuse/core'
 import type { FeePriority } from '@/mew_api/types'
 import { analytics } from '@/analytics'
 import * as Sentry from '@sentry/vue'
+import { safeLocalStorage } from '@/utils/safeStorage'
 interface SelectedNetwork {
   selectedNetwork: string
 }
@@ -12,11 +13,12 @@ export const useGlobalStore = defineStore('global', () => {
   /** --------------------
  * NETWORK
  --------------------*/
-  const storage = useLocalStorage<SelectedNetwork>(
+  const storage = useStorage<SelectedNetwork>(
     'selectedNetwork',
     {
       selectedNetwork: 'ETHEREUM', // default network
     },
+    safeLocalStorage,
     { mergeDefaults: true },
   )
 
@@ -38,14 +40,15 @@ export const useGlobalStore = defineStore('global', () => {
     maxFeePerGas: '0',
   })
   const gasPriceType = ref<FeePriority>('REGULAR')
-  const defaultGasPriceType = useLocalStorage<FeePriority>('mew-default-gas-price-type', 'REGULAR')
+  const defaultGasPriceType = useStorage<FeePriority>('mew-default-gas-price-type', 'REGULAR', safeLocalStorage)
 
   /**--------------------
    * WELCOME DIALOG
    --------------------*/
-  const welcomeDialogDismissed = useLocalStorage<boolean>(
+  const welcomeDialogDismissed = useStorage<boolean>(
     'mew-welcome-dialog-dismissed',
     false,
+    safeLocalStorage,
   )
   const dismissWelcomeDialog = () => {
     welcomeDialogDismissed.value = true

--- a/src/utils/safeStorage.ts
+++ b/src/utils/safeStorage.ts
@@ -1,0 +1,110 @@
+/**
+ * Safe localStorage helper.
+ *
+ * Some environments crash the app at bootstrap when `localStorage` is touched:
+ *  - Android WebView can expose `localStorage` as `null` -> `TypeError` when
+ *    calling `.getItem()` (Sentry APP-MEW-WEB-199).
+ *  - Sandboxed iframes / strict privacy modes throw a `SecurityError`
+ *    DOMException the moment `window.localStorage` is accessed or used
+ *    (Sentry APP-MEW-WEB-19E).
+ *
+ * This module feature-detects a usable Storage and, when none is available,
+ * transparently swaps in an in-memory fallback so callers never throw. The
+ * returned object is structurally compatible with @vueuse's `StorageLike`, so
+ * it can be passed straight to `useStorage(key, defaults, safeLocalStorage)`.
+ */
+
+export interface SafeStorage {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+  removeItem(key: string): void
+}
+
+/**
+ * A process-local Storage stand-in used when the real one is unavailable.
+ * State lives only for the current page session, which matches the graceful
+ * degradation we want in restricted environments.
+ */
+const createMemoryStorage = (): SafeStorage => {
+  const map = new Map<string, string>()
+  return {
+    getItem: (key) => (map.has(key) ? (map.get(key) as string) : null),
+    setItem: (key, value) => {
+      map.set(key, String(value))
+    },
+    removeItem: (key) => {
+      map.delete(key)
+    },
+  }
+}
+
+/**
+ * Resolves the platform Storage, returning `null` when it is absent or when
+ * accessing/using it throws. Uses a write/remove probe because some
+ * environments expose the object but throw on the first real operation.
+ */
+const resolveNativeStorage = (
+  getStorage: () => Storage | null | undefined,
+): Storage | null => {
+  try {
+    const storage = getStorage()
+    if (!storage) {
+      return null
+    }
+    const probeKey = '__mew_safe_storage_probe__'
+    storage.setItem(probeKey, '1')
+    storage.removeItem(probeKey)
+    return storage
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Builds a SafeStorage backed by `getStorage()` when it is usable, otherwise by
+ * an in-memory map. Even when the native storage passes the initial probe, each
+ * operation is guarded so a later failure (e.g. quota exceeded, privacy toggled
+ * mid-session) degrades to the in-memory fallback instead of throwing.
+ */
+export const createSafeStorage = (
+  getStorage: () => Storage | null | undefined,
+): SafeStorage => {
+  const native = resolveNativeStorage(getStorage)
+  if (!native) {
+    return createMemoryStorage()
+  }
+
+  const fallback = createMemoryStorage()
+  return {
+    getItem: (key) => {
+      try {
+        return native.getItem(key)
+      } catch {
+        return fallback.getItem(key)
+      }
+    },
+    setItem: (key, value) => {
+      try {
+        native.setItem(key, value)
+      } catch {
+        fallback.setItem(key, value)
+      }
+    },
+    removeItem: (key) => {
+      try {
+        native.removeItem(key)
+      } catch {
+        fallback.removeItem(key)
+      }
+    },
+  }
+}
+
+/**
+ * Shared safe wrapper around `window.localStorage`. Import and use this instead
+ * of touching `localStorage` directly at bootstrap, and pass it as the storage
+ * argument to @vueuse's `useStorage`.
+ */
+export const safeLocalStorage: SafeStorage = createSafeStorage(() =>
+  typeof window !== 'undefined' ? window.localStorage : undefined,
+)

--- a/src/utils/safeStorage.ts
+++ b/src/utils/safeStorage.ts
@@ -74,27 +74,37 @@ export const createSafeStorage = (
     return createMemoryStorage()
   }
 
-  const fallback = createMemoryStorage()
+  // Overlay of values (and tombstones = null) for keys whose native operation
+  // failed after construction (e.g. quota exceeded, or privacy toggled
+  // mid-session). getItem consults it before the native store so a failed write
+  // is still read back and a failed removal stays deleted, instead of returning
+  // stale native data.
+  const overlay = new Map<string, string | null>()
   return {
     getItem: (key) => {
+      if (overlay.has(key)) {
+        return overlay.get(key) ?? null
+      }
       try {
         return native.getItem(key)
       } catch {
-        return fallback.getItem(key)
+        return null
       }
     },
     setItem: (key, value) => {
       try {
         native.setItem(key, value)
+        overlay.delete(key)
       } catch {
-        fallback.setItem(key, value)
+        overlay.set(key, String(value))
       }
     },
     removeItem: (key) => {
       try {
         native.removeItem(key)
+        overlay.delete(key)
       } catch {
-        fallback.removeItem(key)
+        overlay.set(key, null)
       }
     },
   }

--- a/tests/unit/utils/safeStorage.spec.ts
+++ b/tests/unit/utils/safeStorage.spec.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import { createSafeStorage, safeLocalStorage } from '@/utils/safeStorage'
+
+describe('createSafeStorage', () => {
+  it('falls back to in-memory storage when localStorage is null (Android WebView)', () => {
+    const storage = createSafeStorage(() => null)
+    expect(() => storage.setItem('k', 'v')).not.toThrow()
+    expect(storage.getItem('k')).toBe('v')
+    storage.removeItem('k')
+    expect(storage.getItem('k')).toBeNull()
+  })
+
+  it('falls back to in-memory storage when localStorage is undefined', () => {
+    const storage = createSafeStorage(() => undefined)
+    expect(() => storage.getItem('missing')).not.toThrow()
+    expect(storage.getItem('missing')).toBeNull()
+  })
+
+  it('falls back to in-memory storage when accessing localStorage throws SecurityError (sandboxed iframe)', () => {
+    const storage = createSafeStorage(() => {
+      throw new DOMException('The operation is insecure.', 'SecurityError')
+    })
+    expect(() => storage.setItem('k', 'v')).not.toThrow()
+    expect(storage.getItem('k')).toBe('v')
+  })
+
+  it('falls back to in-memory storage when a storage method throws on probe (privacy mode)', () => {
+    const throwing = {
+      getItem: () => {
+        throw new DOMException('denied', 'SecurityError')
+      },
+      setItem: () => {
+        throw new DOMException('denied', 'SecurityError')
+      },
+      removeItem: () => {
+        throw new DOMException('denied', 'SecurityError')
+      },
+    } as unknown as Storage
+    const storage = createSafeStorage(() => throwing)
+    expect(() => storage.setItem('k', 'v')).not.toThrow()
+    // served transparently from the in-memory fallback
+    expect(storage.getItem('k')).toBe('v')
+  })
+
+  it('writes through to the native storage when it is available', () => {
+    const backing = new Map<string, string>()
+    const native = {
+      getItem: (k: string) => (backing.has(k) ? backing.get(k)! : null),
+      setItem: (k: string, v: string) => {
+        backing.set(k, v)
+      },
+      removeItem: (k: string) => {
+        backing.delete(k)
+      },
+    } as unknown as Storage
+    const storage = createSafeStorage(() => native)
+    storage.setItem('k', 'v')
+    expect(backing.get('k')).toBe('v')
+    expect(storage.getItem('k')).toBe('v')
+    storage.removeItem('k')
+    expect(backing.has('k')).toBe(false)
+  })
+
+  it('degrades gracefully when a native method throws after construction', () => {
+    let fail = false
+    const native = {
+      getItem: () => null,
+      setItem: () => {
+        if (fail) throw new DOMException('quota', 'QuotaExceededError')
+      },
+      removeItem: () => {},
+    } as unknown as Storage
+    const storage = createSafeStorage(() => native)
+    fail = true
+    expect(() => storage.setItem('k', 'v')).not.toThrow()
+  })
+})
+
+describe('safeLocalStorage singleton', () => {
+  it('exposes a working StorageLike-compatible instance under jsdom', () => {
+    expect(() => safeLocalStorage.setItem('__probe__', '1')).not.toThrow()
+    expect(safeLocalStorage.getItem('__probe__')).toBe('1')
+    safeLocalStorage.removeItem('__probe__')
+    expect(safeLocalStorage.getItem('__probe__')).toBeNull()
+  })
+})

--- a/tests/unit/utils/safeStorage.spec.ts
+++ b/tests/unit/utils/safeStorage.spec.ts
@@ -73,6 +73,8 @@ describe('createSafeStorage', () => {
     const storage = createSafeStorage(() => native)
     fail = true
     expect(() => storage.setItem('k', 'v')).not.toThrow()
+    // the failed write is served from the overlay, not stale native data
+    expect(storage.getItem('k')).toBe('v')
   })
 })
 


### PR DESCRIPTION
## Summary

Bootstrap-time `localStorage` access crashed the app in restricted environments (Android WebView, sandboxed iframes, strict privacy modes). This adds a single safe-storage helper that feature-detects a usable `Storage`, transparently falling back to an in-memory store, and routes the two crash sites through it so the app boots instead of throwing.

## Root cause

- `src/analytics/index.ts` — `getConsentToTrack()` called `localStorage.getItem(...)` directly. In an Android WebView `localStorage` can be `null`, so the property access threw `TypeError: ...reading 'getItem'` during `initAnalytics()`.
- `src/stores/globalStore.ts` — `useLocalStorage('selectedNetwork', ...)` (@vueuse) touched `window.localStorage` at store instantiation (bootstrap, via the router → walletStore → analytics chain). In a sandboxed iframe / privacy-blocked context, accessing/using `localStorage` throws a `SecurityError` DOMException that propagated out of app startup.

Both are unguarded and run at bootstrap, so a single throw takes the whole app down.

## Changes

- **New `src/utils/safeStorage.ts`**
  - `createSafeStorage(getStorage)` — resolves the native `Storage` behind a `try/catch` + write/remove probe. If it is absent (`null`/`undefined`) or throws on access or on the probe, it returns an in-memory `Map`-backed store. Even when the native storage passes the probe, every `getItem`/`setItem`/`removeItem` is individually guarded so a later failure (quota exceeded, privacy toggled mid-session) degrades gracefully instead of throwing.
  - `safeLocalStorage` — shared singleton wrapping `window.localStorage`. Structurally compatible with @vueuse's `StorageLike`, so it drops straight into `useStorage(key, defaults, safeLocalStorage)`.
  - Pure helper — no Sentry/console side effects, so it is safe to import at bootstrap and trivial to unit-test.
- **`src/analytics/index.ts`** — read consent via `safeLocalStorage.getItem(...)`.
- **`src/stores/globalStore.ts`** — switched the three bootstrap `useLocalStorage(...)` calls (`selectedNetwork`, `mew-default-gas-price-type`, `mew-welcome-dialog-dismissed`) to `useStorage(..., safeLocalStorage)`. Keys, defaults and `mergeDefaults` are unchanged, so persisted values remain fully compatible.

## Testing

- Added `tests/unit/utils/safeStorage.spec.ts` (7 cases): `localStorage` null / undefined / throwing-on-access (SecurityError) / throwing-on-probe all return an in-memory fallback and never throw; native storage writes through when available; a native method that throws after construction degrades gracefully; the `safeLocalStorage` singleton works under jsdom.
- `pnpm vitest run tests/unit/utils/safeStorage.spec.ts` → 7 passed.
- `pnpm vue-tsc --noEmit -p tsconfig.app.json` → clean.

## Sentry

- APP-MEW-WEB-199 — `TypeError` reading `getItem` (analytics, Android WebView `localStorage === null`).
- APP-MEW-WEB-19E — `SecurityError` DOMException (globalStore `useLocalStorage` in sandboxed iframe / privacy mode).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved persistence for analytics consent and global application preferences using a safer storage layer.
  - Prevented crashes when browser storage is unavailable, blocked, or becomes inaccessible by automatically falling back to an in-memory store.
  - Ensured preference and consent reads remain consistent even after storage write/remove failures.
  - Expanded automated test coverage for safe storage behavior and analytics consent handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->