### PR TITLE
fix: guard address/chain-type mismatch in watch-only getBalance (MEW-2043)

### DIFF
--- a/src/providers/common/watchOnlyWallet.ts
+++ b/src/providers/common/watchOnlyWallet.ts
@@ -21,7 +21,7 @@ import type {
   ChainType,
 } from '@/mew_api/types'
 import { fetchWithRetry } from '@/mew_api/fetchWithRetry'
-import { isAddress } from '@/utils/addressUtils'
+import { isAddressChainTypeMismatch } from '@/utils/addressUtils'
 import type { Provider } from '@/stores/providerStore'
 import type { HWManager } from '@/providers/hw/types'
 
@@ -180,27 +180,11 @@ class WatchOnlyWallet implements WalletInterface {
     // e.g. an EVM `0x` address paired with a BITCOIN chain (or vice-versa).
     // Building a balance request in that case yields an invalid endpoint the
     // MEW API 404s on, surfacing as an unhandled rejection (MEW-2043).
-    if (this.isAddressChainTypeMismatch(address)) {
+    if (isAddressChainTypeMismatch(address, this.chainType, this.chain.name)) {
       return emptyResponse
     }
     const Endpoint = `/balances/${this.getProvider()}/${address}/?noInjectErrors=false&sparklines=true`
     return fetchWithRetry<TokenBalancesRaw>(Endpoint).catch(() => emptyResponse)
-  }
-
-  /**
-   * Returns true when the wallet address format is incompatible with its chain
-   * type — an EVM `0x` address on a BITCOIN chain, or a non-EVM address on an
-   * EVM chain. Reuses the shared EVM address validator to detect the format.
-   */
-  private isAddressChainTypeMismatch(address: string): boolean {
-    const isEvmAddress = isAddress(address, this.chain.name)
-    if (this.chainType === 'BITCOIN') {
-      return isEvmAddress
-    }
-    if (this.chainType === 'EVM') {
-      return !isEvmAddress
-    }
-    return false
   }
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   broadcastTransaction(signedTx: HexPrefixedString): Promise<string> {

--- a/src/providers/common/watchOnlyWallet.ts
+++ b/src/providers/common/watchOnlyWallet.ts
@@ -21,6 +21,7 @@ import type {
   ChainType,
 } from '@/mew_api/types'
 import { fetchWithRetry } from '@/mew_api/fetchWithRetry'
+import { isAddress } from '@/utils/addressUtils'
 import type { Provider } from '@/stores/providerStore'
 import type { HWManager } from '@/providers/hw/types'
 
@@ -168,16 +169,38 @@ class WatchOnlyWallet implements WalletInterface {
   async getBalance(): Promise<TokenBalancesRaw> {
     const chainStore = useChainsStore()
     const { selectedChain } = storeToRefs(chainStore)
-    if (selectedChain.value?.type === this.chainType) {
-      const address = await this.getAddress()
-      const Endpoint = `/balances/${this.getProvider()}/${address}/?noInjectErrors=false&sparklines=true`
-      return fetchWithRetry<TokenBalancesRaw>(Endpoint)
-    } else {
-      const emptyResponse: TokenBalancesRaw = {
-        result: [],
-      }
+    const emptyResponse: TokenBalancesRaw = {
+      result: [],
+    }
+    if (selectedChain.value?.type !== this.chainType) {
       return emptyResponse
     }
+    const address = await this.getAddress()
+    // Guard against an address whose format does not match the chain type,
+    // e.g. an EVM `0x` address paired with a BITCOIN chain (or vice-versa).
+    // Building a balance request in that case yields an invalid endpoint the
+    // MEW API 404s on, surfacing as an unhandled rejection (MEW-2043).
+    if (this.isAddressChainTypeMismatch(address)) {
+      return emptyResponse
+    }
+    const Endpoint = `/balances/${this.getProvider()}/${address}/?noInjectErrors=false&sparklines=true`
+    return fetchWithRetry<TokenBalancesRaw>(Endpoint).catch(() => emptyResponse)
+  }
+
+  /**
+   * Returns true when the wallet address format is incompatible with its chain
+   * type — an EVM `0x` address on a BITCOIN chain, or a non-EVM address on an
+   * EVM chain. Reuses the shared EVM address validator to detect the format.
+   */
+  private isAddressChainTypeMismatch(address: string): boolean {
+    const isEvmAddress = isAddress(address, this.chain.name)
+    if (this.chainType === 'BITCOIN') {
+      return isEvmAddress
+    }
+    if (this.chainType === 'EVM') {
+      return !isEvmAddress
+    }
+    return false
   }
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   broadcastTransaction(signedTx: HexPrefixedString): Promise<string> {

--- a/src/stores/walletStore.ts
+++ b/src/stores/walletStore.ts
@@ -10,6 +10,7 @@ import { storeToRefs } from 'pinia'
 import { formatUnits } from 'viem'
 import WatchOnlyWallet from '@/providers/common/watchOnlyWallet'
 import { useWatchOnlyStore } from './watchOnlyStore'
+import { isAddressChainTypeMismatch } from '@/utils/addressUtils'
 import { useToastStore } from './toastStore'
 import { ToastType } from '@/types/notification'
 import type BaseEvmWallet from '@/providers/ethereum/baseEvmWallet'
@@ -90,24 +91,29 @@ export const useWalletStore = defineStore('walletStore', () => {
     const { watchOnlyAddresses } = useWatchOnlyStore()
     const currentRecentAddressList =
       watchOnlyAddresses[selectedChain.value?.type || 'EVM']
-    if (currentRecentAddressList.length > 0) {
+    // Skip stale entries whose address format does not match their chain type
+    // (e.g. legacy localStorage with an EVM `0x` address under BITCOIN), which
+    // would otherwise rebuild a wallet that hits an invalid balance endpoint
+    // (MEW-2043). This is the read-side root-cause guard / self-heal.
+    const validEntries = currentRecentAddressList.filter(
+      item =>
+        !isAddressChainTypeMismatch(item.address, item.type, item.chain.name),
+    )
+    const latest = validEntries[validEntries.length - 1]
+    if (latest) {
       const newWallet = new WatchOnlyWallet(
-        currentRecentAddressList[currentRecentAddressList.length - 1].address,
-        currentRecentAddressList[currentRecentAddressList.length - 1].chain,
-        currentRecentAddressList[currentRecentAddressList.length - 1]
-          .walletType as WalletType,
-        currentRecentAddressList[currentRecentAddressList.length - 1].type,
-        currentRecentAddressList[currentRecentAddressList.length - 1]
-          .walletName,
+        latest.address,
+        latest.chain,
+        latest.walletType as WalletType,
+        latest.type,
+        latest.walletName,
       )
       wallet.value = null
       walletAddress.value = null
       setWallet(
         newWallet,
-        currentRecentAddressList[currentRecentAddressList.length - 1]
-          .walletName,
-        currentRecentAddressList[currentRecentAddressList.length - 1]
-          .walletType as WalletConfigType,
+        latest.walletName,
+        latest.walletType as WalletConfigType,
       )
     } else {
       wallet.value = null

--- a/src/stores/watchOnlyStore.ts
+++ b/src/stores/watchOnlyStore.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { useLocalStorage } from '@vueuse/core'
 import type { Chain, ChainType } from '@/mew_api/types'
+import { isAddressChainTypeMismatch } from '@/utils/addressUtils'
 
 interface AddressKeyValue {
   address: string
@@ -34,6 +35,13 @@ export const useWatchOnlyStore = defineStore('useWatchOnlyStore', () => {
     type: ChainType,
     walletName: string,
   ) => {
+    // Never persist an address into a bucket whose chain type its format does
+    // not match (e.g. an EVM `0x` address under BITCOIN). Such a pair is later
+    // rebuilt into a watch-only wallet that hits an invalid balance endpoint
+    // (MEW-2043). This is the write-side root-cause guard.
+    if (isAddressChainTypeMismatch(address, type, chain.name)) {
+      return
+    }
     const addressKeyMap: AddressKeyValue = {
       walletType,
       walletName,

--- a/src/stores/watchOnlyStore.ts
+++ b/src/stores/watchOnlyStore.ts
@@ -38,8 +38,13 @@ export const useWatchOnlyStore = defineStore('useWatchOnlyStore', () => {
     // Never persist an address into a bucket whose chain type its format does
     // not match (e.g. an EVM `0x` address under BITCOIN). Such a pair is later
     // rebuilt into a watch-only wallet that hits an invalid balance endpoint
-    // (MEW-2043). This is the write-side root-cause guard.
-    if (isAddressChainTypeMismatch(address, type, chain.name)) {
+    // (MEW-2043). This is the write-side root-cause guard. Validate against
+    // `chain.type` since that is the bucket key, and reject a caller whose
+    // `type` disagrees with it so an entry can't be stored under the wrong one.
+    if (
+      type !== chain.type ||
+      isAddressChainTypeMismatch(address, chain.type, chain.name)
+    ) {
       return
     }
     const addressKeyMap: AddressKeyValue = {

--- a/src/utils/addressUtils.ts
+++ b/src/utils/addressUtils.ts
@@ -6,6 +6,7 @@ import {
 } from '@ethereumjs/util'
 import { useGlobalStore } from '@/stores/globalStore'
 import { storeToRefs } from 'pinia'
+import type { ChainType } from '@/mew_api/types'
 
 const isAddress = (
   address: string,
@@ -58,4 +59,21 @@ const toChecksumAddress = (
   return toChecksumAddressWeb3(address)
 }
 
-export { isAddress, toChecksumAddress }
+/**
+ * Returns true when an address format is incompatible with a chain type —
+ * an EVM `0x` address on a BITCOIN chain, or a non-EVM address on an EVM chain.
+ * Persisting or building a wallet from such a pair yields invalid MEW API
+ * requests the backend 404s on (MEW-2043). Reuses the EVM address validator.
+ */
+const isAddressChainTypeMismatch = (
+  address: string,
+  chainType: ChainType,
+  chainName?: string,
+): boolean => {
+  const isEvmAddress = isAddress(address, chainName)
+  if (chainType === 'BITCOIN') return isEvmAddress
+  if (chainType === 'EVM') return !isEvmAddress
+  return false
+}
+
+export { isAddress, toChecksumAddress, isAddressChainTypeMismatch }

--- a/tests/unit/providers/watchOnlyWallet.spec.ts
+++ b/tests/unit/providers/watchOnlyWallet.spec.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import type { Chain, ChainType, TokenBalancesRaw } from '@/mew_api/types'
+
+// Mock the network layer so getBalance never hits the wire and we can assert
+// whether a request was issued at all.
+const fetchWithRetryMock = vi.fn()
+vi.mock('@/mew_api/fetchWithRetry', () => ({
+  fetchWithRetry: (...args: unknown[]) => fetchWithRetryMock(...args),
+}))
+
+// The analytics module transitively pulls in the hardware-wallet SDK, which is
+// unavailable in the unit-test environment. Stub it so importing the stores
+// under test does not resolve that native dependency.
+vi.mock('@/analytics', () => ({
+  analytics: {
+    setNetwork: vi.fn(),
+    setWalletStatus: vi.fn(),
+    setWalletName: vi.fn(),
+    setWalletType: vi.fn(),
+    setUserProperties: vi.fn(),
+  },
+}))
+
+import WatchOnlyWallet from '@/providers/common/watchOnlyWallet'
+import { useChainsStore } from '@/stores/chainsStore'
+import { useGlobalStore } from '@/stores/globalStore'
+import { WalletType } from '@/providers/types'
+
+const EVM_ADDRESS = '0x1234567890123456789012345678901234567890'
+const BTC_ADDRESS = 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4'
+
+const makeChain = (name: string, type: ChainType): Chain =>
+  ({ name, type, chainID: name === 'ETHEREUM' ? '1' : '0' }) as unknown as Chain
+
+const BTC_CHAIN = makeChain('BITCOIN', 'BITCOIN')
+const ETH_CHAIN = makeChain('ETHEREUM', 'EVM')
+
+const selectChain = (chain: Chain) => {
+  const chainsStore = useChainsStore()
+  const globalStore = useGlobalStore()
+  chainsStore.setChainData([BTC_CHAIN, ETH_CHAIN])
+  globalStore.setSelectedNetwork(chain.name)
+}
+
+describe('WatchOnlyWallet.getBalance address/chain-type guard (MEW-2043)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    setActivePinia(createPinia())
+    fetchWithRetryMock.mockReset()
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('does NOT issue a balance request for an EVM address paired with a BITCOIN chain', async () => {
+    selectChain(BTC_CHAIN)
+    const wallet = new WatchOnlyWallet(
+      EVM_ADDRESS,
+      BTC_CHAIN,
+      WalletType.INJECTED,
+      'BITCOIN',
+      'watch-only',
+    )
+
+    const result = await wallet.getBalance()
+
+    expect(fetchWithRetryMock).not.toHaveBeenCalled()
+    expect(result).toEqual<TokenBalancesRaw>({ result: [] })
+  })
+
+  it('does NOT issue a balance request for a bitcoin address paired with an EVM chain', async () => {
+    selectChain(ETH_CHAIN)
+    const wallet = new WatchOnlyWallet(
+      BTC_ADDRESS,
+      ETH_CHAIN,
+      WalletType.INJECTED,
+      'EVM',
+      'watch-only',
+    )
+
+    const result = await wallet.getBalance()
+
+    expect(fetchWithRetryMock).not.toHaveBeenCalled()
+    expect(result).toEqual<TokenBalancesRaw>({ result: [] })
+  })
+
+  it('DOES issue a balance request when a bitcoin address matches a BITCOIN chain', async () => {
+    selectChain(BTC_CHAIN)
+    fetchWithRetryMock.mockResolvedValue({ result: [] })
+    const wallet = new WatchOnlyWallet(
+      BTC_ADDRESS,
+      BTC_CHAIN,
+      WalletType.INJECTED,
+      'BITCOIN',
+      'watch-only',
+    )
+
+    await wallet.getBalance()
+
+    expect(fetchWithRetryMock).toHaveBeenCalledTimes(1)
+    expect(fetchWithRetryMock).toHaveBeenCalledWith(
+      expect.stringContaining(`/balances/BITCOIN/${BTC_ADDRESS}/`),
+    )
+  })
+
+  it('DOES issue a balance request when an EVM address matches an EVM chain', async () => {
+    selectChain(ETH_CHAIN)
+    fetchWithRetryMock.mockResolvedValue({ result: [] })
+    const wallet = new WatchOnlyWallet(
+      EVM_ADDRESS,
+      ETH_CHAIN,
+      WalletType.INJECTED,
+      'EVM',
+      'watch-only',
+    )
+
+    await wallet.getBalance()
+
+    expect(fetchWithRetryMock).toHaveBeenCalledTimes(1)
+    expect(fetchWithRetryMock).toHaveBeenCalledWith(
+      expect.stringContaining(`/balances/ETHEREUM/${EVM_ADDRESS}/`),
+    )
+  })
+
+  it('resolves safely (no unhandled rejection) when the balance request rejects', async () => {
+    selectChain(BTC_CHAIN)
+    fetchWithRetryMock.mockRejectedValue(new Error('Invalid Bitcoin address'))
+    const wallet = new WatchOnlyWallet(
+      BTC_ADDRESS,
+      BTC_CHAIN,
+      WalletType.INJECTED,
+      'BITCOIN',
+      'watch-only',
+    )
+
+    await expect(wallet.getBalance()).resolves.toEqual<TokenBalancesRaw>({
+      result: [],
+    })
+  })
+})

--- a/tests/unit/stores/watchOnlyStore.spec.ts
+++ b/tests/unit/stores/watchOnlyStore.spec.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import type { Chain, ChainType } from '@/mew_api/types'
+
+// addressUtils (used by the write guard) pulls in globalStore, which
+// transitively resolves the hardware-wallet SDK — unavailable under jsdom.
+// Stub it as a minimal Pinia store so `storeToRefs` still works; the guard
+// passes an explicit chain name so the selectedNetwork fallback is unused.
+vi.mock('@/stores/globalStore', async () => {
+  const { defineStore } = await import('pinia')
+  const { ref } = await import('vue')
+  return {
+    useGlobalStore: defineStore('global', () => ({
+      selectedNetwork: ref(''),
+    })),
+  }
+})
+
+const { useWatchOnlyStore } = await import('@/stores/watchOnlyStore')
+
+const EVM_ADDRESS = '0x1234567890123456789012345678901234567890'
+const BTC_ADDRESS = 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4'
+
+const makeChain = (name: string, type: ChainType): Chain =>
+  ({ name, type }) as unknown as Chain
+
+const BTC_CHAIN = makeChain('BITCOIN', 'BITCOIN')
+const ETH_CHAIN = makeChain('ETHEREUM', 'EVM')
+
+describe('watchOnlyStore.addWallet address/chain-type write guard (MEW-2043)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    setActivePinia(createPinia())
+  })
+
+  it('does NOT persist an EVM address under a BITCOIN chain', () => {
+    const store = useWatchOnlyStore()
+    store.addWallet(EVM_ADDRESS, BTC_CHAIN, 'watch-only', 'BITCOIN', 'w')
+    expect(store.watchOnlyAddresses.BITCOIN).toEqual([])
+  })
+
+  it('does NOT persist a bitcoin address under an EVM chain', () => {
+    const store = useWatchOnlyStore()
+    store.addWallet(BTC_ADDRESS, ETH_CHAIN, 'watch-only', 'EVM', 'w')
+    expect(store.watchOnlyAddresses.EVM).toEqual([])
+  })
+
+  it('persists matching address/chain-type pairs', () => {
+    const store = useWatchOnlyStore()
+    store.addWallet(EVM_ADDRESS, ETH_CHAIN, 'watch-only', 'EVM', 'w')
+    store.addWallet(BTC_ADDRESS, BTC_CHAIN, 'watch-only', 'BITCOIN', 'w')
+    expect(store.watchOnlyAddresses.EVM.map(e => e.address)).toEqual([
+      EVM_ADDRESS,
+    ])
+    expect(store.watchOnlyAddresses.BITCOIN.map(e => e.address)).toEqual([
+      BTC_ADDRESS,
+    ])
+  })
+})

--- a/tests/unit/stores/watchOnlyStore.spec.ts
+++ b/tests/unit/stores/watchOnlyStore.spec.ts
@@ -45,6 +45,15 @@ describe('watchOnlyStore.addWallet address/chain-type write guard (MEW-2043)', (
     expect(store.watchOnlyAddresses.EVM).toEqual([])
   })
 
+  it('does NOT persist when the caller type disagrees with chain.type', () => {
+    const store = useWatchOnlyStore()
+    // Address format is EVM and would match `type`, but the storage bucket key
+    // is `chain.type` (BITCOIN) — reject rather than store under the wrong one.
+    store.addWallet(EVM_ADDRESS, BTC_CHAIN, 'watch-only', 'EVM', 'w')
+    expect(store.watchOnlyAddresses.BITCOIN).toEqual([])
+    expect(store.watchOnlyAddresses.EVM).toEqual([])
+  })
+
   it('persists matching address/chain-type pairs', () => {
     const store = useWatchOnlyStore()
     store.addWallet(EVM_ADDRESS, ETH_CHAIN, 'watch-only', 'EVM', 'w')


### PR DESCRIPTION
## Summary

A watch-only wallet whose chain type is `BITCOIN` was being **built from an EVM `0x…` address** (or the reverse), so `getBalance()` issued `/balances/BITCOIN/0x…/…`. The MEW API 404s (&#34;Invalid Bitcoin address … invalid format&#34;), `fetchWithRetry` re-throws, and the rejection surfaced as an **unhandled promise rejection** (Sentry APP-MEW-WEB-1AP / -197).

This PR fixes the bug at its **origin** — how the mismatched address is persisted and rebuilt — and keeps a defensive guard on the balance request itself.

## Root cause

The bad address/chain-type pair is created and consumed across three points:

1. **Write** — `walletStore.setAddress()` is the only writer of the watch-only list. It calls `watchOnlyStore.addWallet(address, selectedChain, …, selectedChain.type, …)`, stamping the **current** `selectedChain.type` onto the wallet's address **without checking the address format matches that chain type**. When the wallet and the selected chain are momentarily out of sync, an EVM `0x…` address gets persisted (localStorage) under the `BITCOIN` bucket.
2. **Rebuild** — `walletStore.setWatchOnlyIfExist()` reads the bucket for the selected chain type and reconstructs a `WatchOnlyWallet` from the stored entry, producing a `BITCOIN`-typed wallet holding an EVM address.
3. **Request** — `WatchOnlyWallet.getBalance()` only guarded `selectedChain.type === this.chainType`. Both are `BITCOIN`, so the check passed and the invalid endpoint was built; the `fetchWithRetry` rejection had no handler.

## Fix

- **Shared predicate** — extracted `isAddressChainTypeMismatch(address, chainType, chainName)` into `@/utils/addressUtils`, reusing the existing `isAddress` EVM validator. An EVM `0x` address on a `BITCOIN` chain, or a non-EVM address on an `EVM` chain, is a mismatch. One source of truth for all three call sites below.
- **Write guard (origin)** — `watchOnlyStore.addWallet` no longer persists an entry whose address format does not match its chain type. Stops new pollution at the source.
- **Rebuild self-heal** — `walletStore.setWatchOnlyIfExist` skips stale mismatched entries when picking the wallet to rebuild, so already-polluted localStorage (prod v7.0.9) never rebuilds an invalid wallet.
- **Defensive balance guard** — `WatchOnlyWallet.getBalance()` returns the empty balance response on a mismatch (no request issued) and has a `.catch()` so any balance failure resolves to `{ result: [] }` instead of an unhandled rejection.

## Changes

- `src/utils/addressUtils.ts` — new exported `isAddressChainTypeMismatch(address, chainType, chainName?)` helper.
- `src/stores/watchOnlyStore.ts` — `addWallet` guard: skip persisting mismatched (address, chain-type) pairs.
- `src/stores/walletStore.ts` — `setWatchOnlyIfExist` filters out mismatched stored entries before rebuilding the watch-only wallet.
- `src/providers/common/watchOnlyWallet.ts` — `getBalance` uses the shared predicate (replaces the previous private method) + retains the `.catch()`.
- `tests/unit/stores/watchOnlyStore.spec.ts` (new) — write guard: EVM-on-BITCOIN and BTC-on-EVM are not persisted; matching pairs are.
- `tests/unit/providers/watchOnlyWallet.spec.ts` — `getBalance` guard: mismatched pairs issue no request and resolve to `{ result: [] }`; matching pairs issue the request; a rejecting request still resolves safely.

## Testing

- `pnpm vitest run tests/unit/stores/watchOnlyStore.spec.ts tests/unit/providers/watchOnlyWallet.spec.ts` → 8 passed.
- `pnpm vue-tsc --noEmit -p tsconfig.app.json` → clean (0 errors).

## Sentry

- APP-MEW-WEB-1AP
- APP-MEW-WEB-197 (duplicate)



## Summary by CodeRabbit

* **Bug Fixes**
  * Improved balance handling for wallets across different blockchain address formats.
  * Prevented invalid balance requests when an address does not match the selected network.
  * Balance checks now fail safely with an empty result when requests encounter errors.
* **Tests**
  * Added coverage for compatible and incompatible address/network combinations, request behavior, and error handling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved watch-only wallet balance retrieval to always return a safe empty result on errors, and to avoid requesting balances when an address doesn’t match the selected chain type.
  * Hardened watch-only address persistence and wallet rebuilding by filtering out and blocking invalid/mismatched legacy watch-only entries.
* **Tests**
  * Added/expanded unit tests to verify correct behavior for compatible vs. incompatible address/chain combinations, correct balance request URL formation, and graceful handling of balance-fetch failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->