### PR TITLE
fix: 🐛 perps toast

### DIFF
--- a/src/i18n/locales/perps/en.json
+++ b/src/i18n/locales/perps/en.json
@@ -24,7 +24,7 @@
       "take-profit-removed-title": "Take Profit Removed",
       "failed-to-remove-sl-tp-title": "Failed to Remove Stop Loss / Take Profit",
       "failed-to-remove-order-title": "Failed to Remove Order",
-      "sl-tp-line": "{side} {netQuantity} PERPS: {base}{quote} at {price}",
+      "sl-tp-line": "{side} {netQuantity} PERPS: {base} at {price}",
       "liquidation-initiated": "Liquidation Initiated",
       "liquidation-initiated-detail": "Your account is temporarily locked and your open positions are being sold",
       "deposit-complete-title": "Deposit Complete",

--- a/src/modules/perps/composables/usePerpsToasts.ts
+++ b/src/modules/perps/composables/usePerpsToasts.ts
@@ -80,14 +80,18 @@ export function usePerpsToasts() {
     })
   }
 
-  const slTpLine = (args: SlTpArgs): string =>
-    t('perps.toast.sl-tp-line', {
+  const slTpLine = (args: SlTpArgs): string => {
+    console.log(args)
+    return t('perps.toast.sl-tp-line', {
       side: humanSide(args.direction, t).toUpperCase(),
       netQuantity: args.netQuantity,
       base: args.base,
-      quote: args.quote,
+      // quote: args.quote,
       price: formatUsd(args.triggerPrice as string | number),
     })
+
+  }
+
 
   const fillLine = (args: FillArgs): string => {
     // Determine the verb from the raw (untranslated) side so this doesn't

--- a/src/modules/perps/composables/usePerpsToasts.ts
+++ b/src/modules/perps/composables/usePerpsToasts.ts
@@ -81,7 +81,6 @@ export function usePerpsToasts() {
   }
 
   const slTpLine = (args: SlTpArgs): string => {
-    console.log(args)
     return t('perps.toast.sl-tp-line', {
       side: humanSide(args.direction, t).toUpperCase(),
       netQuantity: args.netQuantity,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated stop-loss and take-profit toast text to render the PERPS line correctly, showing the asset name followed by “at {price}”.
  * Removed the redundant quote interpolation/symbol from these notifications so the displayed line no longer includes an extra `{quote}` segment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->