### PR TITLE
fix: [MEW-2065] filter iOS injected-script stack-overflow sentry noise

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ import configs from '@/configs'
 import {
   isExtensionOrProviderError,
   isInvalidWalletAddressError,
+  isForeignStackOverflow,
 } from '@/sentry/extensionNoise'
 
 const app = createApp(App)
@@ -50,8 +51,13 @@ if (dsn) {
       'Request expired',
     ],
     // Drop errors thrown inside browser extensions (catches events that DO
-    // carry parsed extension frames).
-    denyUrls: [/(?:chrome|moz|safari-web)-extension:\/\//i],
+    // carry parsed extension frames). `webkit-masked-url` is how iOS 16.4+
+    // WebKit exposes the source of extension / content-blocker / in-app-browser
+    // injected scripts.
+    denyUrls: [
+      /(?:chrome|moz|safari-web)-extension:\/\//i,
+      /webkit-masked-url:\/\//i,
+    ],
     // Drop wallet-extension / EIP-1193 provider rejections (e.g. code 4900
     // "provider disconnected") and viem InvalidAddressError (a wallet returned
     // a malformed address on connect — already handled with a user toast).
@@ -62,7 +68,10 @@ if (dsn) {
       const originalException = hint?.originalException
       if (
         isExtensionOrProviderError(originalException) ||
-        isInvalidWalletAddressError(originalException)
+        isInvalidWalletAddressError(originalException) ||
+        // iOS injected-script "Maximum call stack" RangeErrors with no app
+        // frame — external, unactionable noise (APP-MEW-WEB-BB / MEW-2065).
+        isForeignStackOverflow(event)
       )
         return null
       return event

--- a/src/sentry/extensionNoise.ts
+++ b/src/sentry/extensionNoise.ts
@@ -36,3 +36,60 @@ export function isInvalidWalletAddressError(err: unknown): boolean {
   if (!err || typeof err !== 'object') return false
   return (err as { name?: unknown }).name === 'InvalidAddressError'
 }
+
+// A stack frame belongs to MEW app code if its source URL is one of ours.
+// `/assets/` covers the hashed production bundles; localhost covers dev.
+const APP_FRAME_URL = /myetherwallet\.com|\/assets\/|localhost|127\.0\.0\.1/i
+
+interface SentryFrameLike {
+  filename?: unknown
+}
+interface SentryExceptionLike {
+  value?: unknown
+  stacktrace?: { frames?: unknown } | null
+}
+interface SentryEventLike {
+  exception?: { values?: unknown } | null
+}
+
+/**
+ * Whether a Sentry event is a "Maximum call stack size exceeded" `RangeError`
+ * that did NOT originate in app code, and is therefore unactionable noise.
+ *
+ * On iOS Safari / WKWebView, scripts injected by content blockers, Safari
+ * extensions, and in-app browsers (the "Google" in-app browser, etc.) throw
+ * uncaught `RangeError`s that bubble to the page's `window.onerror` and get
+ * reported as if they were ours. Since iOS 16.4 / WebKit masks the source URL
+ * of such scripts (`webkit-masked-url://` or an empty URL), the event carries
+ * only frames Sentry cannot attribute to a file (rendered as `undefined:LL:CC`).
+ *
+ * A genuine in-app recursion always leaves at least one frame whose URL is an
+ * app origin, so the presence of any app frame keeps the event. This is
+ * event-based (not `originalException`-based) because "no app frame" is only
+ * reliable on the parsed event frames — the raw exception often has no stack.
+ */
+export function isForeignStackOverflow(event: unknown): boolean {
+  if (!event || typeof event !== 'object') return false
+  const values = (event as SentryEventLike).exception?.values
+  if (!Array.isArray(values) || values.length === 0) return false
+
+  const isStackOverflow = values.some(v => {
+    const value = (v as SentryExceptionLike)?.value
+    return (
+      typeof value === 'string' &&
+      /maximum call stack size exceeded/i.test(value)
+    )
+  })
+  if (!isStackOverflow) return false
+
+  // Keep the event if ANY frame points at app code — that is a real MEW bug.
+  const hasAppFrame = values.some(v => {
+    const frames = (v as SentryExceptionLike)?.stacktrace?.frames
+    if (!Array.isArray(frames)) return false
+    return frames.some(f => {
+      const filename = (f as SentryFrameLike)?.filename
+      return typeof filename === 'string' && APP_FRAME_URL.test(filename)
+    })
+  })
+  return !hasAppFrame
+}

--- a/src/sentry/extensionNoise.ts
+++ b/src/sentry/extensionNoise.ts
@@ -38,8 +38,13 @@ export function isInvalidWalletAddressError(err: unknown): boolean {
 }
 
 // A stack frame belongs to MEW app code if its source URL is one of ours.
-// `/assets/` covers the hashed production bundles; localhost covers dev.
-const APP_FRAME_URL = /myetherwallet\.com|\/assets\/|localhost|127\.0\.0\.1/i
+// The host is anchored to `*.myetherwallet.com` / localhost so look-alike hosts
+// (e.g. `notmyetherwallet.com`) don't match, and a bare `/assets/` is accepted
+// only as a relative path so foreign bundles like
+// `chrome-extension://…/assets/foo.js` are excluded. The hashed production
+// bundles are served from `app.myetherwallet.com/assets/…`.
+const APP_FRAME_URL =
+  /^(?:https?:\/\/(?:(?:[a-z0-9-]+\.)*myetherwallet\.com|localhost|127\.0\.0\.1)(?::\d+)?(?:\/|$)|\/assets\/)/i
 
 interface SentryFrameLike {
   filename?: unknown

--- a/tests/unit/sentry/extensionNoise.spec.ts
+++ b/tests/unit/sentry/extensionNoise.spec.ts
@@ -205,6 +205,37 @@ describe('isForeignStackOverflow', () => {
     ).toBe(false)
   })
 
+  it('is FALSE for a relative /assets/ app bundle path', () => {
+    expect(
+      isForeignStackOverflow(
+        evt('Maximum call stack size exceeded.', [
+          { filename: '/assets/index-abc.js' },
+        ]),
+      ),
+    ).toBe(false)
+  })
+
+  it('is true for an extension bundle whose path merely contains /assets/', () => {
+    // `/assets/` must be anchored: chrome-extension://…/assets/… is NOT ours.
+    expect(
+      isForeignStackOverflow(
+        evt('Maximum call stack size exceeded.', [
+          { filename: 'chrome-extension://abcd/assets/foo.js' },
+        ]),
+      ),
+    ).toBe(true)
+  })
+
+  it('is true for a look-alike host (not our anchored domain)', () => {
+    expect(
+      isForeignStackOverflow(
+        evt('Maximum call stack size exceeded.', [
+          { filename: 'https://notmyetherwallet.com/assets/x.js' },
+        ]),
+      ),
+    ).toBe(true)
+  })
+
   it('is FALSE for a non-stack-overflow error, even with no app frame', () => {
     expect(
       isForeignStackOverflow(

--- a/tests/unit/sentry/extensionNoise.spec.ts
+++ b/tests/unit/sentry/extensionNoise.spec.ts
@@ -3,6 +3,7 @@ import { InvalidAddressError } from 'viem'
 import {
   isExtensionOrProviderError,
   isInvalidWalletAddressError,
+  isForeignStackOverflow,
 } from '@/sentry/extensionNoise'
 
 describe('isExtensionOrProviderError', () => {
@@ -107,5 +108,117 @@ describe('isInvalidWalletAddressError', () => {
     expect(isInvalidWalletAddressError(null)).toBe(false)
     expect(isInvalidWalletAddressError(undefined)).toBe(false)
     expect(isInvalidWalletAddressError('InvalidAddressError')).toBe(false)
+  })
+})
+
+describe('isForeignStackOverflow', () => {
+  // Builds a Sentry ErrorEvent-shaped payload for a single exception value.
+  const evt = (
+    value: string,
+    frames?: Array<{ filename?: unknown }>,
+    type = 'RangeError',
+  ) => ({
+    exception: {
+      values: [
+        {
+          type,
+          value,
+          ...(frames ? { stacktrace: { frames } } : {}),
+        },
+      ],
+    },
+  })
+
+  it('is true for the production payload: iOS masked frame, no app origin', () => {
+    // APP-MEW-WEB-BB: single frame Sentry could not attribute to a file
+    // (rendered as `undefined:38:249`), from an injected/extension script.
+    expect(
+      isForeignStackOverflow(
+        evt('Maximum call stack size exceeded.', [
+          { filename: undefined, lineno: 38, colno: 249 } as {
+            filename?: unknown
+          },
+        ]),
+      ),
+    ).toBe(true)
+  })
+
+  it('is true when frames point at iOS webkit-masked-url (extension/injected)', () => {
+    expect(
+      isForeignStackOverflow(
+        evt('Maximum call stack size exceeded.', [
+          { filename: 'webkit-masked-url://hidden/' },
+        ]),
+      ),
+    ).toBe(true)
+  })
+
+  it('is true when there is no parsed stacktrace at all', () => {
+    expect(
+      isForeignStackOverflow(evt('Maximum call stack size exceeded.')),
+    ).toBe(true)
+  })
+
+  it('is true regardless of exception type when the message matches', () => {
+    // Some iOS payloads surface the message on a generic Error type.
+    expect(
+      isForeignStackOverflow(
+        evt(
+          'RangeError: Maximum call stack size exceeded',
+          [{ filename: undefined }],
+          'Error',
+        ),
+      ),
+    ).toBe(true)
+  })
+
+  it('is FALSE for a genuine in-app stack overflow (carries an app frame)', () => {
+    // A real MEW recursion — must NOT be dropped.
+    expect(
+      isForeignStackOverflow(
+        evt('Maximum call stack size exceeded.', [
+          { filename: 'https://app.myetherwallet.com/assets/index-abc.js' },
+        ]),
+      ),
+    ).toBe(false)
+  })
+
+  it('is FALSE when an app frame appears anywhere among masked frames', () => {
+    expect(
+      isForeignStackOverflow(
+        evt('Maximum call stack size exceeded.', [
+          { filename: 'webkit-masked-url://hidden/' },
+          { filename: undefined },
+          { filename: 'https://app.myetherwallet.com/assets/chunk-x.js' },
+        ]),
+      ),
+    ).toBe(false)
+  })
+
+  it('is FALSE for a localhost (dev) app frame', () => {
+    expect(
+      isForeignStackOverflow(
+        evt('Maximum call stack size exceeded.', [
+          { filename: 'https://localhost:8080/src/App.vue' },
+        ]),
+      ),
+    ).toBe(false)
+  })
+
+  it('is FALSE for a non-stack-overflow error, even with no app frame', () => {
+    expect(
+      isForeignStackOverflow(
+        evt("Cannot read properties of undefined (reading 'x')", [
+          { filename: undefined },
+        ]),
+      ),
+    ).toBe(false)
+  })
+
+  it('is FALSE for empty / non-object / frameless-exception inputs', () => {
+    expect(isForeignStackOverflow(null)).toBe(false)
+    expect(isForeignStackOverflow(undefined)).toBe(false)
+    expect(isForeignStackOverflow({})).toBe(false)
+    expect(isForeignStackOverflow({ exception: { values: [] } })).toBe(false)
   })
 })


### PR DESCRIPTION
## What was wrong

Sentry has been reporting a high-volume crash — `RangeError: Maximum call stack size exceeded` (Sentry issue `APP-MEW-WEB-BB`, 257 events since March, still ongoing) — as if it were an app crash. It is **not** MEW code. The evidence:

- **100% iOS** (Chrome Mobile iOS + the "Google" in-app browser), across every Chrome-iOS version (139→150), every prod release (7.0.4 → 7.0.9-hotfix.1), and **every route** (Home, Access, Crypto, Sign, Stocks, Earn…).
- The stacktrace carries **no app frame** — just a single frame Sentry can't attribute to a file (`undefined:38:249`). This is how iOS 16.4+/WebKit exposes scripts injected by **content blockers, Safari extensions, and in-app browsers** (source URL masked as `webkit-masked-url://` or empty). Those scripts throw uncaught errors that bubble to the page's global `window.onerror` and get reported as ours.
- **0 users impacted** and app state is healthy at crash time — no functional breakage, pure telemetry noise.

## What changed

Extends the existing Sentry noise filter (same pattern as the extension/provider and transient-RPC filters already in `beforeSend`):

- New `isForeignStackOverflow(event)` in `src/sentry/extensionNoise.ts`: drops an event **only** when it is a "Maximum call stack size exceeded" `RangeError` whose stacktrace has **no app-origin frame** (no `myetherwallet.com` / `/assets/` / `localhost`). A genuine in-app recursion always carries an app frame, so real bugs are **not** filtered.
- Wired into the `beforeSend` hook in `src/main.ts`.
- Added `webkit-masked-url://` to `denyUrls`.
- Unit tests in `tests/unit/sentry/extensionNoise.spec.ts` (9 new; the real production payload, masked-URL frames, no-stacktrace, and the "keep genuine app overflow" guard).

## How to test

This is a telemetry-only change with **no visible UI effect**. Verification:

- CI: `pnpm vitest run tests/unit/sentry/extensionNoise.spec.ts` (19/19), `pnpm vue-tsc --noEmit -p tsconfig.app.json` (clean).
- Smoke: load the app, confirm it boots normally and there are no new console/Sentry-init errors on any route. Genuine app errors still report to Sentry as before.

## Sentry

https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-BB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Sentry noise filtering to suppress misleading browser extension/injected script “extension noise.”
  * Expanded suppression rules to reduce additional WebKit masked extension URL events.
  * Added detection to suppress “foreign” stack overflow errors while preserving stack overflows that clearly originate within the app.

* **Tests**
  * Added unit test coverage for the improved stack-overflow suppression logic, including masked traces, missing/malformed payloads, and cases with in-app-origin frames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->