### PR TITLE
fix: [MEW-2084] drop external 'not found rainbowkit' sentry noise

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ import configs from '@/configs'
 import {
   isExtensionOrProviderError,
   isInvalidWalletAddressError,
+  isRainbowKitNotFoundError,
 } from '@/sentry/extensionNoise'
 import { isTransientRpcError } from '@/modules/trade/composables/transientRpcError'
 
@@ -57,15 +58,18 @@ if (dsn && process.env.NODE_ENV === 'production') {
     // "provider disconnected"), viem InvalidAddressError (a wallet returned a
     // malformed address on connect — already handled with a user toast), and
     // transient RPC/WebSocket drops (e.g. a mewapi wss node closing mid-request,
-    // surfacing as an unhandled "Connection is closed" rejection). These surface
-    // as serialized plain objects or bare strings with no parsed frames, so
-    // denyUrls can't catch them — inspect the original exception instead.
-    // Genuine app errors are unaffected.
+    // surfacing as an unhandled "Connection is closed" rejection), and the
+    // external "not found rainbowkit" rejection emitted by a wallet's injected
+    // in-app-browser detection script (not app code — our bundle never throws
+    // it). These surface as serialized plain objects or bare strings with no
+    // parsed frames, so denyUrls can't catch them — inspect the original
+    // exception instead. Genuine app errors are unaffected.
     beforeSend(event, hint) {
       const originalException = hint?.originalException
       if (
         isExtensionOrProviderError(originalException) ||
         isInvalidWalletAddressError(originalException) ||
+        isRainbowKitNotFoundError(originalException) ||
         isTransientRpcError(originalException)
       )
         return null

--- a/src/sentry/extensionNoise.ts
+++ b/src/sentry/extensionNoise.ts
@@ -25,6 +25,22 @@ export function isExtensionOrProviderError(err: unknown): boolean {
 }
 
 /**
+ * Whether an error is the external "not found rainbowkit" rejection. It is
+ * emitted by a wallet's injected in-app-browser detection script (observed on
+ * mobile Safari / iOS in-app wallet browsers), never by app code or any bundled
+ * dependency — our `@rainbow-me/rainbowkit` only ever throws "Connector not
+ * found". It reaches the global Sentry `beforeSend` as an unhandled rejection
+ * with no first-party frames, so it is pure external noise. Matched by message
+ * on both the Error-object and bare-string payload shapes.
+ */
+export function isRainbowKitNotFoundError(err: unknown): boolean {
+  if (typeof err === 'string') return err.includes('not found rainbowkit')
+  if (!err || typeof err !== 'object') return false
+  const message = (err as { message?: unknown }).message
+  return typeof message === 'string' && message.includes('not found rainbowkit')
+}
+
+/**
  * Whether an error is a viem `InvalidAddressError` — thrown when a connected
  * wallet returns a malformed account address from `eth_requestAccounts`
  * (observed from buggy in-app wallet browsers). The connect flow already

--- a/tests/unit/sentry/extensionNoise.spec.ts
+++ b/tests/unit/sentry/extensionNoise.spec.ts
@@ -3,6 +3,7 @@ import { InvalidAddressError } from 'viem'
 import {
   isExtensionOrProviderError,
   isInvalidWalletAddressError,
+  isRainbowKitNotFoundError,
 } from '@/sentry/extensionNoise'
 
 describe('isExtensionOrProviderError', () => {
@@ -107,5 +108,40 @@ describe('isInvalidWalletAddressError', () => {
     expect(isInvalidWalletAddressError(null)).toBe(false)
     expect(isInvalidWalletAddressError(undefined)).toBe(false)
     expect(isInvalidWalletAddressError('InvalidAddressError')).toBe(false)
+  })
+})
+
+describe('isRainbowKitNotFoundError', () => {
+  it('is true for the Error-object rejection from the injected script', () => {
+    expect(isRainbowKitNotFoundError(new Error('not found rainbowkit'))).toBe(
+      true,
+    )
+    expect(
+      isRainbowKitNotFoundError({ message: 'not found rainbowkit' }),
+    ).toBe(true)
+  })
+
+  it('is true for a bare-string rejection', () => {
+    expect(isRainbowKitNotFoundError('not found rainbowkit')).toBe(true)
+    // Some handlers prefix the Error name onto the serialized value.
+    expect(isRainbowKitNotFoundError('Error: not found rainbowkit')).toBe(true)
+  })
+
+  it('is false for our bundled rainbowkit "Connector not found" error', () => {
+    expect(isRainbowKitNotFoundError(new Error('Connector not found'))).toBe(
+      false,
+    )
+  })
+
+  it('is false for genuine app errors and non-matching inputs', () => {
+    expect(
+      isRainbowKitNotFoundError(
+        new TypeError("Cannot read properties of undefined (reading 'x')"),
+      ),
+    ).toBe(false)
+    expect(isRainbowKitNotFoundError(null)).toBe(false)
+    expect(isRainbowKitNotFoundError(undefined)).toBe(false)
+    expect(isRainbowKitNotFoundError({ message: 42 })).toBe(false)
+    expect(isRainbowKitNotFoundError('something else')).toBe(false)
   })
 })


### PR DESCRIPTION
## What was wrong

Sentry was collecting an unhandled promise rejection `Error: not found rainbowkit` (372 events, 0 users) on the `/stocks` route, seen only inside mobile in-app wallet browsers (observed: Mobile Safari iOS 18.5, Rabby Wallet watch-only). The error is emitted by a wallet's injected in-app-browser detection script — it is **not** thrown by our app or any bundled dependency (our `@rainbow-me/rainbowkit` only ever throws `"Connector not found"`), and the event carries no first-party frames. It was pure external noise crowding the Sentry dashboard.

## What changed

- Added a narrow `isRainbowKitNotFoundError` predicate in `src/sentry/extensionNoise.ts` that matches the `"not found rainbowkit"` message on both Error-object and bare-string payload shapes.
- Wired it into the existing `beforeSend` filter chain in `src/main.ts`, alongside the existing extension/provider, invalid-address, and transient-RPC predicates.
- Added unit coverage in `tests/unit/sentry/extensionNoise.spec.ts`, including a guard that the bundled `"Connector not found"` error is **not** filtered.

Genuine app errors are unaffected — the match is specific to the exact injected-script phrase.

## How to test

Behavioral change is Sentry-side only (no user-visible UI change):
- `pnpm vitest run tests/unit/sentry/extensionNoise.spec.ts` — 14 tests pass.
- `pnpm vue-tsc --noEmit -p tsconfig.app.json` — clean.
- Smoke: load `/stocks` in a normal browser and confirm the page behaves exactly as before (this error never fired outside mobile in-app wallet browsers, so there is nothing new to see locally).

## Notes / assumptions (full-auto sweep)

- Triaged as external Sentry noise: the literal string exists in no app source and no dependency; only mobile in-app wallet browsers are affected. Chosen fix follows the established `beforeSend` noise-predicate pattern already used for extension/provider, invalid-address, and transient-RPC errors.

## Sentry

https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-DG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced irrelevant Sentry error reports caused by RainbowKit “not found” rejection noise.
  * Preserved reporting for genuine application errors and unrelated connector errors.
  * Improved detection across string, serialized object, and Error-like rejection formats.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->