### PR TITLE
fix: [MEW-2056] guard providers in sellFiats to prevent Home crash

### DIFF
--- a/src/stores/purchaseStore.ts
+++ b/src/stores/purchaseStore.ts
@@ -154,7 +154,7 @@ export const usePurchaseStore = defineStore('purchase', () => {
 
   const sellFiats = computed<Map<string, BuyFiat>>(() => {
     const fiatsMap = new Map<string, BuyFiat>()
-    const provider = purchaseInfo.value?.providers.find(
+    const provider = purchaseInfo.value?.providers?.find(
       p => p.provider === SELL_PROVIDER,
     )
     if (!provider) return fiatsMap

--- a/tests/unit/stores/purchaseStore.spec.ts
+++ b/tests/unit/stores/purchaseStore.spec.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import type { PurchaseInfo } from '@/types/buyToken'
+
+// purchaseStore instantiates chainsStore and walletStore at setup. The real
+// walletStore transitively imports the wallet-provider chain (Ledger / hw
+// wallets), which is irrelevant to `sellFiats` and heavy to load under jsdom.
+// Stub both with minimal real Pinia setup stores so `storeToRefs` still works.
+vi.mock('@/stores/chainsStore', async () => {
+  const { defineStore } = await import('pinia')
+  const { ref } = await import('vue')
+  return {
+    useChainsStore: defineStore('chains', () => ({
+      chains: ref([]),
+      selectedChain: ref(null),
+    })),
+  }
+})
+vi.mock('@/stores/walletStore', async () => {
+  const { defineStore } = await import('pinia')
+  const { ref } = await import('vue')
+  return {
+    useWalletStore: defineStore('wallet', () => ({
+      isWalletConnected: ref(false),
+    })),
+  }
+})
+
+const { usePurchaseStore } = await import('@/stores/purchaseStore')
+
+describe('purchaseStore.sellFiats', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  it('returns an empty map (no throw) when purchaseInfo is set but has no providers', () => {
+    const store = usePurchaseStore()
+    // Simulate a malformed / partial purchase API response where the object
+    // exists but `providers` is missing. This reproduces APP-MEW-WEB-1DZ:
+    // `purchaseInfo.value?.providers.find(...)` threw because the optional
+    // chain only guarded `purchaseInfo.value`, not `providers`.
+    store.purchaseInfo = { assets: [] } as unknown as PurchaseInfo
+    expect(() => store.sellFiats).not.toThrow()
+    expect(store.sellFiats.size).toBe(0)
+  })
+
+  it('returns an empty map when purchaseInfo is null', () => {
+    const store = usePurchaseStore()
+    store.purchaseInfo = null
+    expect(store.sellFiats.size).toBe(0)
+  })
+
+  it('collects sell-supported fiats from the MOONPAY provider', () => {
+    const store = usePurchaseStore()
+    store.purchaseInfo = {
+      assets: [],
+      providers: [
+        {
+          provider: 'MOONPAY',
+          isos_list: [],
+          isos: [],
+          fiats_list: [],
+          fiats: [
+            {
+              fiat_currency: 'USD',
+              limits: { min: 10, max: 1000 },
+              payment_methods: ['card'],
+              is_sell_supported: true,
+            },
+            {
+              fiat_currency: 'GBP',
+              limits: { min: 10, max: 1000 },
+              payment_methods: ['card'],
+              is_sell_supported: false,
+            },
+          ],
+        },
+      ],
+    } as PurchaseInfo
+    expect(store.sellFiats.size).toBe(1)
+    expect(store.sellFiats.has('USD')).toBe(true)
+    expect(store.sellFiats.has('GBP')).toBe(false)
+  })
+})


### PR DESCRIPTION
## What was wrong

On the Home screen, some users (seen on iPhone / Mobile Safari) hit an uncaught crash that took down the Buy/Sell area. The error was `TypeError: undefined is not an object (evaluating 'be.value?.providers.find')`.

## What changed

The Sell flow builds its list of supported fiat currencies from the purchase-info API response. If that response came back without a `providers` list, the code tried to search an object that didn't exist and crashed the whole component. This adds a safe guard so that when `providers` is missing, the Sell fiat list simply comes back empty instead of throwing — the same guard the sibling Buy flow already had.

One-line source change in `src/stores/purchaseStore.ts` (`providers.find` → `providers?.find`), plus a regression test covering the missing-providers, null, and happy-path cases.

## How to test

1. Open the app at Home (`/`) — no wallet needed (reproduced on a watch-only / not-connected state).
2. The Buy/Sell area should render normally with no console error.
3. Open the Sell flow and confirm the fiat currency list behaves as before (populated when the provider data is present).

## Sentry

- Issue: https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-1DZ
- Event: https://myetherwallet-inc.sentry.io/issues/7623985461/events/2dc5a29770684101acac7e5943739ba1/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented errors when sell provider information is unavailable.
  * Ensured selling fiat options return an empty list when no provider data exists.
  * Continued filtering results to show only supported selling currencies.

* **Tests**
  * Added coverage for missing provider data, absent purchase information, and supported currency filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->