### PR TITLE
fix: make Trezor init idempotent and guard getAddress (MEW-2042)

### DIFF
--- a/src/modules/access/ModuleAccessHardwareWallet.vue
+++ b/src/modules/access/ModuleAccessHardwareWallet.vue
@@ -118,8 +118,8 @@ import { MAIN_TOKEN_CONTRACT } from '@/stores/walletStore'
 import { useI18n } from 'vue-i18n'
 import { useDerivationStore } from '@/stores/derivationStore'
 import { storeToRefs } from 'pinia'
-import HWwallet from '@enkryptcom/hw-wallets'
 import LedgerManager from '@/providers/hw/ledger'
+import { getTrezorManager } from '@/providers/hw/trezorManager'
 import type { HWManager } from '@/providers/hw/types'
 import {
   getLedgerWebUSBTransport,
@@ -171,8 +171,13 @@ const { setSelectedNetwork: setSelectedChainGlobalStore } = globalStore
 const accessStore = useAccessStore()
 const { currentView, selectedChain, isEvmChain } = storeToRefs(accessStore)
 
+// Reuse one Trezor manager for the whole session: creating a fresh manager on
+// every connect / chain / derivation change re-ran the process-wide
+// `TrezorConnect.init()`, which threw "TrezorConnect has been already
+// initialized" and poisoned the cached provider (MEW-2042). Ledger keeps a
+// fresh manager per connection.
 const createHwManager = (): HWManager =>
-  currentView.value === 'ledger' ? new LedgerManager() : new HWwallet()
+  currentView.value === 'ledger' ? new LedgerManager() : getTrezorManager()
 
 // Wallet instance
 let hwWalletInstance: HWManager | null = createHwManager()

--- a/src/providers/hw/trezorManager.ts
+++ b/src/providers/hw/trezorManager.ts
@@ -1,0 +1,184 @@
+import HWwallet from '@enkryptcom/hw-wallets'
+import type { HWwalletType, NetworkNames } from '@enkryptcom/types'
+
+type GetAddressOptions = Parameters<HWwallet['getAddress']>[0]
+type GetAddressResult = Awaited<ReturnType<HWwallet['getAddress']>>
+type IsConnectedOptions = Parameters<HWwallet['isConnected']>[0]
+
+/**
+ * A cached Trezor network provider as held in the underlying manager's public
+ * `providers` map. `TrezorConnect` is left `undefined` when the process-wide
+ * `TrezorConnect.init()` throws (e.g. "already initialized"). Calling
+ * `getAddress` against such a provider is what produces the downstream
+ * `TypeError: ...reading 'ethereumGetPublicKey'`.
+ */
+interface TrezorProviderLike {
+  TrezorConnect?: unknown
+}
+
+/**
+ * `@trezor/connect-web` is a process-wide singleton whose `init()` throws
+ * `TrezorConnect has been already initialized` if it runs a second time. When it
+ * does throw, the underlying library still caches the (now uninitialized)
+ * provider, so a later `getAddress` dereferences `undefined`.
+ */
+export const isTrezorAlreadyInitializedError = (error: unknown): boolean => {
+  const message = error instanceof Error ? error.message : String(error ?? '')
+  return message.toLowerCase().includes('already initialized')
+}
+
+/**
+ * App-level wrapper around `@enkryptcom/hw-wallets` for Trezor.
+ *
+ * The underlying manager calls the process-wide `TrezorConnect.init()` the first
+ * time each network provider is initialized. Because the app used to create a
+ * fresh manager on every connect attempt (and per chain/derivation change), a
+ * second connect re-ran that global init and threw
+ * `TrezorConnect has been already initialized` (Sentry APP-MEW-WEB-HV); the
+ * poisoned, cached provider then made `getAddress` deref an undefined
+ * `TrezorConnect` (Sentry APP-MEW-WEB-WH).
+ *
+ * This wrapper makes init idempotent and guards the getAddress path:
+ *  - {@link init} memoizes initialization so it runs once (see also
+ *    {@link getTrezorManager}, which keeps a single manager per session);
+ *  - an "already initialized" error is treated as success;
+ *  - {@link getAddress} recovers any provider left uninitialized before
+ *    delegating, so it never dereferences an undefined `TrezorConnect`.
+ */
+export class TrezorManager extends HWwallet {
+  private isInitialized = false
+  private initPromise: Promise<boolean> | null = null
+
+  /**
+   * Idempotent, memoized initialization. The first call drives the underlying
+   * manager's per-network init (which triggers the single process-wide
+   * `TrezorConnect.init()`); subsequent calls are a no-op success. An
+   * "already initialized" error is treated as success.
+   */
+  async init(
+    wallet: HWwalletType,
+    networkName: NetworkNames,
+  ): Promise<boolean> {
+    if (this.isInitialized) return true
+    if (!this.initPromise) {
+      this.initPromise = this.performInit(wallet, networkName).then(
+        result => {
+          this.isInitialized = true
+          return result
+        },
+        error => {
+          // Allow a retry after a genuine (non "already initialized") failure.
+          this.initPromise = null
+          throw error
+        },
+      )
+    }
+    return this.initPromise
+  }
+
+  private async performInit(
+    wallet: HWwalletType,
+    networkName: NetworkNames,
+  ): Promise<boolean> {
+    try {
+      // `isConnected` drives the underlying manager's internal init for this
+      // network, which is where `TrezorConnect.init()` is invoked.
+      await super.isConnected({ wallet, networkName })
+    } catch (error) {
+      if (!isTrezorAlreadyInitializedError(error)) throw error
+      // The global TrezorConnect is already up; recover any poisoned provider.
+      this.recoverUninitializedProviders()
+    }
+    return true
+  }
+
+  override async isConnected(options: IsConnectedOptions): Promise<boolean> {
+    try {
+      return await super.isConnected(options)
+    } catch (error) {
+      if (isTrezorAlreadyInitializedError(error)) {
+        this.recoverUninitializedProviders()
+        return true
+      }
+      throw error
+    }
+  }
+
+  override async getAddress(
+    options: GetAddressOptions,
+  ): Promise<GetAddressResult> {
+    // Guard: ensure init ran once so we never reach `getAddress` before the
+    // underlying `TrezorConnect` exists.
+    if (!this.isInitialized) {
+      await this.init(options.wallet, options.networkName)
+    }
+    // Guard: repair any provider whose init failed and left `TrezorConnect`
+    // unset before delegating, so we never deref `undefined`.
+    this.recoverUninitializedProviders()
+    try {
+      return await super.getAddress(options)
+    } catch (error) {
+      if (isTrezorAlreadyInitializedError(error)) {
+        this.recoverUninitializedProviders()
+        return super.getAddress(options)
+      }
+      throw error
+    }
+  }
+
+  /**
+   * Repairs providers whose init failed (their `TrezorConnect` is unset) by
+   * reusing the already-initialized `TrezorConnect` from a healthy sibling
+   * provider. When none exists, the poisoned entry is dropped so the next call
+   * re-initializes it rather than dereferencing `undefined`.
+   */
+  private recoverUninitializedProviders(): void {
+    const providers = this.providers as
+      | Record<string, TrezorProviderLike | undefined>
+      | undefined
+    if (!providers) return
+    const healthy = this.findInitializedTrezorConnect(providers)
+    for (const key of Object.keys(providers)) {
+      const provider = providers[key]
+      if (provider && 'TrezorConnect' in provider && !provider.TrezorConnect) {
+        if (healthy) {
+          provider.TrezorConnect = healthy
+        } else {
+          delete providers[key]
+        }
+      }
+    }
+  }
+
+  private findInitializedTrezorConnect(
+    providers: Record<string, TrezorProviderLike | undefined>,
+  ): unknown {
+    for (const key of Object.keys(providers)) {
+      const provider = providers[key]
+      if (provider && 'TrezorConnect' in provider && provider.TrezorConnect) {
+        return provider.TrezorConnect
+      }
+    }
+    return null
+  }
+}
+
+let trezorManagerSingleton: TrezorManager | null = null
+
+/**
+ * Returns the process-wide Trezor manager, creating it once. Reusing a single
+ * manager keeps the underlying provider cache warm so `TrezorConnect.init()`
+ * runs only once per session — a second connect attempt no longer throws
+ * `TrezorConnect has been already initialized`.
+ */
+export const getTrezorManager = (): TrezorManager => {
+  if (!trezorManagerSingleton) {
+    trezorManagerSingleton = new TrezorManager()
+  }
+  return trezorManagerSingleton
+}
+
+/** Test-only: reset the module-level singleton between test cases. */
+export const resetTrezorManager = (): void => {
+  trezorManagerSingleton = null
+}

--- a/tests/unit/providers/trezorManager.spec.ts
+++ b/tests/unit/providers/trezorManager.spec.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { HWwalletType, NetworkNames } from '@enkryptcom/types'
+
+/**
+ * Regression tests for MEW-2042.
+ *
+ * We mock the underlying `@enkryptcom/hw-wallets` manager so the wrapper's
+ * init-once + uninitialized-getAddress guards can be exercised in isolation
+ * (the real manager lazily imports `@trezor/connect-web` and talks to a device).
+ * The fake base class exposes `isConnected` / `getAddress` on its prototype so
+ * the wrapper's `super.*` calls resolve to them, and a public `providers` map
+ * matching the real manager.
+ */
+const { fakeIsConnected, fakeGetAddress } = vi.hoisted(() => ({
+  fakeIsConnected: vi.fn(),
+  fakeGetAddress: vi.fn(),
+}))
+
+vi.mock('@enkryptcom/hw-wallets', () => {
+  class FakeHWwalletManager {
+    providers: Record<string, unknown> = {}
+    isConnected(options: unknown): Promise<boolean> {
+      return fakeIsConnected(options)
+    }
+    getAddress(options: unknown): Promise<unknown> {
+      return fakeGetAddress(options)
+    }
+  }
+  return { default: FakeHWwalletManager }
+})
+
+// Imported after the mock is registered (vi.mock is hoisted above imports).
+import {
+  TrezorManager,
+  getTrezorManager,
+  resetTrezorManager,
+  isTrezorAlreadyInitializedError,
+} from '@/providers/hw/trezorManager'
+
+const TREZOR = 'trezor' as HWwalletType
+const ETH = 'ETH' as NetworkNames
+const MATIC = 'MATIC' as NetworkNames
+
+const addressResponse = { address: '0xabc', publicKey: '0x01' }
+const getAddressOptions = {
+  confirmAddress: false,
+  networkName: ETH,
+  pathType: { path: "m/44'/60'/0'/0/{index}", basePath: "m/44'/60'/0'/0" },
+  pathIndex: '0',
+  wallet: TREZOR,
+}
+
+const ALREADY_INITIALIZED = 'TrezorConnect has been already initialized'
+
+beforeEach(() => {
+  fakeIsConnected.mockReset()
+  fakeGetAddress.mockReset()
+  resetTrezorManager()
+})
+
+describe('isTrezorAlreadyInitializedError', () => {
+  it('matches the Trezor re-init error message (case-insensitive)', () => {
+    expect(
+      isTrezorAlreadyInitializedError(new Error(ALREADY_INITIALIZED)),
+    ).toBe(true)
+    expect(
+      isTrezorAlreadyInitializedError(new Error('Already Initialized')),
+    ).toBe(true)
+  })
+
+  it('does not match unrelated errors or non-error inputs', () => {
+    expect(
+      isTrezorAlreadyInitializedError(new Error('device disconnected')),
+    ).toBe(false)
+    expect(isTrezorAlreadyInitializedError(null)).toBe(false)
+    expect(isTrezorAlreadyInitializedError(undefined)).toBe(false)
+  })
+})
+
+describe('getTrezorManager', () => {
+  it('returns the same instance across calls (init runs once)', () => {
+    const a = getTrezorManager()
+    const b = getTrezorManager()
+    expect(a).toBe(b)
+  })
+
+  it('creates a fresh instance after reset', () => {
+    const a = getTrezorManager()
+    resetTrezorManager()
+    const b = getTrezorManager()
+    expect(a).not.toBe(b)
+  })
+})
+
+describe('TrezorManager.init', () => {
+  it('initializes only once when called twice (2nd is a no-op success)', async () => {
+    fakeIsConnected.mockResolvedValue(true)
+    const manager = new TrezorManager()
+
+    await expect(manager.init(TREZOR, ETH)).resolves.toBe(true)
+    await expect(manager.init(TREZOR, ETH)).resolves.toBe(true)
+
+    expect(fakeIsConnected).toHaveBeenCalledTimes(1)
+  })
+
+  it('treats "already initialized" as a successful init instead of throwing', async () => {
+    fakeIsConnected.mockRejectedValueOnce(new Error(ALREADY_INITIALIZED))
+    const manager = new TrezorManager()
+
+    await expect(manager.init(TREZOR, ETH)).resolves.toBe(true)
+  })
+
+  it('rethrows genuine (non re-init) failures and allows a retry', async () => {
+    fakeIsConnected
+      .mockRejectedValueOnce(new Error('device disconnected'))
+      .mockResolvedValueOnce(true)
+    const manager = new TrezorManager()
+
+    await expect(manager.init(TREZOR, ETH)).rejects.toThrow(
+      'device disconnected',
+    )
+    // The failed init must not be memoized — a retry should re-run isConnected.
+    await expect(manager.init(TREZOR, ETH)).resolves.toBe(true)
+    expect(fakeIsConnected).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('TrezorManager.getAddress', () => {
+  it('drives init before delegating when not initialized (guarded, no undefined deref)', async () => {
+    fakeIsConnected.mockResolvedValue(true)
+    fakeGetAddress.mockResolvedValue(addressResponse)
+    const manager = new TrezorManager()
+
+    const result = await manager.getAddress(getAddressOptions)
+
+    expect(result).toEqual(addressResponse)
+    expect(fakeIsConnected).toHaveBeenCalledTimes(1)
+    expect(fakeGetAddress).toHaveBeenCalledTimes(1)
+  })
+
+  it('drops a poisoned provider (TrezorConnect unset) so it never derefs undefined', async () => {
+    fakeIsConnected.mockResolvedValue(true)
+    fakeGetAddress.mockResolvedValue(addressResponse)
+    const manager = new TrezorManager()
+    // Simulate the library caching a provider whose init failed.
+    ;(manager.providers as Record<string, unknown>)[ETH] = {
+      TrezorConnect: undefined,
+    }
+
+    const result = await manager.getAddress(getAddressOptions)
+
+    expect(result).toEqual(addressResponse)
+    // No healthy sibling to repair from -> the poisoned entry is dropped.
+    expect((manager.providers as Record<string, unknown>)[ETH]).toBeUndefined()
+  })
+
+  it('repairs a poisoned provider by reusing a healthy sibling TrezorConnect', async () => {
+    fakeIsConnected.mockResolvedValue(true)
+    fakeGetAddress.mockResolvedValue(addressResponse)
+    const manager = new TrezorManager()
+    const healthyTrezorConnect = { ethereumGetPublicKey: vi.fn() }
+    const providers = manager.providers as Record<string, unknown>
+    providers[ETH] = { TrezorConnect: healthyTrezorConnect }
+    providers[MATIC] = { TrezorConnect: undefined }
+
+    await manager.getAddress({ ...getAddressOptions, networkName: MATIC })
+
+    // The poisoned MATIC provider is repaired, not dropped.
+    expect((providers[MATIC] as { TrezorConnect: unknown }).TrezorConnect).toBe(
+      healthyTrezorConnect,
+    )
+  })
+
+  it('recovers when getAddress itself throws "already initialized" and retries', async () => {
+    fakeIsConnected.mockResolvedValue(true)
+    const manager = new TrezorManager()
+    const healthyTrezorConnect = { ethereumGetPublicKey: vi.fn() }
+    const providers = manager.providers as Record<string, unknown>
+    providers[ETH] = { TrezorConnect: healthyTrezorConnect }
+
+    fakeGetAddress
+      .mockRejectedValueOnce(new Error(ALREADY_INITIALIZED))
+      .mockResolvedValueOnce(addressResponse)
+
+    const result = await manager.getAddress(getAddressOptions)
+
+    expect(result).toEqual(addressResponse)
+    expect(fakeGetAddress).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
## Summary

Connecting a Trezor a second time in the same session threw `Error: TrezorConnect has been already initialized`, and the failed init left the cached provider without a `TrezorConnect` reference, so the next `getAddress` crashed with `TypeError: ...reading 'ethereumGetPublicKey'`. This makes Trezor initialization idempotent and guards the `getAddress` path so it never dereferences an uninitialized `TrezorConnect`.

## Root cause

`@enkryptcom/hw-wallets` lazily calls the process-wide `TrezorConnect.init()` the first time each network provider is initialized. `@trezor/connect-web` is a global singleton whose `init()` throws if it runs a second time.

The access flow created a **brand-new** `HWwallet` manager on every connect attempt (and on each chain / derivation-path change), and nulled it after accessing a wallet. Each fresh manager had an empty provider cache, so a second connect re-ran the global `TrezorConnect.init()`:

- `TrezorConnect.init()` threw `already initialized` (Sentry APP-MEW-WEB-HV).
- The library still cached the provider (assigned before the awaited `init()`), but with `TrezorConnect` left `undefined`. The next `getAddress` on that poisoned provider dereferenced `undefined` -> `reading 'ethereumGetPublicKey'` (Sentry APP-MEW-WEB-WH, downstream).

## Changes

- **New `src/providers/hw/trezorManager.ts`** — an app-level `TrezorManager extends HWwallet`:
  - `init()` is memoized so initialization runs once; an `already initialized` error is treated as success.
  - `getAddress()` ensures init has run and recovers any provider whose init failed (its `TrezorConnect` is unset) before delegating, reusing the already-initialized `TrezorConnect` from a healthy sibling provider (or dropping the poisoned entry so it re-initializes) — so it never derefs `undefined`.
  - `isConnected()` treats `already initialized` as connected.
  - `getTrezorManager()` returns a **process-wide singleton**, keeping the provider cache warm so a second connect reuses the initialized manager instead of re-running the global init.
- **`src/modules/access/ModuleAccessHardwareWallet.vue`** — `createHwManager()` now returns the shared `getTrezorManager()` for Trezor (Ledger unchanged, still a fresh manager per connection).

Scope is limited to the re-init singleton guard + uninitialized-getAddress guard. The separate iOS `chrome` ReferenceError is out of scope.

## Testing

- `pnpm vitest run tests/unit/providers/trezorManager.spec.ts` — 11 passed (init-once, `already initialized` -> success, genuine failures rethrow + retry, getAddress guards/recovery, singleton identity). Verified the guard tests fail against an unguarded wrapper.
- `pnpm vue-tsc --noEmit -p tsconfig.app.json` — clean, zero errors.

## Sentry

- APP-MEW-WEB-HV — `TrezorConnect has been already initialized`
- APP-MEW-WEB-WH — `TypeError: ...reading 'ethereumGetPublicKey'` (downstream of the failed re-init)

🤖 Generated with [Claude Code](https://claude.com/claude-code)