### PR TITLE
fix: 🐛 quote failed sentry bug

### DIFF
--- a/src/modules/swap/ModuleSwap.vue
+++ b/src/modules/swap/ModuleSwap.vue
@@ -1466,16 +1466,40 @@ watch(
 watch(
   () => selectedQuote.value,
   async provider => {
-    if (provider) {
-      // disable proceeding while we fetch swap info for the selected quote to prevent user from clicking "proceed" before we have the necessary transaction data
-      txProceeding.value = true
-      await getSwap(provider).then(async res => {
-        swapInfo.value = res
-        const quoteRes = await (isBitcoinChain.value
-          ? generateBTCGasFeeQuote()
-          : generateEVMGasFeeQuote())
-        swapGasFeeQuote.value = (quoteRes as QuotesResponse) || undefined
-      })
+    if (!provider) return
+    // disable proceeding while we fetch swap info for the selected quote to prevent user from clicking "proceed" before we have the necessary transaction data
+    txProceeding.value = true
+    const analyticsPayload = getAnalyticsShared()
+    try {
+      const res = await getSwap(provider)
+      swapInfo.value = res
+      const quoteRes = await (isBitcoinChain.value
+        ? generateBTCGasFeeQuote()
+        : generateEVMGasFeeQuote())
+      swapGasFeeQuote.value = (quoteRes as QuotesResponse) || undefined
+    } catch (e: any) {
+      generalError.value = e?.message || 'Error fetching gas fees'
+      const isExpectedQuoteError =
+        e?.message === t('swap.error.pair-not-available') ||
+        /insufficient funds/i.test(e?.message ?? '')
+      if (isDevMode) {
+        console.error('Error fetching gas fees:', e)
+      } else {
+        analytics.trackSwapEventError(SwapEventError.OFFER_ERROR, {
+          ...analyticsPayload,
+          errorMsg: generalError.value,
+        })
+        if (!isExpectedQuoteError) {
+          captureException(e, {
+            ...SENTRY_MODULE_TAGS.SWAP,
+            extra: {
+              title: 'SWAP: Error fetching gas fees on quote selection',
+              errorMessage: generalError.value,
+            },
+          })
+        }
+      }
+    } finally {
       txProceeding.value = false
     }
   },


### PR DESCRIPTION
### Fix

## What
Add error handling to the swap quote selection flow so failed gas-fee/quote
fetches are caught, surfaced to the user, and no longer flood Sentry with
expected errors.

## Why
Expected quote failures (e.g. "pair not available" and "insufficient funds for
gas price") were being reported to Sentry as unhandled exceptions, creating
noise (MEW-2052) and leaving the UI in a stuck "proceeding" state on failure.

## How
- Wrap the quote/gas-fee fetch on quote selection in a `try/catch/finally`.
- Reset `txProceeding` in `finally` so the UI recovers on error.
- Track quote errors via `trackSwapEventError` (OFFER_ERROR) with analytics payload.
- Skip `captureException` for expected errors (pair-not-available / insufficient funds).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap quote processing and transaction preparation.
  * Added clearer error handling when swap offers are unavailable or funds are insufficient.
  * Ensured transaction progress indicators are reset after processing, including when errors occur.
  * Improved reporting of unexpected swap failures for more reliable issue tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->