### PR TITLE
fix: guard undefined enkryptInjection for BTC injected wallets (MEW-2040)

### DIFF
--- a/src/modules/access/composables/useConnectWallet.ts
+++ b/src/modules/access/composables/useConnectWallet.ts
@@ -89,8 +89,26 @@ export const useConnectWallet = () => {
         })
         return
       }
+      // Resolve the injected provider that matches the selected wallet.
+      // Wallets other than Unisat / Enkrypt (e.g. SafePal) do not expose a
+      // supported Bitcoin injection, so bail out gracefully instead of
+      // dereferencing an undefined provider (MEW-2040).
+      const btcInjection =
+        wallet.id === 'unisat'
+          ? unisatInjection
+          : wallet.id === 'enkrypt'
+            ? enkryptInjection
+            : undefined
+      if (!btcInjection) {
+        toastStore.addToastMessage({
+          text: 'Wallet not supported for Bitcoin',
+          textSecondary: `${wallet.name} can't be used to connect to Bitcoin. Please select a different wallet.`,
+          type: ToastType.Warning,
+        })
+        return
+      }
       const unisatWallet = new UnisatInjectWallet(
-        wallet.id === 'unisat' ? unisatInjection! : enkryptInjection!,
+        btcInjection,
         selectedChain.value?.name ?? 'BITCOIN',
       )
 

--- a/tests/unit/composables/useConnectWallet.spec.ts
+++ b/tests/unit/composables/useConnectWallet.spec.ts
@@ -1,0 +1,159 @@
+// tests/unit/composables/useConnectWallet.spec.ts
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { ToastType } from '@/types/notification/index'
+import {
+  WalletConfigType,
+  type WalletConfig,
+} from '@/modules/access/common/walletConfigs'
+import type { Chain } from '@/mew_api/types'
+
+// --- Mocks ---------------------------------------------------------------
+
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useRoute: () => ({ name: undefined }),
+}))
+
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (k: string) => k }),
+}))
+
+// Avoid pulling the heavy wagmi / rainbowkit graph into the unit test.
+vi.mock('@/providers/ethereum/wagmiConfig', () => ({
+  generateConfig: () => ({ connectors: [] }),
+}))
+
+vi.mock('@/providers/ethereum/wagmiWallet', () => ({ default: class {} }))
+vi.mock('@/providers/ethereum/web3InjectedWallet', () => ({
+  default: class {},
+}))
+
+vi.mock('@sentry/vue', () => ({ captureException: vi.fn() }))
+
+// walletConfigs.ts imports these hardware-wallet libs (used lazily inside
+// canSupport helpers). Their transitive @ledgerhq/hw-app-eth dep does not
+// resolve cleanly under Vitest, so stub the leaf modules to load the graph.
+vi.mock('@enkryptcom/hw-wallets', () => ({
+  default: class {
+    isNetworkSupported() {
+      return false
+    }
+  },
+}))
+vi.mock('@/providers/hw/ledger', () => ({
+  default: class {
+    isNetworkSupported() {
+      return false
+    }
+  },
+}))
+
+vi.mock('@/analytics', () => ({
+  analytics: { trackConnectWalletEvent: vi.fn() },
+  ConnectWalletEvent: { SUCCESS: 'success', SHOWN: 'shown' },
+}))
+
+// Spy on the Bitcoin injected wallet. We record the constructor args so we can
+// assert it is never instantiated with an undefined provider — that undefined
+// deref is the MEW-2040 crash (`Cannot read properties of undefined (reading
+// 'getNetwork')`). connect() resolves false so the happy-path branch never
+// reaches _storeWallet (which would drag in the full wallet store graph).
+const unisatCtorSpy = vi.fn()
+vi.mock('@/providers/bitcoin/unisatInjectedWallet', () => ({
+  default: class {
+    constructor(...args: unknown[]) {
+      unisatCtorSpy(...args)
+    }
+    connect() {
+      return Promise.resolve(false)
+    }
+  },
+}))
+
+const { useConnectWallet } = await import(
+  '@/modules/access/composables/useConnectWallet'
+)
+import { useAccessStore } from '@/stores/accessStore'
+import { useToastStore } from '@/stores/toastStore'
+
+// --- Helpers -------------------------------------------------------------
+
+const BITCOIN_CHAIN = {
+  name: 'BITCOIN',
+  type: 'BITCOIN',
+} as unknown as Chain
+
+const makeWallet = (id: string, name: string): WalletConfig => ({
+  id,
+  name,
+  icon: `${id}.webp`,
+  type: [WalletConfigType.EXTENSION],
+})
+
+const flush = () => new Promise(resolve => setTimeout(resolve, 0))
+
+// --- Tests ---------------------------------------------------------------
+
+describe('useConnectWallet — Bitcoin injected wallet guard (MEW-2040)', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    unisatCtorSpy.mockReset()
+    useAccessStore().setSelectedChain(BITCOIN_CHAIN)
+    // Clean slate for injected providers each run.
+    window.unisat = undefined
+    window.enkrypt = undefined
+  })
+
+  afterEach(() => {
+    window.unisat = undefined
+    window.enkrypt = undefined
+  })
+
+  it('does not instantiate the injected BTC wallet for an unsupported wallet (no undefined deref) and shows a friendly warning', async () => {
+    // SafePal-style wallet: neither unisat nor enkrypt, and no BTC injection.
+    const toastStore = useToastStore()
+    const addToastSpy = vi.spyOn(toastStore, 'addToastMessage')
+
+    const { connect } = useConnectWallet()
+    await connect(makeWallet('safepal', 'SafePal'))
+    await flush()
+
+    // The crash was caused by `new UnisatInjectWallet(undefined, ...)`.
+    expect(unisatCtorSpy).not.toHaveBeenCalled()
+    expect(addToastSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: ToastType.Warning,
+        textSecondary: expect.stringMatching(/bitcoin/i),
+      }),
+    )
+  })
+
+  it('still guards unsupported wallets even when a different BTC extension (enkrypt) is installed', async () => {
+    // Enkrypt IS present, but the selected wallet is SafePal. The old code fell
+    // through to `enkryptInjection!`, wrongly using enkrypt's provider.
+    window.enkrypt = {
+      providers: { bitcoin: { getNetwork: () => Promise.resolve('livenet') } },
+    } as unknown as typeof window.enkrypt
+
+    const { connect } = useConnectWallet()
+    await connect(makeWallet('safepal', 'SafePal'))
+    await flush()
+
+    expect(unisatCtorSpy).not.toHaveBeenCalled()
+  })
+
+  it('still connects supported injected wallets (unisat) when present', async () => {
+    const unisatInjection = {
+      getNetwork: () => Promise.resolve('livenet'),
+    } as unknown as typeof window.unisat
+    window.unisat = unisatInjection
+
+    const { connect } = useConnectWallet()
+    await connect(makeWallet('unisat', 'Unisat'))
+    await flush()
+
+    expect(unisatCtorSpy).toHaveBeenCalledTimes(1)
+    expect(unisatCtorSpy).toHaveBeenCalledWith(unisatInjection, 'BITCOIN')
+  })
+})


### PR DESCRIPTION
## Summary

When a Bitcoin chain is selected and the user picks an injected wallet that is **not** Unisat or Enkrypt (e.g. SafePal), the connect flow crashed with `TypeError: Cannot read properties of undefined (reading 'getNetwork')`. This adds a guard so unsupported wallets fail gracefully with a friendly warning toast instead of crashing.

## Root cause

In `src/modules/access/composables/useConnectWallet.ts`, the Bitcoin branch of `_connectWeb3` built the injected wallet with:

```ts
new UnisatInjectWallet(
  wallet.id === 'unisat' ? unisatInjection! : enkryptInjection!,
  ...
)
```

For any wallet whose `id` is neither `unisat` nor `enkrypt`, the ternary fell through to `enkryptInjection!`, which is `undefined` when Enkrypt's Bitcoin provider isn't present. `UnisatInjectWallet.connect()` then dereferenced `this.unisat.getNetwork()` on `undefined`. The non-null assertions (`!`) hid the possibility from the type checker. Sentry: `APP-MEW-WEB-DW`.

## Changes

- `src/modules/access/composables/useConnectWallet.ts`: resolve the injected BTC provider explicitly per `wallet.id` (unisat → `window.unisat`, enkrypt → `window.enkrypt.providers.bitcoin`, anything else → `undefined`). If the resolved provider is absent, show a `Warning` toast ("Wallet not supported for Bitcoin") and return early — no more dereferencing `undefined`. The existing per-extension "not detected" install prompts are preserved.
- `tests/unit/composables/useConnectWallet.spec.ts`: new focused unit test covering the unsupported-wallet path (no `UnisatInjectWallet` construction with `undefined`, friendly warning shown), the case where a different BTC extension is installed but the selected wallet is still unsupported, and the preserved happy path for Unisat.

## Testing

- `pnpm vitest run tests/unit/composables/useConnectWallet.spec.ts` → 3 passed (both regression tests fail on the pre-fix code as expected).
- `pnpm vue-tsc --noEmit -p tsconfig.app.json` → clean, zero errors.

## Sentry

Fixes `APP-MEW-WEB-DW` (`TypeError` reading `getNetwork` on undefined during Bitcoin injected-wallet connect).