### PR TITLE
fix: [MEW-2080] handle transient Trezor connect error on access

### DIFF
--- a/src/i18n/locales/common/en.json
+++ b/src/i18n/locales/common/en.json
@@ -53,6 +53,7 @@
       "user_canceled_request": "User canceled the request",
       "ledger_locked": "Your Ledger is locked. Unlock it and try again.",
       "ledger_app_not_open": "Open the Ethereum app on your Ledger and try again.",
+      "trezor_read_failed": "Couldn't read your address from Trezor. Reconnect the device and try again.",
       "method_not_implemented": "Method not implemented: {method}",
       "invalid_name": "Invalid name",
       "address_resolution_failed": "Address resolution failed",

--- a/src/i18n/locales/common/es.json
+++ b/src/i18n/locales/common/es.json
@@ -53,6 +53,7 @@
       "user_canceled_request": "El usuario canceló la solicitud",
       "ledger_locked": "Tu Ledger está bloqueado. Desbloquéalo e inténtalo de nuevo.",
       "ledger_app_not_open": "Abre la aplicación de Ethereum en tu Ledger e inténtalo de nuevo.",
+      "trezor_read_failed": "No se pudo leer tu dirección desde Trezor. Reconecta el dispositivo e inténtalo de nuevo.",
       "method_not_implemented": "Método no implementado: {method}",
       "invalid_name": "Nombre no válido",
       "address_resolution_failed": "No se pudo resolver la dirección",

--- a/src/i18n/locales/common/zh.json
+++ b/src/i18n/locales/common/zh.json
@@ -53,6 +53,7 @@
       "user_canceled_request": "用户已取消请求",
       "ledger_locked": "您的 Ledger 已锁定。请解锁后重试。",
       "ledger_app_not_open": "请在您的 Ledger 上打开以太坊应用后重试。",
+      "trezor_read_failed": "无法从 Trezor 读取您的地址。请重新连接设备后重试。",
       "method_not_implemented": "方法未实现：{method}",
       "invalid_name": "名称无效",
       "address_resolution_failed": "地址解析失败",

--- a/src/modules/access/ModuleAccessHardwareWallet.vue
+++ b/src/modules/access/ModuleAccessHardwareWallet.vue
@@ -116,7 +116,10 @@ import {
 import { useRecentWalletsStore } from '@/stores/recentWalletsStore'
 import { MAIN_TOKEN_CONTRACT } from '@/stores/walletStore'
 import { useI18n } from 'vue-i18n'
-import { getLocalizedWalletError } from '@/utils/walletUtils'
+import {
+  getLocalizedWalletError,
+  isTransientTrezorError,
+} from '@/utils/walletUtils'
 import { useDerivationStore } from '@/stores/derivationStore'
 import { storeToRefs } from 'pinia'
 import HWwallet from '@enkryptcom/hw-wallets'
@@ -494,7 +497,11 @@ const loadList = async (page: number = 0) => {
         getLocalizedWalletError(e instanceof Error ? e.message : String(e)) ??
         (e instanceof Error ? e.message : String(e)),
     })
-    captureException(e, SENTRY_MODULE_TAGS.ACCESS)
+    // Skip Sentry for the known transient Trezor connect state (APP-MEW-WEB-P5):
+    // the popup returns success with an empty payload and retrying works.
+    if (!isTransientTrezorError(e)) {
+      captureException(e, SENTRY_MODULE_TAGS.ACCESS)
+    }
   } finally {
     if (generation === loadListGeneration) {
       isLoadingWalletList.value = false

--- a/src/utils/walletUtils.ts
+++ b/src/utils/walletUtils.ts
@@ -60,5 +60,26 @@ export const getLocalizedWalletError = (
   ) {
     return t('common.error.ledger_app_not_open')
   }
+  // Transient Trezor connect state (APP-MEW-WEB-P5)
+  if (isTransientTrezorError(raw)) {
+    return t('common.error.trezor_read_failed')
+  }
   return undefined
+}
+
+/**
+ * A transient Trezor Connect failure: the popup/iframe returned `success`
+ * with an empty payload, so `@enkryptcom/hw-wallets` runs an unguarded
+ * `Buffer.from(undefined)` and throws a cryptic TypeError (or "popup failed
+ * to open"). Retrying usually succeeds, so this is safe to surface as a
+ * friendly "reconnect" message rather than reporting it as noise.
+ */
+export const isTransientTrezorError = (error: unknown): boolean => {
+  const message = (
+    error instanceof Error ? error.message : String(error ?? '')
+  ).toLowerCase()
+  return (
+    message.includes('popup failed to open') ||
+    message.includes('the first argument must be one of type string, buffer')
+  )
 }

--- a/tests/unit/utils/walletError.spec.ts
+++ b/tests/unit/utils/walletError.spec.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import i18n from '@/i18n'
-import { getLocalizedWalletError } from '@/utils/walletUtils'
+import {
+  getLocalizedWalletError,
+  isTransientTrezorError,
+} from '@/utils/walletUtils'
 
 /**
  * MEW-2049 — hardware-wallet (Ledger) errors must be shown localized.
@@ -57,5 +60,40 @@ describe('getLocalizedWalletError (MEW-2049)', () => {
     expect(getLocalizedWalletError('')).toBeUndefined()
     expect(getLocalizedWalletError(undefined)).toBeUndefined()
     expect(getLocalizedWalletError(null)).toBeUndefined()
+  })
+
+  // APP-MEW-WEB-P5 (MEW-2080) — transient Trezor connect state:
+  // @enkryptcom/hw-wallets does an unguarded Buffer.from(undefined) when
+  // Trezor Connect returns success with an empty payload.
+  it('maps the transient Trezor Buffer/popup errors to a localized message', () => {
+    const friendly =
+      "Couldn't read your address from Trezor. Reconnect the device and try again."
+    expect(
+      getLocalizedWalletError(
+        'The first argument must be one of type string, Buffer, ArrayBuffer, Array, or Array-like Object. Received type undefined',
+      ),
+    ).toBe(friendly)
+    expect(getLocalizedWalletError('popup failed to open')).toBe(friendly)
+  })
+})
+
+describe('isTransientTrezorError (MEW-2080)', () => {
+  it('flags the transient Trezor connect failures', () => {
+    expect(
+      isTransientTrezorError(
+        new TypeError(
+          'The first argument must be one of type string, Buffer, ArrayBuffer, Array, or Array-like Object. Received type undefined',
+        ),
+      ),
+    ).toBe(true)
+    expect(isTransientTrezorError(new Error('popup failed to open'))).toBe(true)
+    expect(isTransientTrezorError('popup failed to open')).toBe(true)
+  })
+
+  it('does not flag unrelated errors', () => {
+    expect(isTransientTrezorError(new Error('Ledger locked 0x5515'))).toBe(false)
+    expect(isTransientTrezorError('some unrelated rpc error')).toBe(false)
+    expect(isTransientTrezorError(undefined)).toBe(false)
+    expect(isTransientTrezorError(null)).toBe(false)
   })
 })


### PR DESCRIPTION
## What was wrong

When connecting a **Trezor** on the Access page, users sometimes saw a "Something went wrong" toast with a cryptic message: _"The first argument must be one of type string, Buffer... Received type undefined"_. This happens when the Trezor Connect popup returns "success" but an empty response (a transient device/popup state) — retrying normally works. Every occurrence was also reported to Sentry (460+ events, 0 users actually impacted).

## What changed

- The transient Trezor state now shows a clear, localized message instead of the raw error: **"Couldn't read your address from Trezor. Reconnect the device and try again."** (en / es / zh).
- This specific transient, retry-able state is no longer reported to Sentry as an error (removes the noise).
- Added a small `isTransientTrezorError` helper + unit tests.

## How to test

1. Go to `/access` and choose **Trezor** on **Ethereum**.
2. Happy path: the address list should load normally (fix does not change successful connects).
3. Transient-failure path (if you can reproduce it — cancel/close the Trezor popup mid-read, or otherwise get an empty response): instead of the cryptic Buffer message, the toast should read _"Couldn't read your address from Trezor. Reconnect the device and try again."_
4. Ledger connect flows should be unchanged (locked/app-not-open messages still work).

## Sentry

https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-P5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added clearer localized messaging when reading a Trezor address fails.
  * Users are prompted to reconnect their device and try again.
  * Transient Trezor connection errors are handled without unnecessary error reporting.
  * Added support for English, Spanish, and Chinese translations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->