### PR TITLE
chore: use Ondo perps sandbox API instead of live

### DIFF
--- a/src/modules/perps/configs.ts
+++ b/src/modules/perps/configs.ts
@@ -1,24 +1,22 @@
-import configs from '@/configs'
 import { PerpsClient } from './sdk'
 import { mainnet } from 'viem/chains'
 
 const IS_PERPS_LIVE = true
 
 const PERPS_BASE_URL = {
-  sandbox: { url: `https://api.ondoperps-sandbox.xyz` },
+  sandbox: { url: `https://app.ondoperps-sandbox.xyz` },
   live: { url: `https://api.ondoperps.xyz` },
 }
 
 const PERPS_WS_URL = {
-  sandbox: `wss://api.ondoperps-sandbox.xyz/ws`,
+  sandbox: `wss://app.ondoperps-sandbox.xyz/ws`,
   live: `wss://api.ondoperps.xyz/ws`,
 }
 
-const perpsClient = new PerpsClient(
-  !configs.IS_DEV_MODE ? PERPS_BASE_URL.live.url : PERPS_BASE_URL.sandbox.url,
-)
+// Point the perps REST + WS client at the Ondo sandbox instead of the live API.
+const perpsClient = new PerpsClient(PERPS_BASE_URL.sandbox.url)
 
-const perpsWsUrl = !configs.IS_DEV_MODE ? PERPS_WS_URL.live : PERPS_WS_URL.sandbox
+const perpsWsUrl = PERPS_WS_URL.sandbox
 
 const SUPPORTED_NETWORK = [mainnet]
 // Perps operates on Ethereum mainnet only; the API takes chainId as a string.


### PR DESCRIPTION
## Summary

Points the Ondo perps client at the **sandbox** environment instead of the real (live) API, so the app always talks to sandbox regardless of build mode.

Branch prefix is `devops/` so CI produces a build (the `chore/` prefix does not).

## Changes

- `src/modules/perps/configs.ts`
  - `perpsClient` now constructed with `PERPS_BASE_URL.sandbox.url` (was selected via `!configs.IS_DEV_MODE`, which used the live API in production builds).
  - `perpsWsUrl` now uses `PERPS_WS_URL.sandbox`.
  - Updated the sandbox host to `https://app.ondoperps-sandbox.xyz` (REST) and `wss://app.ondoperps-sandbox.xyz/ws` (WS).
  - Removed the now-unused `@/configs` import.

## Notes

- `IS_PERPS_LIVE` is left untouched (`true`), so the deposit dialog keeps its current live-deposit flow while the API points at sandbox.
- Sandbox host changed from `api.ondoperps-sandbox.xyz` to `app.ondoperps-sandbox.xyz` per request — please confirm the subdomain.

## Verification

- `pnpm vue-tsc --noEmit -p tsconfig.app.json` ✅
- `eslint src/modules/perps/configs.ts` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)