### PR TITLE
fix: [MEW-2078] drop wagmi ProviderNotFoundError from Sentry

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ import configs from '@/configs'
 import {
   isExtensionOrProviderError,
   isInvalidWalletAddressError,
+  isProviderNotFoundError,
 } from '@/sentry/extensionNoise'
 import { isTransientRpcError } from '@/modules/trade/composables/transientRpcError'
 
@@ -55,7 +56,9 @@ if (dsn && process.env.NODE_ENV === 'production') {
     denyUrls: [/(?:chrome|moz|safari-web)-extension:\/\//i],
     // Drop wallet-extension / EIP-1193 provider rejections (e.g. code 4900
     // "provider disconnected"), viem InvalidAddressError (a wallet returned a
-    // malformed address on connect — already handled with a user toast), and
+    // malformed address on connect — already handled with a user toast), wagmi
+    // ProviderNotFoundError (user tried to connect a browser wallet with no
+    // injected provider — already handled with a user toast), and
     // transient RPC/WebSocket drops (e.g. a mewapi wss node closing mid-request,
     // surfacing as an unhandled "Connection is closed" rejection). These surface
     // as serialized plain objects or bare strings with no parsed frames, so
@@ -66,6 +69,7 @@ if (dsn && process.env.NODE_ENV === 'production') {
       if (
         isExtensionOrProviderError(originalException) ||
         isInvalidWalletAddressError(originalException) ||
+        isProviderNotFoundError(originalException) ||
         isTransientRpcError(originalException)
       )
         return null

--- a/src/sentry/extensionNoise.ts
+++ b/src/sentry/extensionNoise.ts
@@ -36,3 +36,16 @@ export function isInvalidWalletAddressError(err: unknown): boolean {
   if (!err || typeof err !== 'object') return false
   return (err as { name?: unknown }).name === 'InvalidAddressError'
 }
+
+/**
+ * Whether an error is a wagmi `ProviderNotFoundError` — thrown when a connector
+ * calls `getProvider()` and no injected wallet is present (e.g. the user clicks
+ * "Browser Wallet" with no extension installed). The connect flow already
+ * handles it (the user sees a "Could not connect" toast), so it is expected,
+ * unactionable Sentry noise. Detected via the wagmi-guaranteed error `name`
+ * rather than the message so it survives minification.
+ */
+export function isProviderNotFoundError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false
+  return (err as { name?: unknown }).name === 'ProviderNotFoundError'
+}

--- a/tests/unit/sentry/extensionNoise.spec.ts
+++ b/tests/unit/sentry/extensionNoise.spec.ts
@@ -3,6 +3,7 @@ import { InvalidAddressError } from 'viem'
 import {
   isExtensionOrProviderError,
   isInvalidWalletAddressError,
+  isProviderNotFoundError,
 } from '@/sentry/extensionNoise'
 
 describe('isExtensionOrProviderError', () => {
@@ -107,5 +108,31 @@ describe('isInvalidWalletAddressError', () => {
     expect(isInvalidWalletAddressError(null)).toBe(false)
     expect(isInvalidWalletAddressError(undefined)).toBe(false)
     expect(isInvalidWalletAddressError('InvalidAddressError')).toBe(false)
+  })
+})
+
+describe('isProviderNotFoundError', () => {
+  it('is true for a wagmi ProviderNotFoundError (matched by name)', () => {
+    // The exact production trigger: a connector calls getProvider() with no
+    // injected wallet present and @wagmi/core throws ProviderNotFoundError.
+    expect(
+      isProviderNotFoundError({
+        name: 'ProviderNotFoundError',
+        message: 'Provider not found.',
+      }),
+    ).toBe(true)
+  })
+
+  it('is false for a genuine app error', () => {
+    expect(isProviderNotFoundError(new Error('boom'))).toBe(false)
+    expect(
+      isProviderNotFoundError({ name: 'TypeError', message: 'x' }),
+    ).toBe(false)
+  })
+
+  it('is false for non-object inputs', () => {
+    expect(isProviderNotFoundError(null)).toBe(false)
+    expect(isProviderNotFoundError(undefined)).toBe(false)
+    expect(isProviderNotFoundError('Provider not found.')).toBe(false)
   })
 })


### PR DESCRIPTION
## What was wrong

When a user clicks a browser/injected wallet (e.g. "Browser Wallet") on a device that has no wallet extension installed, the app correctly shows a "Could not connect to wallet" toast — but it was **also** reporting the underlying `ProviderNotFoundError` to Sentry. This produced 224 non-actionable error events (0 users actually impacted) that were pure noise.

## What changed

Sentry now recognizes this error as an expected, already-handled condition and drops it before it's sent, exactly like it already does for the equivalent "wallet returned a bad address on connect" case. Nothing the user sees changes — the same toast still appears.

Technically: a new `isProviderNotFoundError` predicate in `src/sentry/extensionNoise.ts` (matched by the error's `name`, minification-safe) wired into the `beforeSend` hook in `src/main.ts`. Added a small unit test.

## How to test

1. Open the app in a browser **without** any wallet extension installed (e.g. Safari, or Chrome with no MetaMask/Enkrypt).
2. Open the "Access my wallet" dialog and click the **Browser Wallet** (injected) option.
3. You should see the "Could not connect to wallet / Failed to connect" warning toast.

Expected: the toast still shows normally, and no `ProviderNotFoundError` event is generated (in production it would no longer reach Sentry).

## Sentry

https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-A7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented expected missing-wallet-provider errors from being reported as unexpected errors.
  * Reduced unnecessary error-reporting noise in monitoring.

* **Tests**
  * Added coverage for identifying provider-not-found errors while preserving reporting for genuine application errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->