### PR TITLE
fix: [MEW-2086] drop transient walletconnect subscribe-failed sentry noise

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -49,6 +49,11 @@ if (dsn && process.env.NODE_ENV === 'production') {
       'Proposal expired',
       'Pairing expired',
       'Request expired',
+      // Transient WalletConnect relay hiccup: the @walletconnect/core Subscriber
+      // fails to subscribe to a session topic over the relay WebSocket. The
+      // connect flow already handles it (user gets a "Could not connect" toast
+      // and can retry), so it is benign, unactionable network noise.
+      /Subscribing to \w+ failed, please try again/,
     ],
     // Drop errors thrown inside browser extensions (catches events that DO
     // carry parsed extension frames).


### PR DESCRIPTION
## What was wrong

When a user starts a WalletConnect connection from Home and the WalletConnect relay WebSocket hiccups, the `@walletconnect/core` SDK throws `Error: Subscribing to <topic> failed, please try again`. This is transient network flakiness with the third-party relay — the app already catches it, shows a "Could not connect to wallet" toast, and lets the user retry. Despite being handled and harmless, it was being reported to Sentry (179 events, 0 users impacted over ~3.5 months), adding noise.

## What changed

Added a narrow message pattern to the existing `ignoreErrors` list in `src/main.ts` — the same section that already ignores WalletConnect "Proposal/Pairing/Request expired" rejections. The regex `/Subscribing to \w+ failed, please try again/` drops only this specific benign WalletConnect relay error before it reaches Sentry. No app behavior changes; genuine errors are unaffected.

## How to test

There is no deterministic client-side repro (it depends on a relay-side subscribe failure). Smoke-test that the normal WalletConnect flow still works and no console/behavior regressions occur:

1. Open the app at the dev server URL, land on Home (wallet not connected).
2. Start the "Connect Wallet" / WalletConnect flow.
3. Verify the connect modal opens and a successful connect still works as before.
4. Verify that when a connection genuinely fails, the existing "Could not connect to wallet" toast still appears (unchanged behavior).

The filter itself is verified by the pattern; production Sentry should stop receiving this specific error going forward.

## Assumptions (full-auto sweep)

- Treated this as pure transient third-party Sentry noise (handled = yes, 0 users impacted). Chose the idiomatic one-line `ignoreErrors` addition over a new `extensionNoise.ts` predicate because the error carries a clean, stable message and lives in the same benign-WalletConnect category already handled there.

## Sentry

https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-PH