### PR TITLE
fix: [MEW-2079] guard updateAddress on stale accountsChanged listener

### DIFF
--- a/src/components/core_layouts/TheHeader.vue
+++ b/src/components/core_layouts/TheHeader.vue
@@ -285,6 +285,11 @@ watch(
               (accounts as string[])[0] !== (await wallet.value?.getAddress())
             ) {
               const _wallet = wallet.value as Web3InjectedWallet
+              // The listener outlives the injected wallet: switching to a
+              // watch-only view (which inherits walletType INJECTED) or
+              // disconnecting leaves a wallet without updateAddress. Bail
+              // instead of crashing on a stale accountsChanged event.
+              if (typeof _wallet?.updateAddress !== 'function') return
               _wallet.updateAddress(
                 (accounts as string[])[0] as HexPrefixedString,
               )
@@ -300,6 +305,7 @@ watch(
             (accounts as string[])[0] !== (await wallet.value?.getAddress())
           ) {
             const _wallet = wallet.value as Web3InjectedWallet
+            if (typeof _wallet?.updateAddress !== 'function') return
             _wallet.updateAddress(
               (accounts as string[])[0] as HexPrefixedString,
             )


### PR DESCRIPTION
## What was wrong

When you connect a browser-extension wallet (Rabby, MetaMask, …) and then switch to a **watch-only view** of that address — or disconnect — the app could crash in the background with an unhandled error (`updateAddress is not a function`). It happened when you later changed the active account **inside the extension**: MEW was still listening for that change from the earlier connected session and tried to update an address on a wallet that can no longer be updated. 205 occurrences in Sentry since April, still happening on the latest release.

## What changed

The header's "account changed" listener now checks that the current wallet actually supports address updates before doing anything. If you're in watch-only mode or disconnected, the stale event is simply ignored instead of throwing. Applied to both the Ethereum and Bitcoin extension paths. No behavior change for a normally connected extension wallet — switching accounts still updates the active address as before.

## How to test

1. In Chrome with the Rabby (or MetaMask) extension, open the app and **connect** the extension wallet on Ethereum.
2. Switch to a **watch-only** view of an address (or disconnect the wallet) so you're no longer actively connected via the extension.
3. In the extension, **switch the active account**.
4. **Expected:** nothing crashes; no error toast / no console TypeError. Before this fix, step 3 threw `TypeError: updateAddress is not a function`.
5. Regression check: connect the extension wallet normally and switch accounts in the extension → the app should still update to the new address.

## Sentry

https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-V8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented errors when wallet account-change events occur after switching to a watch-only or disconnected state.
  * Improved handling of wallet connections that no longer support address updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->