### PR TITLE
fix: [MEW-2055] drop transient WebSocket "Connection is closed" Sentry noise

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@ import {
   isExtensionOrProviderError,
   isInvalidWalletAddressError,
 } from '@/sentry/extensionNoise'
+import { isTransientRpcError } from '@/modules/trade/composables/transientRpcError'
 
 const app = createApp(App)
 
@@ -53,16 +54,19 @@ if (dsn) {
     // carry parsed extension frames).
     denyUrls: [/(?:chrome|moz|safari-web)-extension:\/\//i],
     // Drop wallet-extension / EIP-1193 provider rejections (e.g. code 4900
-    // "provider disconnected") and viem InvalidAddressError (a wallet returned
-    // a malformed address on connect — already handled with a user toast).
-    // These surface as serialized plain objects with no parsed frames, so
+    // "provider disconnected"), viem InvalidAddressError (a wallet returned a
+    // malformed address on connect — already handled with a user toast), and
+    // transient RPC/WebSocket drops (e.g. a mewapi wss node closing mid-request,
+    // surfacing as an unhandled "Connection is closed" rejection). These surface
+    // as serialized plain objects or bare strings with no parsed frames, so
     // denyUrls can't catch them — inspect the original exception instead.
     // Genuine app errors are unaffected.
     beforeSend(event, hint) {
       const originalException = hint?.originalException
       if (
         isExtensionOrProviderError(originalException) ||
-        isInvalidWalletAddressError(originalException)
+        isInvalidWalletAddressError(originalException) ||
+        isTransientRpcError(originalException)
       )
         return null
       return event

--- a/src/modules/trade/composables/transientRpcError.ts
+++ b/src/modules/trade/composables/transientRpcError.ts
@@ -7,25 +7,43 @@ const TRANSIENT_RPC_ERROR_NAMES = new Set<string>([
   'TimeoutError',
 ])
 
+// Message fragments (matched case-insensitively) that identify a transient
+// RPC/WebSocket drop. "connection is closed" / "connection closed" cover the
+// plain-value rejection some WS layers emit when the socket drops mid-request.
+const TRANSIENT_MESSAGE_FRAGMENTS = [
+  'websocket request failed',
+  'socket has been closed',
+  'socket closed',
+  'connection is closed',
+  'connection closed',
+]
+
+function hasTransientMessage(message: string): boolean {
+  const msg = message.toLowerCase()
+  return TRANSIENT_MESSAGE_FRAGMENTS.some(fragment => msg.includes(fragment))
+}
+
 /**
  * Whether an error is a transient RPC/WebSocket failure — expected flakiness of
  * the node connection (idle disconnect / node restart), not an app bug, so it
  * should be skipped in Sentry. Matches by viem error name or message, walking
- * the `cause` chain since viem wraps the socket error several levels deep.
+ * the `cause` chain since viem wraps the socket error several levels deep. Also
+ * handles a bare-string rejection (e.g. a WS layer that rejects with the plain
+ * string "Connection is closed"), which reaches the global Sentry `beforeSend`
+ * as an unhandled rejection with no Error, stack, or cause chain.
  */
 export function isTransientRpcError(e: unknown): boolean {
+  if (typeof e === 'string') return hasTransientMessage(e)
   let cur: unknown = e
   for (let depth = 0; cur && typeof cur === 'object' && depth < 6; depth++) {
     const err = cur as { name?: unknown; message?: unknown; cause?: unknown }
-    if (typeof err.name === 'string' && TRANSIENT_RPC_ERROR_NAMES.has(err.name)) {
+    if (
+      typeof err.name === 'string' &&
+      TRANSIENT_RPC_ERROR_NAMES.has(err.name)
+    ) {
       return true
     }
-    const msg = typeof err.message === 'string' ? err.message.toLowerCase() : ''
-    if (
-      msg.includes('websocket request failed') ||
-      msg.includes('socket has been closed') ||
-      msg.includes('socket closed')
-    ) {
+    if (typeof err.message === 'string' && hasTransientMessage(err.message)) {
       return true
     }
     cur = err.cause

--- a/tests/unit/modules/trade/transientRpcError.spec.ts
+++ b/tests/unit/modules/trade/transientRpcError.spec.ts
@@ -37,6 +37,17 @@ describe('isTransientRpcError', () => {
     ).toBe(true)
   })
 
+  it('is true for an object whose message is "Connection is closed"', () => {
+    expect(isTransientRpcError({ message: 'Connection is closed' })).toBe(true)
+  })
+
+  it('is true for a bare-string "Connection is closed" rejection', () => {
+    // The production shape captured by Sentry `onunhandledrejection`: a WS layer
+    // rejects with a plain string (no Error, no stack, no cause chain).
+    expect(isTransientRpcError('Connection is closed')).toBe(true)
+    expect(isTransientRpcError('The socket has been closed.')).toBe(true)
+  })
+
   it('is false for a genuine app error', () => {
     expect(
       isTransientRpcError({
@@ -50,9 +61,16 @@ describe('isTransientRpcError', () => {
     expect(isTransientRpcError(new Error('Bad Request'))).toBe(false)
   })
 
-  it('is false for non-object inputs', () => {
+  it('is false for a non-transient bare string', () => {
+    expect(isTransientRpcError('Bad Request')).toBe(false)
+    expect(isTransientRpcError('Cannot read properties of undefined')).toBe(
+      false,
+    )
+  })
+
+  it('is false for empty / nullish inputs', () => {
     expect(isTransientRpcError(null)).toBe(false)
     expect(isTransientRpcError(undefined)).toBe(false)
-    expect(isTransientRpcError('socket has been closed')).toBe(false)
+    expect(isTransientRpcError('')).toBe(false)
   })
 })


### PR DESCRIPTION
## What was wrong

On the Access page (and anywhere else that reads on-chain over a mewapi WebSocket node, e.g. `wss://nodes.mewapi.io/ws/bsc`), a request that is still in flight when the socket drops rejects with the bare string `"Connection is closed"`. Because that rejection wasn't caught anywhere, it surfaced as a **global unhandled promise rejection** and was reported to Sentry as an error (`APP-MEW-WEB-1E0`) — even though nothing is actually broken for the user (balances/quotes simply retry). It's pure telemetry noise.

## What changed

- Extended the existing transient-RPC/WebSocket classifier (`isTransientRpcError`) to also recognise `"connection is closed"` / `"connection closed"` messages, and to handle a **bare-string rejection** (a value with no `Error`, stack, or `cause` chain — the exact shape Sentry captured).
- Wired that classifier into the global Sentry `beforeSend` in `main.ts`, next to the existing wallet-extension / provider-error and invalid-address filters. These transient socket drops are now dropped before reaching Sentry.
- Genuine application errors are unaffected — only known transient connection-drop messages are filtered.
- Added unit coverage for the new string/message cases.

## How to test

This is a telemetry-noise filter, so there's no visible UI change — the smoke test just confirms the Access flow is healthy and nothing regressed:

1. Open `https://localhost:8081/access`.
2. Pick a wallet option (e.g. **Ledger** / software wallet) and select the **BSC** network.
3. Move through the access dialog normally; let balances load.

**Expected:** the access flow works exactly as before — no new console errors, no broken screens. (The underlying Sentry change can't be observed in the browser; it only affects what is reported to Sentry in production.)

## Sentry

https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-1E0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filtering of transient RPC and WebSocket connection errors from error reporting.
  * Recognized additional connection-closed error messages, including plain-text rejections.
  * Prevented empty and unrelated errors from being incorrectly classified as transient.

* **Tests**
  * Expanded coverage for connection-closed scenarios and non-transient inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->