### PR TITLE
feat: [MEW-1918] add Perps Withdraw Amplitude events

### DIFF
--- a/src/analytics/amplitude.ts
+++ b/src/analytics/amplitude.ts
@@ -53,6 +53,11 @@ import type {
   PerpsDepositEvent,
   PerpsDepositPayload,
   PerpsDepositErrorPayload,
+  PerpsWithdrawEvent,
+  PerpsWithdrawPayload,
+  PerpsWithdrawErrorPayload,
+  PerpsWithdrawAuthorizeEvent,
+  PerpsWithdrawAuthorizeErrorPayload,
   PerpsTradeOrderEvent,
   PerpsTradeOrderPayload,
   PerpsTradeOrderFailPayload,
@@ -763,6 +768,43 @@ export class Analytics {
   readonly trackPerpsDepositErrorEvent = (
     event: typeof PerpsDepositEvent.ERROR,
     payload: PerpsDepositErrorPayload,
+  ): Promise<void> => {
+    return this._track(event, { ...payload })
+  }
+
+  // =============================================================================
+  // PERPS WITHDRAW
+  // =============================================================================
+
+  readonly trackPerpsWithdrawEvent = (
+    event: PerpsWithdrawEvent,
+    payload?: PerpsWithdrawPayload,
+  ): Promise<void> => {
+    return this._track(event, { ...payload })
+  }
+
+  readonly trackPerpsWithdrawErrorEvent = (
+    event: typeof PerpsWithdrawEvent.ERROR,
+    payload: PerpsWithdrawErrorPayload,
+  ): Promise<void> => {
+    return this._track(event, { ...payload })
+  }
+
+  // =============================================================================
+  // PERPS WITHDRAW AUTHORIZE
+  // =============================================================================
+
+  readonly trackPerpsWithdrawAuthorizeEvent = (
+    event:
+      | typeof PerpsWithdrawAuthorizeEvent.SUBMIT
+      | typeof PerpsWithdrawAuthorizeEvent.SUCCESS,
+  ): Promise<void> => {
+    return this._track(event, {})
+  }
+
+  readonly trackPerpsWithdrawAuthorizeErrorEvent = (
+    event: typeof PerpsWithdrawAuthorizeEvent.ERROR,
+    payload: PerpsWithdrawAuthorizeErrorPayload,
   ): Promise<void> => {
     return this._track(event, { ...payload })
   }

--- a/src/analytics/events.ts
+++ b/src/analytics/events.ts
@@ -279,6 +279,45 @@ export type PerpsDepositErrorPayload = PerpsDepositPayload & {
 }
 
 // =============================================================================
+// PERPS WITHDRAW
+// =============================================================================
+
+export const PerpsWithdrawEvent = {
+  CLICKED: 'Perps_Withdraw_Clicked',
+  SUBMIT: 'Perps_Withdraw_Submit',
+  SUCCESS: 'Perps_Withdraw_Success',
+  ERROR: 'Perps_Withdraw_Error',
+  COMPLETED: 'Perps_Withdraw_Completed',
+} as const
+export type PerpsWithdrawEvent =
+  (typeof PerpsWithdrawEvent)[keyof typeof PerpsWithdrawEvent]
+
+export type PerpsWithdrawPayload = {
+  withdrawAmount?: string
+  token?: string
+}
+
+export type PerpsWithdrawErrorPayload = PerpsWithdrawPayload & {
+  errorMessage: string
+}
+
+// =============================================================================
+// PERPS WITHDRAW AUTHORIZE
+// =============================================================================
+
+export const PerpsWithdrawAuthorizeEvent = {
+  SUBMIT: 'Perps_Withdraw_Authorize_Submit',
+  SUCCESS: 'Perps_Withdraw_Authorize_Success',
+  ERROR: 'Perps_Withdraw_Authorize_Error',
+} as const
+export type PerpsWithdrawAuthorizeEvent =
+  (typeof PerpsWithdrawAuthorizeEvent)[keyof typeof PerpsWithdrawAuthorizeEvent]
+
+export type PerpsWithdrawAuthorizeErrorPayload = {
+  errorMessage: string
+}
+
+// =============================================================================
 // PERPS TRADE ORDER
 // =============================================================================
 

--- a/src/i18n/locales/perps/en.json
+++ b/src/i18n/locales/perps/en.json
@@ -279,7 +279,8 @@
       "amount-too-large": "Amount is too large",
       "amount-precision": "Amount supports up to {decimals} decimal places",
       "amount-exceeds-balance": "Amount exceeds available balance",
-      "withdrawal-failed": "Withdrawal failed"
+      "withdrawal-failed": "Withdrawal failed",
+      "authorize-failed": "Failed to authorize withdrawal address"
     },
     "market-list": {
       "title": "Perpetuals Markets",

--- a/src/modules/perps/components/PerpsWithdrawDialog.vue
+++ b/src/modules/perps/components/PerpsWithdrawDialog.vue
@@ -139,6 +139,11 @@ import { captureException } from '@sentry/vue'
 import { SENTRY_MODULE_TAGS } from '@/sentry/constants'
 import { useI18n } from 'vue-i18n'
 import { toChecksumAddress } from '@/utils/addressUtils'
+import {
+  analytics,
+  PerpsWithdrawEvent,
+  PerpsWithdrawAuthorizeEvent,
+} from '@/analytics'
 
 const { t } = useI18n()
 
@@ -247,6 +252,7 @@ watch(
   () => props.visible,
   async visible => {
     if (!visible) return
+    analytics.trackPerpsWithdrawEvent(PerpsWithdrawEvent.CLICKED)
     amount.value = null
     amountError.value = ''
     error.value = null
@@ -279,6 +285,7 @@ async function submitAuthorize() {
   if (!walletAddress.value || !wallet.value) return
   authorizing.value = true
   error.value = null
+  analytics.trackPerpsWithdrawAuthorizeEvent(PerpsWithdrawAuthorizeEvent.SUBMIT)
   try {
     const checksumAddress = toChecksumAddress(walletAddress.value)
     const challenge = await perpsClient.getAddressBookChallenge({
@@ -295,12 +302,20 @@ async function submitAuthorize() {
       addressLabel: 'wallet',
     })
     perpsToasts.toastWithdrawalAddressAdded(walletAddress.value)
+    analytics.trackPerpsWithdrawAuthorizeEvent(
+      PerpsWithdrawAuthorizeEvent.SUCCESS,
+    )
     // Keep the withdraw dialog open and switch to the withdraw view now that
     // the address is authorized (the toast already surfaces the 24h cooldown).
     isAddressAuthorized.value = true
   } catch (e) {
-    error.value =
+    const msg =
       e instanceof Error ? e.message : 'Failed to authorize withdrawal address'
+    error.value = msg
+    analytics.trackPerpsWithdrawAuthorizeErrorEvent(
+      PerpsWithdrawAuthorizeEvent.ERROR,
+      { errorMessage: msg },
+    )
   } finally {
     authorizing.value = false
   }
@@ -308,24 +323,43 @@ async function submitAuthorize() {
 
 async function submitWithdraw() {
   if (!isValidAmount.value || !walletAddress.value || !accountId.value) return
+  const withdrawAmount = String(amount.value)
   sending.value = true
   error.value = null
+  analytics.trackPerpsWithdrawEvent(PerpsWithdrawEvent.SUBMIT, {
+    withdrawAmount,
+    token: 'USDC',
+  })
   try {
     await perpsClient.withdraw({
       customer_withdrawal_id: `withdraw-${Date.now()}`,
       symbol: 'USDC',
       network: 'ethereum',
-      amount: String(amount.value),
+      amount: withdrawAmount,
       address: toChecksumAddress(walletAddress.value),
       from: { id: accountId.value, wallet: 'margin' },
     })
     triggerRefresh()
+    analytics.trackPerpsWithdrawEvent(PerpsWithdrawEvent.SUCCESS, {
+      withdrawAmount,
+      token: 'USDC',
+    })
+    analytics.trackPerpsWithdrawEvent(PerpsWithdrawEvent.COMPLETED, {
+      withdrawAmount,
+      token: 'USDC',
+    })
     perpsToasts.toastWithdrawalComplete()
     emit('close')
   } catch (e) {
     // TODO(perps-toasts): spec has no withdrawal-failure toast; revisit with design if needed
-    error.value =
+    const msg =
       e instanceof Error ? e.message : t('perps.withdraw.withdrawal-failed')
+    error.value = msg
+    analytics.trackPerpsWithdrawErrorEvent(PerpsWithdrawEvent.ERROR, {
+      withdrawAmount,
+      token: 'USDC',
+      errorMessage: msg,
+    })
   } finally {
     sending.value = false
   }

--- a/src/modules/perps/components/PerpsWithdrawDialog.vue
+++ b/src/modules/perps/components/PerpsWithdrawDialog.vue
@@ -310,7 +310,7 @@ async function submitAuthorize() {
     isAddressAuthorized.value = true
   } catch (e) {
     const msg =
-      e instanceof Error ? e.message : 'Failed to authorize withdrawal address'
+      e instanceof Error ? e.message : t('perps.withdraw.authorize-failed')
     error.value = msg
     analytics.trackPerpsWithdrawAuthorizeErrorEvent(
       PerpsWithdrawAuthorizeEvent.ERROR,


### PR DESCRIPTION
## Summary

Adds Amplitude analytics to the Perps **withdraw** flow, mirroring the existing Perps Deposit events (MEW-1891). Event names follow the established `Perps_Withdraw_*` convention from the Figma Amplitude board; the polished withdraw handoff section is empty, so the funnel names mirror the deposit funnel one-to-one.

## Events

**Withdraw funnel** (`PerpsWithdrawEvent`)
| Event | Fires when | Props |
|---|---|---|
| `Perps_Withdraw_Clicked` | Withdraw dialog opens | — |
| `Perps_Withdraw_Submit` | User clicks Withdraw | `withdrawAmount`, `token` |
| `Perps_Withdraw_Success` | Withdrawal succeeds | `withdrawAmount`, `token` |
| `Perps_Withdraw_Completed` | Withdrawal succeeds (funnel end) | `withdrawAmount`, `token` |
| `Perps_Withdraw_Error` | Withdrawal fails | `withdrawAmount`, `token`, `errorMessage` |

**Address authorization** (`PerpsWithdrawAuthorizeEvent`)
| Event | Fires when |
|---|---|
| `Perps_Withdraw_Authorize_Submit` | User clicks Authorize Withdrawals |
| `Perps_Withdraw_Authorize_Success` | Address authorization completes |
| `Perps_Withdraw_Authorize_Error` | Address authorization fails (`errorMessage`) |

## Changes
- `src/analytics/events.ts` — `PerpsWithdrawEvent` / `PerpsWithdrawAuthorizeEvent` constants + payload types.
- `src/analytics/amplitude.ts` — `trackPerpsWithdraw*` / `trackPerpsWithdrawAuthorize*` methods.
- `src/modules/perps/components/PerpsWithdrawDialog.vue` — wire events into the open / authorize / withdraw handlers.

## Testing
- `pnpm vue-tsc --noEmit -p tsconfig.app.json` — clean.
- `pnpm vitest run tests/unit/specs/modules/perps/` — 58 pass; the 3 failures are pre-existing, unrelated hw-wallet module-resolution errors in `usePerpsAuth.spec.ts` (not touched by this change).
- `pnpm eslint` on the changed files — clean.
- Manual smoke: events fire in DevTools → Network (`/record`) at each step of the withdraw flow.

No copy changes; event constants only, referenced by symbol at call-sites.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added analytics tracking for Perps withdrawal flows, including dialog visibility, authorization (submit/success/error), and withdrawal submission lifecycle (submit/success/completed) with token and amount.
  * Added analytics error tracking for authorization and withdrawal failures, including derived error messages.
* **Bug Fixes**
  * Adjusted the successful authorization flow to avoid triggering the “address added” toast while still transitioning to the withdrawal view.
* **Documentation / Localization**
  * Added a new Perps authorization-failed error message string for withdrawal failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->