### PR TITLE
fix: [MEW-2083] drop viem tx receipt timeout sentry noise

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ import configs from '@/configs'
 import {
   isExtensionOrProviderError,
   isInvalidWalletAddressError,
+  isTransactionReceiptTimeoutError,
 } from '@/sentry/extensionNoise'
 import { isTransientRpcError } from '@/modules/trade/composables/transientRpcError'
 
@@ -57,16 +58,19 @@ if (dsn && process.env.NODE_ENV === 'production') {
     // "provider disconnected"), viem InvalidAddressError (a wallet returned a
     // malformed address on connect — already handled with a user toast), and
     // transient RPC/WebSocket drops (e.g. a mewapi wss node closing mid-request,
-    // surfacing as an unhandled "Connection is closed" rejection). These surface
-    // as serialized plain objects or bare strings with no parsed frames, so
-    // denyUrls can't catch them — inspect the original exception instead.
-    // Genuine app errors are unaffected.
+    // surfacing as an unhandled "Connection is closed" rejection), and viem
+    // WaitForTransactionReceiptTimeoutError (a submitted trade tx that did not
+    // confirm within the timeout — a network condition the app already handles).
+    // These surface as serialized plain objects or bare strings with no parsed
+    // frames, so denyUrls can't catch them — inspect the original exception
+    // instead. Genuine app errors are unaffected.
     beforeSend(event, hint) {
       const originalException = hint?.originalException
       if (
         isExtensionOrProviderError(originalException) ||
         isInvalidWalletAddressError(originalException) ||
-        isTransientRpcError(originalException)
+        isTransientRpcError(originalException) ||
+        isTransactionReceiptTimeoutError(originalException)
       )
         return null
       return event
@@ -122,11 +126,10 @@ pinia.use(
           },
           purchase: null,
           chainsStore: {
-            ...state.chainsStore as | Record<string, unknown> | undefined,
+            ...(state.chainsStore as Record<string, unknown> | undefined),
             allChains: null, // too large to send
-            chains: null // too large to send
-
-          }
+            chains: null, // too large to send
+          },
         }
       }
       return state

--- a/src/sentry/extensionNoise.ts
+++ b/src/sentry/extensionNoise.ts
@@ -36,3 +36,23 @@ export function isInvalidWalletAddressError(err: unknown): boolean {
   if (!err || typeof err !== 'object') return false
   return (err as { name?: unknown }).name === 'InvalidAddressError'
 }
+
+/**
+ * Whether an error is a viem `WaitForTransactionReceiptTimeoutError` — thrown
+ * when `waitForTransactionReceipt` times out because a submitted trade/swap tx
+ * did not confirm within the timeout window (slow node, congestion, dropped tx,
+ * or a flaky mobile connection). This is an inherent blockchain/network
+ * condition, not an app bug — the tx may still confirm later and the app
+ * already handles it (`handled: yes`), so it is unactionable Sentry noise.
+ * Detected via the viem-guaranteed error `name` (survives minification),
+ * walking the `cause` chain since viem may nest it.
+ */
+export function isTransactionReceiptTimeoutError(err: unknown): boolean {
+  let cur: unknown = err
+  for (let depth = 0; cur && typeof cur === 'object' && depth < 6; depth++) {
+    const e = cur as { name?: unknown; cause?: unknown }
+    if (e.name === 'WaitForTransactionReceiptTimeoutError') return true
+    cur = e.cause
+  }
+  return false
+}

--- a/tests/unit/sentry/extensionNoise.spec.ts
+++ b/tests/unit/sentry/extensionNoise.spec.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect } from 'vitest'
-import { InvalidAddressError } from 'viem'
+import {
+  InvalidAddressError,
+  WaitForTransactionReceiptTimeoutError,
+} from 'viem'
 import {
   isExtensionOrProviderError,
   isInvalidWalletAddressError,
+  isTransactionReceiptTimeoutError,
 } from '@/sentry/extensionNoise'
 
 describe('isExtensionOrProviderError', () => {
@@ -57,9 +61,9 @@ describe('isExtensionOrProviderError', () => {
   })
 
   it('is false for non-benign provider-looking codes (e.g. -32603 internal)', () => {
-    expect(isExtensionOrProviderError({ code: -32603, message: 'Internal' })).toBe(
-      false,
-    )
+    expect(
+      isExtensionOrProviderError({ code: -32603, message: 'Internal' }),
+    ).toBe(false)
   })
 
   it('is false for non-object inputs', () => {
@@ -107,5 +111,55 @@ describe('isInvalidWalletAddressError', () => {
     expect(isInvalidWalletAddressError(null)).toBe(false)
     expect(isInvalidWalletAddressError(undefined)).toBe(false)
     expect(isInvalidWalletAddressError('InvalidAddressError')).toBe(false)
+  })
+})
+
+describe('isTransactionReceiptTimeoutError', () => {
+  it('is true for a real viem WaitForTransactionReceiptTimeoutError instance', () => {
+    const err = new WaitForTransactionReceiptTimeoutError({ hash: '0xabc' })
+    expect(isTransactionReceiptTimeoutError(err)).toBe(true)
+  })
+
+  it('is true for the serialized production payload (plain object with name)', () => {
+    // Sentry hands beforeSend the original exception, but be robust to a
+    // serialized plain object carrying only the viem error name.
+    expect(
+      isTransactionReceiptTimeoutError({
+        name: 'WaitForTransactionReceiptTimeoutError',
+        message:
+          'Timed out while waiting for transaction with hash "0x99…" to be confirmed.',
+      }),
+    ).toBe(true)
+  })
+
+  it('is true when nested in the cause chain', () => {
+    expect(
+      isTransactionReceiptTimeoutError({
+        name: 'SomeWrapperError',
+        cause: { name: 'WaitForTransactionReceiptTimeoutError' },
+      }),
+    ).toBe(true)
+  })
+
+  it('is false for a genuine app error', () => {
+    expect(
+      isTransactionReceiptTimeoutError(
+        new TypeError("Cannot read properties of undefined (reading 'x')"),
+      ),
+    ).toBe(false)
+    expect(
+      isTransactionReceiptTimeoutError({
+        name: 'SomeOtherError',
+        message: 'x',
+      }),
+    ).toBe(false)
+  })
+
+  it('is false for non-object inputs', () => {
+    expect(isTransactionReceiptTimeoutError(null)).toBe(false)
+    expect(isTransactionReceiptTimeoutError(undefined)).toBe(false)
+    expect(
+      isTransactionReceiptTimeoutError('WaitForTransactionReceiptTimeoutError'),
+    ).toBe(false)
   })
 })


### PR DESCRIPTION
## What was wrong

Sentry was collecting `WaitForTransactionReceiptTimeoutError` (viem) whenever a submitted trade/swap transaction did not confirm within viem's `waitForTransactionReceipt` timeout window. 153 events since April, 0 users impacted, mostly on mobile in-app browsers (Chrome Mobile WebView / MEW Mobile). This is an inherent blockchain/network condition — a slow node, congestion, a dropped tx, or a flaky mobile connection — not a defect in MEW code. The error is already `handled: yes` (the app catches it and the tx may still confirm later), so it was pure Sentry noise.

## What changed

Added a narrow `beforeSend` filter, `isTransactionReceiptTimeoutError`, in `src/sentry/extensionNoise.ts`, wired into `src/main.ts` alongside the existing extension / invalid-address / transient-RPC noise filters. It matches viem's guaranteed error `name` (`WaitForTransactionReceiptTimeoutError`), walking the `cause` chain so it survives minification and nesting. Kept deliberately separate from `isTransientRpcError` so trade quote-retry behavior is untouched. Added a unit spec.

Only Sentry reporting is affected — genuine app errors and all user-visible behavior are unchanged.

## How to test

This change is not directly user-visible (it only suppresses a Sentry report). To verify behavior is intact:
- Run the wallet, connect a wallet, submit a swap/trade on Ethereum, and confirm the flow behaves exactly as before (success toast on confirmation, existing handling on timeout).
- Unit: `pnpm vitest run tests/unit/sentry/extensionNoise.spec.ts` (15 tests pass, including the new `isTransactionReceiptTimeoutError` cases).
- Type-check + lint are green.

## Assumptions (full-auto sweep)

- Treated this as unactionable Sentry noise rather than a behavioral bug: the error is `handled: yes` and the timeout is intrinsic to on-chain confirmation, so there is no MEW-side code path that can prevent it. If the team instead wants a user-facing "still pending" affordance on receipt timeout, that is a separate feature ticket.

## Sentry

https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-X6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary error reporting by filtering transaction receipt timeout errors from diagnostics.
  * Improved handling of application state captured in diagnostic reports to avoid sending oversized chain data.
* **Tests**
  * Added coverage for timeout errors represented as native errors, serialized payloads, nested causes, and unrelated inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->