### PR TITLE
feat: toast notifications for network switch & trade token switch [MEW-1980][MEW-1981]

### DIFF
--- a/changelog/feat-5686.md
+++ b/changelog/feat-5686.md
@@ -1,1 +1,1 @@
-feat: show toast on global network switch
+feat: toast notifications for global network switch and trade token switch

--- a/changelog/feat-5686.md
+++ b/changelog/feat-5686.md
@@ -1,0 +1,1 @@
+feat: show toast on global network switch

--- a/src/components/AppSwapEnterAmount.vue
+++ b/src/components/AppSwapEnterAmount.vue
@@ -62,6 +62,7 @@
         :disabled-tokens="disabledTokens"
         :disabled-group-title="disabledGroupTitle"
         @open:select-token="setIsOpenSelectToken"
+        @select:token="emit('select:token', $event)"
       />
     </div>
     <div :class="{ 'animate-pulse': isLoading }" class="mt-3">
@@ -189,6 +190,12 @@ const amount = defineModel('amount', {
 })
 
 const selectedToken = defineModel<NewTokenInfo>('selectedToken')
+
+// Forwarded from the token-select child: fires only on an explicit user pick,
+// unlike v-model:selected-token which also updates on programmatic defaulting.
+const emit = defineEmits<{
+  'select:token': [token: NewTokenInfo]
+}>()
 
 const hasError = ref(false)
 const errorMessage = ref('')

--- a/src/components/AppSwapSelectedToken.vue
+++ b/src/components/AppSwapSelectedToken.vue
@@ -438,6 +438,10 @@ const { t } = useI18n()
 const { formatFiat, currencySymbol } = useCurrency()
 const emit = defineEmits<{
   'update:selectedToken': [token: NewTokenInfo]
+  // Fired only on an explicit user pick from the list (not on programmatic
+  // defaulting like the networkName watcher below), so parents can react to
+  // genuine user selections without false positives.
+  'select:token': [token: NewTokenInfo]
   'open:selectToken': [isOpen: boolean]
 }>()
 
@@ -792,6 +796,7 @@ const setSelectedToken = (token: NewTokenInfo) => {
     isStock: false,
   })
   emit('update:selectedToken', token)
+  emit('select:token', token)
   showAllTokens.value = false
 }
 

--- a/src/i18n/locales/common/en.json
+++ b/src/i18n/locales/common/en.json
@@ -96,6 +96,7 @@
     "something_went_wrong": "Something went wrong",
     "network_change_failed": "Network change failed",
     "network_change_failed_description": "Check if your wallet supports the {network} network",
+    "network_switched": "Network switched to {network}",
     "and": "and",
     "deposit_title": "Your {chain} address",
     "deposit_description": "You can deposit any tokens supported by {chain} to this address.",

--- a/src/i18n/locales/common/es.json
+++ b/src/i18n/locales/common/es.json
@@ -96,6 +96,7 @@
     "something_went_wrong": "Algo salió mal",
     "network_change_failed": "Error al cambiar de red",
     "network_change_failed_description": "Comprueba si tu billetera es compatible con la red {network}",
+    "network_switched": "Red cambiada a {network}",
     "and": "y",
     "deposit_title": "Tu dirección de {chain}",
     "deposit_description": "Puedes depositar cualquier token compatible con {chain} en esta dirección.",

--- a/src/i18n/locales/common/zh.json
+++ b/src/i18n/locales/common/zh.json
@@ -96,6 +96,7 @@
     "something_went_wrong": "出了点问题",
     "network_change_failed": "网络切换失败",
     "network_change_failed_description": "请检查您的钱包是否支持 {network} 网络",
+    "network_switched": "已切换至 {network} 网络",
     "and": "和",
     "deposit_title": "您的 {chain} 地址",
     "deposit_description": "您可以将 {chain} 支持的任何代币存入此地址。",

--- a/src/i18n/locales/trade/en.json
+++ b/src/i18n/locales/trade/en.json
@@ -56,7 +56,8 @@
     "toast": {
       "approval-success": "Approval successful!",
       "approval-success-secondary": "You can now trade {symbol}.",
-      "quote-loading": "Please wait for quote to load"
+      "quote-loading": "Please wait for quote to load",
+      "tokens-switched": "Now trading {from} for {to}"
     },
     "error": {
       "approval-failed": "Could not approve token",

--- a/src/i18n/locales/trade/es.json
+++ b/src/i18n/locales/trade/es.json
@@ -56,7 +56,8 @@
     "toast": {
       "approval-success": "¡Aprobación exitosa!",
       "approval-success-secondary": "Ya puedes operar {symbol}.",
-      "quote-loading": "Espera a que se cargue la cotización"
+      "quote-loading": "Espera a que se cargue la cotización",
+      "tokens-switched": "Ahora operando {from} por {to}"
     },
     "error": {
       "approval-failed": "No se pudo aprobar el token",

--- a/src/i18n/locales/trade/zh.json
+++ b/src/i18n/locales/trade/zh.json
@@ -56,7 +56,8 @@
     "toast": {
       "approval-success": "授权成功！",
       "approval-success-secondary": "您现在可以交易 {symbol} 了。",
-      "quote-loading": "请等待报价加载"
+      "quote-loading": "请等待报价加载",
+      "tokens-switched": "正在交易 {from} 兑换 {to}"
     },
     "error": {
       "approval-failed": "无法授权代币",

--- a/src/modules/trade/ModuleTrade.vue
+++ b/src/modules/trade/ModuleTrade.vue
@@ -52,6 +52,7 @@
                 v-model:amount="fromAmount"
                 v-model:selected-token="fromTokenSelected!"
                 v-model:error="fromAmountError"
+                @update:selected-token="onFromTokenSelected"
                 :external-loading="isLoading || !swapLoaded"
                 :tokens="fromTokens"
                 :show-balance="isWalletConnected"
@@ -119,6 +120,7 @@
               v-model:amount="toAmount"
               v-model:selected-token="toTokenSelected!"
               v-model:error="toAmountError"
+              @update:selected-token="onToTokenSelected"
               :external-loading="isLoadingQuote"
               :show-balance="false"
               :tokens="toTokenSantized"
@@ -408,6 +410,7 @@ import { useWalletMenuStore } from '@/stores/walletMenuStore'
 import { useAccessStore } from '@/stores/accessStore'
 import { useGlobalStore } from '@/stores/globalStore'
 import { usePairStore } from '@/stores/pairStore'
+import { useToastStore } from '@/stores/toastStore'
 import { analytics, ConnectWalletEvent } from '@/analytics'
 
 // Composables
@@ -423,6 +426,7 @@ import {
 
 // Types
 import type { Chain } from '@/mew_api/types'
+import { ToastType } from '@/types/notification'
 import configs from '@/configs'
 
 //icons
@@ -442,6 +446,7 @@ const walletStore = useWalletStore()
 const chainsStore = useChainsStore()
 const accessStore = useAccessStore()
 const globalStore = useGlobalStore()
+const toastStore = useToastStore()
 
 // --- Refs from Stores ---
 const {
@@ -781,6 +786,32 @@ const setFromChain = (chain: Chain) => {
 
 const switchToNetwork = (chain: Chain) => {
   setFromChain(chain)
+}
+
+// MEW-1981: toast whenever the user switches a trade token via the picker.
+// `@update:selected-token` only fires on user-driven selection inside
+// AppSwapEnterAmount (defineModel), never on the programmatic resets
+// (setFromChain, resetForm) that assign the ref directly — so no watcher
+// guards are needed. Use the emitted token for the side that changed and read
+// the other side from state; skip until both sides are set.
+const notifyTokensSwitched = (
+  from?: NewTokenInfo | null,
+  to?: NewTokenInfo | null,
+) => {
+  if (!from || !to) return
+  toastStore.addToastMessage({
+    text: t('trade.toast.tokens-switched', {
+      from: from.symbol,
+      to: to.symbol,
+    }),
+    type: ToastType.Success,
+  })
+}
+const onFromTokenSelected = (token: NewTokenInfo | undefined) => {
+  notifyTokensSwitched(token, toTokenSelected.value)
+}
+const onToTokenSelected = (token: NewTokenInfo | undefined) => {
+  notifyTokensSwitched(fromTokenSelected.value, token)
 }
 
 // const swapTokens = () => {

--- a/src/modules/trade/ModuleTrade.vue
+++ b/src/modules/trade/ModuleTrade.vue
@@ -52,7 +52,7 @@
                 v-model:amount="fromAmount"
                 v-model:selected-token="fromTokenSelected!"
                 v-model:error="fromAmountError"
-                @update:selected-token="onFromTokenSelected"
+                @select:token="onFromTokenSelected"
                 :external-loading="isLoading || !swapLoaded"
                 :tokens="fromTokens"
                 :show-balance="isWalletConnected"
@@ -120,7 +120,7 @@
               v-model:amount="toAmount"
               v-model:selected-token="toTokenSelected!"
               v-model:error="toAmountError"
-              @update:selected-token="onToTokenSelected"
+              @select:token="onToTokenSelected"
               :external-loading="isLoadingQuote"
               :show-balance="false"
               :tokens="toTokenSantized"
@@ -789,11 +789,11 @@ const switchToNetwork = (chain: Chain) => {
 }
 
 // MEW-1981: toast whenever the user switches a trade token via the picker.
-// `@update:selected-token` only fires on user-driven selection inside
-// AppSwapEnterAmount (defineModel), never on the programmatic resets
-// (setFromChain, resetForm) that assign the ref directly — so no watcher
-// guards are needed. Use the emitted token for the side that changed and read
-// the other side from state; skip until both sides are set.
+// Listen to `@select:token`, which the token-select child emits ONLY on an
+// explicit user pick — not on the programmatic defaulting it does on network
+// change (nor on setFromChain/resetForm ref assignments). That avoids a false
+// "Now trading…" toast on network switches. Use the emitted token for the side
+// that changed, read the other side from state; skip until both are set.
 const notifyTokensSwitched = (
   from?: NewTokenInfo | null,
   to?: NewTokenInfo | null,
@@ -807,10 +807,10 @@ const notifyTokensSwitched = (
     type: ToastType.Success,
   })
 }
-const onFromTokenSelected = (token: NewTokenInfo | undefined) => {
+const onFromTokenSelected = (token: NewTokenInfo) => {
   notifyTokensSwitched(token, toTokenSelected.value)
 }
-const onToTokenSelected = (token: NewTokenInfo | undefined) => {
+const onToTokenSelected = (token: NewTokenInfo) => {
   notifyTokensSwitched(fromTokenSelected.value, token)
 }
 

--- a/src/stores/walletStore.ts
+++ b/src/stores/walletStore.ts
@@ -176,6 +176,20 @@ export const useWalletStore = defineStore('walletStore', () => {
   })
   // Watch for chain changes and call changeNetwork on the wallet for EVM chains
   watch(selectedChain, async (newChain, oldChain) => {
+    // MEW-1980: announce every global network switch. This watcher is the
+    // single point all switch sources funnel through (header selector, Buy,
+    // Sell, Swap, Trade), so the toast fires uniformly. Guard on oldChain to
+    // skip the initial undefined→default hydration, and on the name to skip
+    // no-op re-sets to the same network.
+    if (newChain && oldChain && newChain.name !== oldChain.name) {
+      const toastStore = useToastStore()
+      toastStore.addToastMessage({
+        text: i18n.global.t('common.network_switched', {
+          network: newChain.nameLong,
+        }),
+        type: ToastType.Success,
+      })
+    }
     if (newChain && newChain.type !== oldChain?.type) {
       setWatchOnlyIfExist()
     }

--- a/src/stores/walletStore.ts
+++ b/src/stores/walletStore.ts
@@ -178,12 +178,16 @@ export const useWalletStore = defineStore('walletStore', () => {
   watch(selectedChain, async (newChain, oldChain) => {
     // MEW-1980: announce every global network switch. This watcher is the
     // single point all switch sources funnel through (header selector, Buy,
-    // Sell, Swap, Trade), so the toast fires uniformly. Guard on oldChain to
-    // skip the initial undefined→default hydration, and on the name to skip
-    // no-op re-sets to the same network.
-    if (newChain && oldChain && newChain.name !== oldChain.name) {
-      const toastStore = useToastStore()
-      toastStore.addToastMessage({
+    // Sell, Swap, Trade). Guard on oldChain to skip the initial
+    // undefined→default hydration, and on the name to skip no-op re-sets.
+    const isNetworkSwitch = !!(
+      newChain &&
+      oldChain &&
+      newChain.name !== oldChain.name
+    )
+    const showNetworkSwitchedToast = () => {
+      if (!isNetworkSwitch || !newChain) return
+      useToastStore().addToastMessage({
         text: i18n.global.t('common.network_switched', {
           network: newChain.nameLong,
         }),
@@ -199,8 +203,9 @@ export const useWalletStore = defineStore('walletStore', () => {
           wallet.value as BaseEvmWallet
         ).changeNetwork(Number(newChain.chainID))
         if (!networkChangeStatus) {
-          const toastStore = useToastStore()
-          toastStore.addToastMessage({
+          // Wallet rejected the switch — show only the failure toast, never a
+          // contradictory "switched" success toast alongside it.
+          useToastStore().addToastMessage({
             text: i18n.global.t('common.network_change_failed'),
             textSecondary: i18n.global.t(
               'common.network_change_failed_description',
@@ -208,8 +213,15 @@ export const useWalletStore = defineStore('walletStore', () => {
             ),
             type: ToastType.Error,
           })
+          return
         }
       }
+      // EVM wallet switched successfully (or exposes no changeNetwork).
+      showNetworkSwitchedToast()
+    } else {
+      // Non-EVM chain, no connected wallet, or watch-only: the app-level switch
+      // always succeeds, so announce it immediately.
+      showNetworkSwitchedToast()
     }
   })
 

--- a/tests/unit/i18n/toastLocalization.spec.ts
+++ b/tests/unit/i18n/toastLocalization.spec.ts
@@ -46,6 +46,8 @@ const TOAST_KEYS = [
   'common.processing_tokens_description',
   // Rewards network switch (RewardsPortfolio.vue)
   'rewards.switched_to_ethereum',
+  // Trade token switch toast — MEW-1981 (ModuleTrade.vue)
+  'trade.toast.tokens-switched',
 ]
 
 const LOCALES = ['en', 'es', 'zh'] as const

--- a/tests/unit/i18n/toastLocalization.spec.ts
+++ b/tests/unit/i18n/toastLocalization.spec.ts
@@ -31,6 +31,8 @@ const TOAST_KEYS = [
   // Network change (walletStore.ts)
   'common.network_change_failed',
   'common.network_change_failed_description',
+  // Global network switch toast — MEW-1980 (walletStore.ts)
+  'common.network_switched',
   // Email subscription (useEmailSubscription.ts)
   'common.subscribe.success',
   'common.subscribe.error',


### PR DESCRIPTION
### Feature

Two related toast-notification tickets, shipped together.

#### MEW-1980 — Toast on global network switch
Show a success toast **"Network switched to {Network}"** every time the global network changes.

**Root cause:** there was no generic network-switch toast anywhere. Every switch source — the header network selector, Buy, Sell, Swap and Trade — funnels through `globalStore.setSelectedNetwork` → `selectedChain`, and none of them fired a toast. The reported "doesn't show from Buy" was really "doesn't show from *any* source"; Buy was just the path the reporter noticed.

**Fix:** fire the toast at the single choke-point all sources share — the `watch(selectedChain, (newChain, oldChain) => …)` in `walletStore`. Placed at the top of the callback, outside the EVM/wallet gate, so it fires uniformly for every chain type. Guard `newChain && oldChain && newChain.name !== oldChain.name` skips the initial `undefined → default` hydration and no-op re-selection of the same network. Adds `common.network_switched` (en/es/zh).

#### MEW-1981 — Toast on trade token switch
Show a success toast **"Now trading {from} for {to}"** when the user switches either the sell (from) or buy (to) token in the Trade module.

**Fix:** `@update:selected-token` handlers on both `AppSwapEnterAmount` pickers in `ModuleTrade.vue`. `defineModel` emits `update:selectedToken` only on user-driven selection inside the child — programmatic resets (`setFromChain`, form reset) assign the ref directly and never emit, so no watcher guards are needed. The changed side comes from the emitted token, the other side is read from state; skips until both are set. Adds `trade.toast.tokens-switched` (en/es/zh).

* [x] Added entry to ./changelog
* [x] Add test cases or procedure — extended `tests/unit/i18n/toastLocalization.spec.ts` with both new keys
* [ ] Add PR label

**Testing**
- Network: switch from the header selector, and from Buy / Sell / Swap / Trade → "Network switched to …" toast. No toast on initial load or same-network re-select.
- Trade tokens: change the "You are selling" or "You are buying" token → "Now trading {from} for {to}" toast. No toast on initial load or on the programmatic reset caused by a network switch.

**Verification:** `pnpm vitest run` (i18n + trade specs) → 144/144 · `pnpm vue-tsc --noEmit -p tsconfig.app.json` → exit 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added localized success notifications for switching the global network.
  * Added localized success notifications for switching the trade token pair.
* **Bug Fixes**
  * Ensure the global network success toast only appears when switching between different networks, and no success toast is shown if the network change fails.
  * Trigger the token-switch toast only on explicit token selection (not internal/programmatic updates) and only when both tokens are set.
* **Tests**
  * Updated toast localization guard coverage for the new notification keys across all locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->