### PR TITLE
fix: align table action buttons (single vs. two) (MEW-2033)

### DIFF
--- a/src/modules/crypto/ModuleExploreCrypto.vue
+++ b/src/modules/crypto/ModuleExploreCrypto.vue
@@ -487,19 +487,38 @@
                       </template>
                     </app-pop-up-menu>
                   </div>
-                  <div class="hidden lg:flex flex-row gap-2 justify-end">
+                  <div
+                    class="hidden lg:grid grid-cols-2 gap-2 w-[160px] ml-auto"
+                  >
+                    <!-- Buy first (inverted order for the Explore Tokens table) -->
+                    <app-base-button
+                      v-if="isBuyableOnCompatibleChain(token.coinId)"
+                      size="small"
+                      @click="buyBtn(token)"
+                      is-outline
+                      class="w-full"
+                      :class="{ 'col-start-2': !hasPrimaryAction(token) }"
+                      >{{ $t('common.buy') }}</app-base-button
+                    >
+                    <!-- Primary action: trade / bridge / swap -->
                     <app-base-button
                       v-if="token.ondo !== null"
                       size="small"
                       @click="tradeBtn(token)"
-                      class="min-w-[64px]"
+                      class="w-full"
+                      :class="{
+                        'col-start-2': !isBuyableOnCompatibleChain(token.coinId),
+                      }"
                       >{{ $t('crypto.trade') }}
                     </app-base-button>
                     <app-base-button
                       v-else-if="getIsBridgeable(token)"
                       size="small"
                       @click="bridgeBtn(token)"
-                      class="min-w-[64px]"
+                      class="w-full"
+                      :class="{
+                        'col-start-2': !isBuyableOnCompatibleChain(token.coinId),
+                      }"
                       >{{ $t('crypto.bridge') }}
                     </app-base-button>
                     <app-base-button
@@ -510,19 +529,12 @@
                       "
                       size="small"
                       @click="swapBtn(token)"
-                      class="min-w-[64px]"
+                      class="w-full"
+                      :class="{
+                        'col-start-2': !isBuyableOnCompatibleChain(token.coinId),
+                      }"
                       >{{ $t('common.swap') }}
                     </app-base-button>
-
-                    <app-base-button
-                      v-if="isBuyableOnCompatibleChain(token.coinId)"
-                      size="small"
-                      @click="buyBtn(token)"
-                      is-outline
-                      class="min-w-[60px]"
-                      >{{ $t('common.buy') }}</app-base-button
-                    >
-                    <div v-else class="w-[60px]"></div>
                   </div>
                 </td>
               </tr>
@@ -811,6 +823,14 @@ const getIsBridgeable = (token: DisplayToken): boolean => {
   }
   return isNativeToken && !isAvailableOnCurrentChain && hasSwapSupportChain
 }
+// A token has a "primary" action (trade / bridge / swap) in the desktop actions
+// cell — mirrors the v-if/v-else-if chain in the template. Used to make a lone
+// button span the full actions width so rows stay vertically aligned.
+const hasPrimaryAction = (token: DisplayToken): boolean =>
+  token.ondo !== null ||
+  getIsBridgeable(token) ||
+  (currentChainhasSwapSupport.value &&
+    (token.chains.length > 0 || getTokenIsCurrentNative(token)))
 const buyBtn = (token: DisplayToken, isMobile = false) => {
   analytics.trackClickTokenTradeEvent(ClickTokenTradeEvent.BUY, {
     location: 'crypto_table',

--- a/src/modules/crypto/ModuleExploreCrypto.vue
+++ b/src/modules/crypto/ModuleExploreCrypto.vue
@@ -488,7 +488,7 @@
                     </app-pop-up-menu>
                   </div>
                   <div
-                    class="hidden lg:grid grid-cols-2 gap-2 w-[160px] ml-auto"
+                    class="hidden lg:grid grid-cols-2 gap-2 w-full max-w-[160px] ml-auto"
                   >
                     <!-- Buy first (inverted order for the Explore Tokens table) -->
                     <app-base-button

--- a/src/modules/portfolio/components/balances/TableTokenBalance.vue
+++ b/src/modules/portfolio/components/balances/TableTokenBalance.vue
@@ -383,7 +383,7 @@
               </p>
             </td>
             <!-- Actions -->
-            <td class="lg:pr-2 py-1 rounded-r-12 relative text-right">
+            <td class="lg:pl-6 lg:pr-2 py-1 rounded-r-12 relative text-right">
               <div
                 class="flex items-center justify-end lg:hidden ml-auto -mr-1 md:mr-auto"
               >
@@ -490,20 +490,26 @@
               </div>
               <div
                 v-if="props.view !== 'custom'"
-                class="hidden lg:flex flex-row gap-2 justify-end"
+                class="hidden lg:grid grid-cols-2 gap-2 w-full max-w-[160px] ml-auto"
               >
                 <app-base-button
                   v-if="token.ondo !== undefined"
                   size="small"
                   @click="tradeBtn(token)"
-                  class="min-w-[60px]"
+                  class="w-full"
+                  :class="{
+                    'col-start-2': !isBuyableOnCompatibleChain(token.coinId),
+                  }"
                   >{{ $t('portfolio.table.trade') }}
                 </app-base-button>
                 <app-base-button
                   v-else-if="currentChainhasSwapSupport"
                   size="small"
                   @click="swapBtn(token)"
-                  class="min-w-[60px]"
+                  class="w-full"
+                  :class="{
+                    'col-start-2': !isBuyableOnCompatibleChain(token.coinId),
+                  }"
                   >{{ $t('common.swap') }}
                 </app-base-button>
                 <app-base-button
@@ -511,10 +517,10 @@
                   size="small"
                   @click="buyBtn(token)"
                   is-outline
-                  class="min-w-[60px]"
+                  class="w-full"
+                  :class="{ 'col-start-2': !hasPrimaryAction(token) }"
                   >{{ $t('common.buy') }}
                 </app-base-button>
-                <div v-else class="w-[60px]"></div>
               </div>
               <div
                 class="hidden lg:flex flex-row gap-1 justify-end flex-wrap"
@@ -1111,6 +1117,10 @@ const getCurrentViewableItemsIndex = computed(() =>
 /** -------------------------------
  * Navigation & Handlers
  -------------------------------*/
+// A token has a "primary" action (trade / swap) in the desktop actions cell.
+// Used so a lone button spans the full actions width and rows stay aligned.
+const hasPrimaryAction = (token: DisplayToken): boolean =>
+  token.ondo !== undefined || currentChainhasSwapSupport.value
 const buyBtn = (token?: DisplayToken, isMobile = false) => {
   analytics.trackClickTokenTradeEvent(ClickTokenTradeEvent.BUY, {
     location: 'balance_table',

--- a/src/modules/portfolio/components/balances/TableTokenBalance.vue
+++ b/src/modules/portfolio/components/balances/TableTokenBalance.vue
@@ -383,7 +383,7 @@
               </p>
             </td>
             <!-- Actions -->
-            <td class="lg:pl-6 lg:pr-2 py-1 rounded-r-12 relative text-right">
+            <td class="lg:pr-2 py-1 rounded-r-12 relative text-right">
               <div
                 class="flex items-center justify-end lg:hidden ml-auto -mr-1 md:mr-auto"
               >
@@ -490,7 +490,7 @@
               </div>
               <div
                 v-if="props.view !== 'custom'"
-                class="hidden lg:grid grid-cols-2 gap-2 w-full max-w-[160px] ml-auto"
+                class="hidden lg:grid grid-cols-2 gap-2 w-[160px] ml-auto"
               >
                 <app-base-button
                   v-if="token.ondo !== undefined"

--- a/src/modules/portfolio/components/balances/TableTokenBalance.vue
+++ b/src/modules/portfolio/components/balances/TableTokenBalance.vue
@@ -490,7 +490,7 @@
               </div>
               <div
                 v-if="props.view !== 'custom'"
-                class="hidden lg:grid grid-cols-2 gap-2 w-[160px] ml-auto"
+                class="hidden lg:grid grid-cols-2 gap-2 w-full max-w-[160px] ml-auto"
               >
                 <app-base-button
                   v-if="token.ondo !== undefined"


### PR DESCRIPTION
## What

The token tables rendered their per-row action buttons with `flex justify-end` + a fixed-width spacer, so a lone button (Bridge/Swap/Buy) didn't line up column-to-column with the two-button rows — a vertical misalignment between rows with one vs. two buttons.

## Changes

- **Explore Tokens table** (`ModuleExploreCrypto.vue`): actions cell → fixed-width 2-column grid. Each button occupies one column; a lone button sits in the **second** column (`col-start-2`), leaving the first empty, so it lines up with the second button of two-button rows. **Order inverted** for this table (Buy first, then Swap/Bridge/Trade) per the ticket. Added a `hasPrimaryAction()` helper.
- **Portfolio balances table** (`TableTokenBalance.vue`): same 1-vs-2 misalignment (identical flex+spacer markup) → same 2-column grid with the lone button in the second column. Order unchanged (primary then Buy).

## Notes

- Replaced the empty `<div class="w-[60px]">` spacer with the grid's empty column.
- `vue-tsc` 0 errors, ESLint clean.

MEW-2033

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Reworked desktop (lg+) action layouts in crypto and portfolio token tables to use a consistent two-column grid for improved row alignment.
  * Updated action buttons to full-width for a cleaner, more balanced appearance.
  * Standardized how Buy, Trade, Bridge, and Swap are positioned per token, ensuring buttons stay correctly aligned when some actions aren’t available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->