### PR TITLE
[MEW-2047] fix: localize AppSearchInput placeholder default

### DIFF
--- a/src/components/AppSearchInput.vue
+++ b/src/components/AppSearchInput.vue
@@ -18,8 +18,8 @@
         size === 'compact' ? 'pl-10 text-[15px]' : 'pl-[46px] text-[17px]',
         bgClass,
       ]"
-      :aria-label="placeholder"
-      :placeholder="placeholder"
+      :aria-label="placeholder || $t('common.search')"
+      :placeholder="placeholder || $t('common.search')"
       @focus="inFocusInput = true"
       @blur="inFocusInput = false"
     />
@@ -60,10 +60,11 @@ import { XCircleIcon } from '@heroicons/vue/24/outline'
 defineProps({
   /**
    * @placeholder The placeholder text of the input field. Also used as the aria label.
+   * When empty, falls back to the localized `common.search` string.
    */
   placeholder: {
     type: String,
-    default: 'Search',
+    default: '',
   },
   /**
    * @bgClass The background color of the input field.

--- a/tests/unit/components/AppSearchInput.spec.ts
+++ b/tests/unit/components/AppSearchInput.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { shallowMount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import AppSearchInput from '@/components/AppSearchInput.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  fallbackLocale: 'en',
+  messages: {
+    en: { common: { search: 'Search', clear_icon: 'Clear' } },
+    zh: { common: { search: '搜索', clear_icon: '清除' } },
+  },
+})
+
+const mountInput = (props: Record<string, unknown> = {}) =>
+  shallowMount(AppSearchInput, {
+    props,
+    global: { plugins: [i18n] },
+  })
+
+describe('AppSearchInput placeholder localization (MEW-2047)', () => {
+  it('falls back to the localized common.search when no placeholder is passed (en)', () => {
+    i18n.global.locale.value = 'en'
+    const input = mountInput().find('input')
+    expect(input.attributes('placeholder')).toBe('Search')
+  })
+
+  it('localizes the default placeholder when the locale changes (zh)', () => {
+    i18n.global.locale.value = 'zh'
+    const input = mountInput().find('input')
+    // Regression guard: before the fix the hardcoded default 'Search' leaked here.
+    expect(input.attributes('placeholder')).toBe('搜索')
+  })
+
+  it('uses an explicit placeholder prop verbatim, overriding the default', () => {
+    i18n.global.locale.value = 'zh'
+    const input = mountInput({ placeholder: 'Custom placeholder' }).find('input')
+    expect(input.attributes('placeholder')).toBe('Custom placeholder')
+  })
+
+  it('mirrors the resolved placeholder onto aria-label', () => {
+    i18n.global.locale.value = 'zh'
+    const input = mountInput().find('input')
+    expect(input.attributes('aria-label')).toBe('搜索')
+  })
+})


### PR DESCRIPTION
## Summary

The `AppSearchInput` `placeholder` prop defaulted to the hardcoded English literal `'Search'`, so any caller that omits `:placeholder` rendered an untranslated `Search` regardless of the active locale. This was visible in the **Connect Wallet** dialog's wallet search (reported) and also in the **Stocks list** search — both omit the prop.

## Fix

- `src/components/AppSearchInput.vue`: default the `placeholder` prop to `''` and fall back to `$t('common.search')` for both `:placeholder` and `:aria-label`. The `common.search` key already exists (`= "Search"`), so English is unchanged and all other locales now localize correctly.
- Callers that pass an explicit `:placeholder` are unaffected (their value overrides the fallback).

## Tests

- Adds `tests/unit/components/AppSearchInput.spec.ts` (the repo's first component-mount spec): localized fallback in English, localized fallback in a non-English locale (regression guard against the hardcoded default), explicit-override, and aria-label mirroring. **4/4 passing.**
- `vue-tsc --noEmit` → 0 errors · `eslint` → 0 errors.

## Out of scope

`TableTokenBalance.vue` passes a hardcoded literal `placeholder="table options"` (supplies an explicit value, so unaffected by this change). Logged as a follow-up.

## Testing

1. Switch the app language to a non-English locale (Settings → language dropdown).
2. Open **Connect Wallet** → the wallet-grid search placeholder is translated (no longer `Search`).
3. In English the placeholder still reads `Search` (no regression).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Search inputs now use localized labels and placeholders, including support for language changes.

* **Bug Fixes**
  * Fixed the default search text so it no longer remains hardcoded in English.
  * Explicit placeholder text continues to override the localized default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->