### PR TITLE
fix: [MEW-2082] skip transient 1inch network errors in trade quote sentry reporting

### DIFF
--- a/src/modules/trade/composables/transientRpcError.ts
+++ b/src/modules/trade/composables/transientRpcError.ts
@@ -50,3 +50,22 @@ export function isTransientRpcError(e: unknown): boolean {
   }
   return false
 }
+
+/**
+ * Whether an error is an axios "Network Error" — the HTTP request never
+ * completed (no response received: offline, DNS/CORS failure, connection reset,
+ * request aborted). axios flags these with `code === 'ERR_NETWORK'` and a
+ * hard-coded `message === 'Network Error'`. These are transient, environmental
+ * failures already surfaced to the user, so the trade-quote flow skips reporting
+ * them to Sentry. Deliberately kept separate from `isTransientRpcError` (which
+ * the global `beforeSend` also uses) so the trade-quote suppression does not
+ * broaden into dropping unrelated "network error" messages app-wide.
+ */
+export function isAxiosNetworkError(e: unknown): boolean {
+  if (!e || typeof e !== 'object') return false
+  const err = e as { code?: unknown; message?: unknown; response?: unknown }
+  return (
+    err.code === 'ERR_NETWORK' ||
+    (err.response == null && err.message === 'Network Error')
+  )
+}

--- a/src/modules/trade/composables/useTradeQuote.ts
+++ b/src/modules/trade/composables/useTradeQuote.ts
@@ -175,12 +175,17 @@ export function useTradeQuote(options: UseTradeQuoteOptions) {
         // wss://nodes.mewapi.io) are surfaced to the user above but are pure
         // Sentry noise — only report genuine quote failures.
         // Expected client errors (1inch 4xx, flagged by OneInchFusion.getQuote)
-        // are surfaced to the user above but are pure Sentry noise — skip them.
+        // and transient axios "Network Error"s (the 1inch request never
+        // completed) are surfaced to the user above but are pure Sentry noise —
+        // skip them.
         const isExpectedClientError = !!(e as { expectedClientError?: boolean })
           .expectedClientError
+        const isTransientNetworkError = !!(
+          e as { transientNetworkError?: boolean }
+        ).transientNetworkError
         if (isDevMode) {
           console.error('Error fetching quote:', e)
-        } else if (!isExpectedClientError) {
+        } else if (!isExpectedClientError && !isTransientNetworkError) {
           captureException(e, {
             ...SENTRY_MODULE_TAGS.TRADE,
             extra: {

--- a/src/modules/trade/providers/oneinch_fusion/oneInchFusion.ts
+++ b/src/modules/trade/providers/oneinch_fusion/oneInchFusion.ts
@@ -28,6 +28,7 @@ import {
 } from './configs'
 import { Web3ProviderConnector } from './oneInchProvider'
 import type { AxiosError } from 'axios'
+import { isAxiosNetworkError } from '@/modules/trade/composables/transientRpcError'
 // NOTE: getQuote no longer reports to Sentry directly — reporting is centralized
 // in the caller (useTradeQuote) so expected 4xx client errors can be skipped.
 import type BaseEvmWallet from '@/providers/ethereum/baseEvmWallet'
@@ -180,9 +181,16 @@ class OneInchFusion {
         response ||
           rawMessage ||
           i18n.global.t('trade.error.failed-fetch-quote-1inch'),
-      ) as Error & { expectedClientError?: boolean }
+      ) as Error & {
+        expectedClientError?: boolean
+        transientNetworkError?: boolean
+      }
       error.expectedClientError =
         typeof status === 'number' && status >= 400 && status < 500
+      // A transient axios "Network Error" (the 1inch request never completed —
+      // no response received) is environmental noise, already surfaced to the
+      // user; flag it so the caller skips Sentry reporting.
+      error.transientNetworkError = isAxiosNetworkError(e)
       throw error
     }
   }

--- a/tests/unit/modules/trade/transientRpcError.spec.ts
+++ b/tests/unit/modules/trade/transientRpcError.spec.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest'
-import { isTransientRpcError } from '@/modules/trade/composables/transientRpcError'
+import {
+  isTransientRpcError,
+  isAxiosNetworkError,
+} from '@/modules/trade/composables/transientRpcError'
 
 describe('isTransientRpcError', () => {
   it('is true for the top-level viem error whose message is "WebSocket request failed"', () => {
@@ -72,5 +75,48 @@ describe('isTransientRpcError', () => {
     expect(isTransientRpcError(null)).toBe(false)
     expect(isTransientRpcError(undefined)).toBe(false)
     expect(isTransientRpcError('')).toBe(false)
+  })
+})
+
+describe('isAxiosNetworkError', () => {
+  it('is true for a raw axios network error (code ERR_NETWORK, no response)', () => {
+    // The exact production shape: axios rejects with code 'ERR_NETWORK' and a
+    // hard-coded message when the 1inch request never completes (APP-MEW-WEB-13E).
+    expect(
+      isAxiosNetworkError({
+        code: 'ERR_NETWORK',
+        message: 'Network Error',
+        request: {},
+      }),
+    ).toBe(true)
+  })
+
+  it('is true when the code is absent but message is "Network Error" and no response', () => {
+    expect(isAxiosNetworkError({ message: 'Network Error' })).toBe(true)
+  })
+
+  it('is false for a 1inch 4xx client error (has a response)', () => {
+    expect(
+      isAxiosNetworkError({
+        code: 'ERR_BAD_REQUEST',
+        message: 'Request failed with status code 400',
+        response: { status: 400 },
+      }),
+    ).toBe(false)
+  })
+
+  it('is false for a genuine app error', () => {
+    expect(
+      isAxiosNetworkError({
+        name: 'TypeError',
+        message: "Cannot read properties of undefined (reading 'presets')",
+      }),
+    ).toBe(false)
+  })
+
+  it('is false for non-object / nullish inputs', () => {
+    expect(isAxiosNetworkError(null)).toBe(false)
+    expect(isAxiosNetworkError(undefined)).toBe(false)
+    expect(isAxiosNetworkError('Network Error')).toBe(false)
   })
 })


### PR DESCRIPTION
## What was wrong

On the trade/stocks quote flow, when the request to 1inch for a quote fails at the network layer (an axios "Network Error" — the HTTP call never completes: offline, DNS/CORS failure, connection reset, aborted request), the app already handles it gracefully (shows the user a "failed to fetch quote" message) but still reported the error to Sentry. This is a transient, environmental failure — not an actionable app bug — and it accounted for 606 Sentry events / 0 users over ~2 months, drowning out real errors.

The existing quote-error suppression only skipped viem WebSocket/socket drops (`isTransientRpcError`) and 1inch 4xx client errors (`expectedClientError`); a bare network failure matched neither and slipped through.

## What changed

- Added a precise `isAxiosNetworkError` predicate (matches axios `code === 'ERR_NETWORK'`, or a no-response error whose message is `"Network Error"`).
- `OneInchFusion.getQuote` now flags a network failure on the thrown error (`transientNetworkError`), exactly like it already flags `expectedClientError` for 1inch 4xx responses.
- The single reporting caller (`useTradeQuote`) skips `captureException` for that flag.
- The predicate is deliberately kept out of the global `beforeSend` chain (unlike `isTransientRpcError`) so suppression stays scoped to the trade-quote path and does not start dropping unrelated "network error" messages app-wide (e.g. MEW-API failures).
- Added unit coverage in `transientRpcError.spec.ts`.

The user-facing behavior is unchanged — the "failed to fetch quote" message still shows. Only the redundant Sentry report is suppressed.

## How to test

1. Open the dev server, connect any EVM wallet (e.g. Rabby), go to a trade/stocks page and start a swap quote (route `/stocks/stock/*` or the trade panel).
2. Simulate a network failure for the 1inch quote request — e.g. in DevTools set the network to Offline (or block `fusion.1inch.io`) and enter an amount so a quote is requested.
3. Expected: the UI shows the "failed to fetch quote" error/toast as before, and **no** `TRADE: Error fetching quote` / "Network Error" event is sent to Sentry.
4. Sanity check the happy path still works with the network back online, and that a genuine bad-pair error (1inch 4xx) still surfaces to the user.

## Notes / assumptions (full-auto sweep)

- Root-caused against `feat/v7-develop` @ 431765318e. This is a handled error already surfaced to the user; the fix only removes the redundant Sentry noise, so it is low-risk.
- Kept within a scoped 3-file change (+ test) rather than a global `beforeSend` predicate, to avoid suppressing unrelated network errors elsewhere.

## Sentry

https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-13E

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of temporary network failures during trade quote requests.
  * Prevented transient network issues from being reported as unexpected application errors.
  * Continued distinguishing genuine quote failures from expected client-side errors.

* **Tests**
  * Added coverage for various network error scenarios, including malformed, client, and non-object errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->