### PR TITLE
[MEW-2034] fix: localize Earn page email subscription error messages

### DIFF
--- a/src/composables/useEmailSubscription.ts
+++ b/src/composables/useEmailSubscription.ts
@@ -1,4 +1,4 @@
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { watchDebounced } from '@vueuse/core'
 import { useToastStore } from '@/stores/toastStore'
@@ -12,20 +12,26 @@ export const useEmailSubscription = () => {
 
   const email = ref('')
   const isValidEmail = ref<boolean>(true)
-  const emailErrorMessage = ref<string | undefined>(undefined)
+  // Store the i18n key (not the resolved string) so the message re-translates
+  // reactively when the locale changes — resolving with t() into a plain ref
+  // would freeze the message in whatever locale was active at validation time.
+  const emailErrorKey = ref<string | undefined>(undefined)
+  const emailErrorMessage = computed(() =>
+    emailErrorKey.value ? t(emailErrorKey.value) : undefined,
+  )
 
   // Valid Email:
   const validateEmail = () => {
     isValidEmail.value = true
     if (email.value === '' || email.value === undefined) {
-      emailErrorMessage.value = t('common.subscribe.email_required')
+      emailErrorKey.value = 'common.subscribe.email_required'
       isValidEmail.value = false
     } else {
       const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
       isValidEmail.value = emailRegex.test(email.value)
-      emailErrorMessage.value = isValidEmail.value
+      emailErrorKey.value = isValidEmail.value
         ? undefined
-        : t('common.subscribe.email_invalid')
+        : 'common.subscribe.email_invalid'
     }
   }
   const isLoading = ref(false)

--- a/src/composables/useEmailSubscription.ts
+++ b/src/composables/useEmailSubscription.ts
@@ -1,4 +1,5 @@
 import { ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { watchDebounced } from '@vueuse/core'
 import { useToastStore } from '@/stores/toastStore'
 import { ToastType } from '@/types/notification'
@@ -6,6 +7,7 @@ import Configs from '@/configs'
 import { captureException } from '@sentry/vue'
 
 export const useEmailSubscription = () => {
+  const { t } = useI18n()
   const toastStore = useToastStore()
 
   const email = ref('')
@@ -16,14 +18,14 @@ export const useEmailSubscription = () => {
   const validateEmail = () => {
     isValidEmail.value = true
     if (email.value === '' || email.value === undefined) {
-      emailErrorMessage.value = 'email required'
+      emailErrorMessage.value = t('common.subscribe.email_required')
       isValidEmail.value = false
     } else {
       const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
       isValidEmail.value = emailRegex.test(email.value)
       emailErrorMessage.value = isValidEmail.value
         ? undefined
-        : 'Email address is not valid'
+        : t('common.subscribe.email_invalid')
     }
   }
   const isLoading = ref(false)

--- a/src/i18n/locales/common/en.json
+++ b/src/i18n/locales/common/en.json
@@ -164,7 +164,9 @@
     "subscribe": {
       "cta": "Level up your skills with security tips, industry insights, news and more!",
       "button": "Sign me up!",
-      "email_placeholder": "Enter your email"
+      "email_placeholder": "Enter your email",
+      "email_required": "email required",
+      "email_invalid": "Email address is not valid"
     },
     "chart_1d": "1d",
     "chart_7d": "7d",

--- a/src/i18n/locales/common/es.json
+++ b/src/i18n/locales/common/es.json
@@ -164,7 +164,9 @@
     "subscribe": {
       "cta": "¡Mejora tus habilidades con consejos de seguridad, perspectivas del sector, noticias y mucho más!",
       "button": "¡Suscríbeme!",
-      "email_placeholder": "Ingresa tu correo electrónico"
+      "email_placeholder": "Ingresa tu correo electrónico",
+      "email_required": "Correo electrónico obligatorio",
+      "email_invalid": "La dirección de correo electrónico no es válida"
     },
     "chart_1d": "1d",
     "chart_7d": "7d",

--- a/src/i18n/locales/common/zh.json
+++ b/src/i18n/locales/common/zh.json
@@ -164,7 +164,9 @@
     "subscribe": {
       "cta": "通过安全提示、行业洞察、新闻等内容提升您的技能！",
       "button": "立即订阅！",
-      "email_placeholder": "请输入您的邮箱"
+      "email_placeholder": "请输入您的邮箱",
+      "email_required": "请输入您的邮箱",
+      "email_invalid": "邮箱地址无效"
     },
     "chart_1d": "1天",
     "chart_7d": "7天",

--- a/tests/unit/composables/useEmailSubscription.spec.ts
+++ b/tests/unit/composables/useEmailSubscription.spec.ts
@@ -1,0 +1,45 @@
+// tests/unit/composables/useEmailSubscription.spec.ts
+import { describe, it, expect, vi } from 'vitest'
+
+// t() echoes the key so we can assert the inline validation messages route
+// through vue-i18n instead of emitting hardcoded English (MEW-2034).
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('@/stores/toastStore', () => ({
+  useToastStore: () => ({ addToastMessage: vi.fn() }),
+}))
+
+import { useEmailSubscription } from '@/composables/useEmailSubscription'
+
+describe('useEmailSubscription (MEW-2034 i18n)', () => {
+  describe('validateEmail', () => {
+    it('uses the i18n key when the email is empty', () => {
+      const { email, validateEmail, isValidEmail, emailErrorMessage } =
+        useEmailSubscription()
+      email.value = ''
+      validateEmail()
+      expect(isValidEmail.value).toBe(false)
+      expect(emailErrorMessage.value).toBe('common.subscribe.email_required')
+    })
+
+    it('uses the i18n key when the email is invalid', () => {
+      const { email, validateEmail, isValidEmail, emailErrorMessage } =
+        useEmailSubscription()
+      email.value = 'not-an-email'
+      validateEmail()
+      expect(isValidEmail.value).toBe(false)
+      expect(emailErrorMessage.value).toBe('common.subscribe.email_invalid')
+    })
+
+    it('clears the error for a valid email', () => {
+      const { email, validateEmail, isValidEmail, emailErrorMessage } =
+        useEmailSubscription()
+      email.value = 'user@example.com'
+      validateEmail()
+      expect(isValidEmail.value).toBe(true)
+      expect(emailErrorMessage.value).toBeUndefined()
+    })
+  })
+})

--- a/tests/unit/composables/useEmailSubscription.spec.ts
+++ b/tests/unit/composables/useEmailSubscription.spec.ts
@@ -1,45 +1,100 @@
 // tests/unit/composables/useEmailSubscription.spec.ts
 import { describe, it, expect, vi } from 'vitest'
+import { defineComponent, nextTick } from 'vue'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
 
-// t() echoes the key so we can assert the inline validation messages route
-// through vue-i18n instead of emitting hardcoded English (MEW-2034).
-vi.mock('vue-i18n', () => ({
-  useI18n: () => ({ t: (key: string) => key }),
-}))
-
+// The composable only needs the toast store / Sentry for subscribeToUpdates;
+// the inline-validation path (the MEW-2034 fix) does not, so stub them out and
+// exercise the real vue-i18n so locale reactivity is genuinely covered.
 vi.mock('@/stores/toastStore', () => ({
   useToastStore: () => ({ addToastMessage: vi.fn() }),
 }))
+vi.mock('@sentry/vue', () => ({ captureException: vi.fn() }))
 
 import { useEmailSubscription } from '@/composables/useEmailSubscription'
 
+const messages = {
+  en: {
+    common: {
+      subscribe: {
+        email_required: 'email required',
+        email_invalid: 'Email address is not valid',
+      },
+    },
+  },
+  es: {
+    common: {
+      subscribe: {
+        email_required: 'Correo electrónico obligatorio',
+        email_invalid: 'La dirección de correo electrónico no es válida',
+      },
+    },
+  },
+}
+
+const mountComposable = () => {
+  const i18n = createI18n({
+    legacy: false,
+    locale: 'en',
+    fallbackLocale: 'en',
+    messages,
+  })
+  let api!: ReturnType<typeof useEmailSubscription>
+  const Comp = defineComponent({
+    setup() {
+      api = useEmailSubscription()
+      return () => null
+    },
+  })
+  mount(Comp, { global: { plugins: [i18n] } })
+  return { api, i18n }
+}
+
 describe('useEmailSubscription (MEW-2034 i18n)', () => {
-  describe('validateEmail', () => {
-    it('uses the i18n key when the email is empty', () => {
-      const { email, validateEmail, isValidEmail, emailErrorMessage } =
-        useEmailSubscription()
-      email.value = ''
-      validateEmail()
-      expect(isValidEmail.value).toBe(false)
-      expect(emailErrorMessage.value).toBe('common.subscribe.email_required')
-    })
+  it('resolves the empty-email error from the active locale', () => {
+    const { api } = mountComposable()
+    api.email.value = ''
+    api.validateEmail()
+    expect(api.isValidEmail.value).toBe(false)
+    expect(api.emailErrorMessage.value).toBe('email required')
+  })
 
-    it('uses the i18n key when the email is invalid', () => {
-      const { email, validateEmail, isValidEmail, emailErrorMessage } =
-        useEmailSubscription()
-      email.value = 'not-an-email'
-      validateEmail()
-      expect(isValidEmail.value).toBe(false)
-      expect(emailErrorMessage.value).toBe('common.subscribe.email_invalid')
-    })
+  it('resolves the invalid-email error from the active locale', () => {
+    const { api } = mountComposable()
+    api.email.value = 'not-an-email'
+    api.validateEmail()
+    expect(api.isValidEmail.value).toBe(false)
+    expect(api.emailErrorMessage.value).toBe('Email address is not valid')
+  })
 
-    it('clears the error for a valid email', () => {
-      const { email, validateEmail, isValidEmail, emailErrorMessage } =
-        useEmailSubscription()
-      email.value = 'user@example.com'
-      validateEmail()
-      expect(isValidEmail.value).toBe(true)
-      expect(emailErrorMessage.value).toBeUndefined()
-    })
+  it('clears the error for a valid email', () => {
+    const { api } = mountComposable()
+    api.email.value = 'user@example.com'
+    api.validateEmail()
+    expect(api.isValidEmail.value).toBe(true)
+    expect(api.emailErrorMessage.value).toBeUndefined()
+  })
+
+  it('re-translates the already-visible error when the locale changes', async () => {
+    const { api, i18n } = mountComposable()
+    api.email.value = ''
+    api.validateEmail()
+    expect(api.emailErrorMessage.value).toBe('email required')
+    // Simulate the language dropdown switching locale while the error is shown.
+    i18n.global.locale.value = 'es'
+    await nextTick()
+    expect(api.emailErrorMessage.value).toBe('Correo electrónico obligatorio')
+  })
+
+  it('resolves the invalid-email error in the switched locale', async () => {
+    const { api, i18n } = mountComposable()
+    i18n.global.locale.value = 'es'
+    api.email.value = 'nope'
+    api.validateEmail()
+    await nextTick()
+    expect(api.emailErrorMessage.value).toBe(
+      'La dirección de correo electrónico no es válida',
+    )
   })
 })


### PR DESCRIPTION
## Summary

The inline validation error shown **below the email input on the Earn page** (`/earn` → `ViewTemp.vue` → `AppSubscribeToUpdates`) was hardcoded in English and did not respond to the language selector.

## Changes

- Route the two inline validation messages in `useEmailSubscription.ts` through `vue-i18n` — `common.subscribe.email_required` and `common.subscribe.email_invalid`.
- Expose `emailErrorMessage` as a `computed` over an error-key ref so it **re-translates reactively** when the locale changes. Resolving `t()` into a plain `ref` froze the message in whatever locale was active at validation time (this was why the error stayed English after switching language).
- Add the new keys to every bundled locale: `en`, `es`, `zh`. Previously only `en.json` had them, so other locales fell back to the English source.

## Out of scope

- The three subscribe **toast** strings (`Thank you for subscribing!`, `Something went wrong`, `Please try again later.`) are intentionally left in English and will be localized in a separate follow-up PR.

## Testing

- New spec `tests/unit/composables/useEmailSubscription.spec.ts` (5 tests): key resolution in `en`/`es`, error clearing on a valid email, and **locale-switch reactivity** of an already-visible error.
- `pnpm vitest run` green · `pnpm vue-tsc --noEmit -p tsconfig.app.json` clean · `eslint` clean.
- Manual smoke on `/earn`: switching language now translates the inline error for both the empty and the invalid-email cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized email placeholder and validation messages in English, Spanish, and Chinese.
  * Email validation errors now update automatically when the application language changes.

* **Bug Fixes**
  * Improved handling of required and invalid email messages to ensure they display in the active locale.

* **Tests**
  * Added coverage for email validation, error clearing, and locale switching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->