### PR TITLE
Feat/v7 perps status

### DIFF
--- a/src/i18n/locales/perps/en.json
+++ b/src/i18n/locales/perps/en.json
@@ -430,6 +430,9 @@
       "panel-title": "Perpetuals isn’t available",
       "panel-description": "Unfortunately, trading perpetuals isn’t allowed in your current jurisdiction."
     },
+    "status": {
+      "unavailable": "Service temporarily unavailable, please try again later."
+    },
     "order-status": {
       "open": "Open",
       "fully-filled": "Fully Filled",

--- a/src/i18n/locales/perps/es.json
+++ b/src/i18n/locales/perps/es.json
@@ -446,6 +446,9 @@
       "panel-title": "Perpetuos no está disponible",
       "panel-description": "Lamentablemente, operar con perpetuos no está permitido en tu jurisdicción actual."
     },
+    "status": {
+      "unavailable": "Servicio temporalmente no disponible, vuelve a intentarlo más tarde."
+    },
     "pagination": {
       "previous-page": "página anterior",
       "next-page": "página siguiente",

--- a/src/i18n/locales/perps/zh.json
+++ b/src/i18n/locales/perps/zh.json
@@ -446,6 +446,9 @@
       "panel-title": "永续合约不可用",
       "panel-description": "很抱歉，您当前所在的司法管辖区不允许进行永续合约交易。"
     },
+    "status": {
+      "unavailable": "服务暂时不可用，请稍后再试。"
+    },
     "pagination": {
       "previous-page": "上一页",
       "next-page": "下一页",

--- a/src/modules/perps/components/PerpsStatusBanner.vue
+++ b/src/modules/perps/components/PerpsStatusBanner.vue
@@ -1,0 +1,42 @@
+<template>
+  <!--
+    Only rendered while `/status` answers with a server error. A 200 and a 429
+    both mean the service is answering, and the unknown state (first paint, or a
+    request that never got a response) reads the same way, so the page never
+    opens with an outage notice it cannot substantiate.
+  -->
+  <div
+    v-if="showBanner"
+    role="status"
+    class="flex items-center gap-2 w-full px-4 py-3 rounded-16 bg-warning-10 border-1 border-warning-10"
+  >
+    <!--
+      The amber lives in the tinted shell and the icon rather than the text:
+      `warning` is rgba(255,165,0) — around 2:1 against this background, which is
+      unreadable for body copy. Near-black text on the amber shell reads as an
+      amber banner without failing contrast.
+    -->
+    <exclamation-triangle-icon
+      class="w-5 h-5 shrink-0 text-warning"
+      aria-hidden="true"
+    />
+    <p class="text-s-14">{{ $t('perps.status.unavailable') }}</p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import { ExclamationTriangleIcon } from '@heroicons/vue/24/outline'
+import { usePerpsStatus } from '../composables/usePerpsStatus'
+import { usePerpsRestriction } from '../composables/usePerpsRestriction'
+
+const { isServiceUnavailable } = usePerpsStatus()
+const { isPerpsRestricted } = usePerpsRestriction()
+
+// The jurisdiction block outranks service availability: when perps are
+// unavailable in the region, whether the service is up is irrelevant and a
+// second banner would only compete with the restricted notice.
+const showBanner = computed(
+  () => isServiceUnavailable.value && !isPerpsRestricted.value,
+)
+</script>

--- a/src/modules/perps/composables/usePerpsStatus.ts
+++ b/src/modules/perps/composables/usePerpsStatus.ts
@@ -1,0 +1,117 @@
+import { computed, getCurrentScope, onScopeDispose, ref } from 'vue'
+import { captureException } from '@sentry/vue'
+import Configs from '@/configs'
+import { SENTRY_MODULE_TAGS } from '@/sentry/constants'
+import { perpsClient } from '../configs'
+import { PerpsHttpError } from '../sdk/client'
+
+const isDevMode = Configs.IS_DEV_MODE
+
+/**
+ * `/status` is unauthenticated and returns a single field, so polling it is
+ * cheap. A minute is enough resolution for a passive banner, and it doubles as
+ * the retry that clears the banner once the service recovers.
+ */
+const POLL_INTERVAL_MS = 60_000
+
+/**
+ * Server-error floor. Only a 5xx counts as an outage worth telling the user
+ * about; the endpoint documents 200, 429 and 500, and of those only the 500 is
+ * the service being down.
+ *
+ * A 429 is the opposite of an outage — the service answered, it just wants us to
+ * poll less — so it must not raise the banner. Anything else the endpoint might
+ * return (4xx, or a request that never got a response at all) is likewise not
+ * evidence the service is down.
+ */
+const SERVER_ERROR_STATUS = 500
+
+// Singleton state: every surface reads the same status, so the page banner and
+// any future consumer can never disagree about service availability.
+//
+// The last HTTP status observed from `/status`, or `null` before the first
+// response — and also when a request never reached one (offline, DNS, CORS,
+// aborted), which is indistinguishable from "unknown" for our purposes and
+// deliberately does not raise the banner.
+const statusCode = ref<number | null>(null)
+const isLoadingStatus = ref(false)
+let pollTimer: ReturnType<typeof setInterval> | null = null
+let consumers = 0
+
+/**
+ * Pings `/status` and returns the HTTP status it answered with (`null` if it
+ * never answered).
+ *
+ * Only the response code is consulted — the `marketStatus` field in the body is
+ * not read, since availability is what the banner reports.
+ */
+export async function fetchPerpsStatus(): Promise<number | null> {
+  isLoadingStatus.value = true
+  try {
+    await perpsClient.getStatus()
+    statusCode.value = 200
+  } catch (e) {
+    statusCode.value = e instanceof PerpsHttpError ? e.status : null
+    if (isDevMode) {
+      console.error('Failed to fetch perps status:', e)
+    } else {
+      captureException(e, {
+        ...SENTRY_MODULE_TAGS.PERPS,
+        extra: {
+          title: 'PERPS: Error fetching service status',
+          httpStatus: statusCode.value,
+          errorMessage: (e as Error).message || 'Unknown error',
+        },
+      })
+    }
+  } finally {
+    isLoadingStatus.value = false
+  }
+  return statusCode.value
+}
+
+/**
+ * True only while `/status` is answering with a server error. Everything else —
+ * a 200, a 429 throttle, an unreachable endpoint, or the window before the first
+ * response — reads as available, so the page never opens with an outage notice
+ * it cannot substantiate.
+ */
+const isServiceUnavailable = computed(
+  () => statusCode.value !== null && statusCode.value >= SERVER_ERROR_STATUS,
+)
+
+/**
+ * Availability of the perps service, from its `/status` endpoint.
+ *
+ * When called from a component (or any active effect scope) the status is
+ * refreshed on entry and kept warm on a timer that runs only while at least one
+ * consumer is mounted — leaving the perps page stops the polling. Called
+ * outside a scope it does a single fetch and never polls.
+ */
+export function usePerpsStatus() {
+  if (getCurrentScope()) {
+    consumers += 1
+    if (consumers === 1) {
+      // Refresh on (re)entry rather than trusting a value that may have gone
+      // stale while nothing was watching it.
+      void fetchPerpsStatus()
+      pollTimer = setInterval(() => void fetchPerpsStatus(), POLL_INTERVAL_MS)
+    }
+    onScopeDispose(() => {
+      consumers -= 1
+      if (consumers === 0 && pollTimer) {
+        clearInterval(pollTimer)
+        pollTimer = null
+      }
+    })
+  } else if (statusCode.value === null) {
+    void fetchPerpsStatus()
+  }
+
+  return {
+    statusCode,
+    isServiceUnavailable,
+    isLoadingStatus,
+    refetch: fetchPerpsStatus,
+  }
+}

--- a/src/modules/perps/sdk/client.ts
+++ b/src/modules/perps/sdk/client.ts
@@ -36,6 +36,23 @@ import type {
   MarketInfoData,
 } from './types'
 
+/**
+ * Thrown for any non-2xx response, carrying the HTTP status so callers can tell
+ * classes of failure apart — a 429 is a throttle to back off from, a 5xx is an
+ * outage worth surfacing. `message` is unchanged from the plain `Error` this
+ * replaced (the body's `error` field, else `HTTP <status>`), so callers that
+ * only read the message keep working.
+ */
+export class PerpsHttpError extends Error {
+  readonly status: number
+
+  constructor(status: number, message: string) {
+    super(message)
+    this.name = 'PerpsHttpError'
+    this.status = status
+  }
+}
+
 export class PerpsClient {
   private baseUrl: string
   private token: string | null = null
@@ -70,7 +87,7 @@ export class PerpsClient {
       } catch {
         // ignore parse errors
       }
-      throw new Error(msg)
+      throw new PerpsHttpError(res.status, msg)
     }
     return res.json()
   }

--- a/src/modules/perps/sdk/index.ts
+++ b/src/modules/perps/sdk/index.ts
@@ -1,4 +1,4 @@
-export { PerpsClient } from './client'
+export { PerpsClient, PerpsHttpError } from './client'
 export type {
   GenericResponse,
   ErrorResponse,

--- a/src/views/ViewPerps.vue
+++ b/src/views/ViewPerps.vue
@@ -1,5 +1,8 @@
 <template>
   <div class="flex flex-col gap-6">
+    <!-- Exchange status notice — self-hiding while markets are open -->
+    <perps-status-banner />
+
     <!-- Not authenticated -->
     <perps-main-banner v-if="!token" />
 
@@ -58,6 +61,7 @@ import PerpsMarketList from '@/modules/perps/components/PerpsMarketList.vue'
 import PerpsDepositDialog from '@/modules/perps/components/PerpsDepositDialog.vue'
 import PerpsWithdrawDialog from '@/modules/perps/components/PerpsWithdrawDialog.vue'
 import PerpsMainBanner from '@/modules/perps/components/PerpsMainBanner.vue'
+import PerpsStatusBanner from '@/modules/perps/components/PerpsStatusBanner.vue'
 import { useWalletMenuStore } from '@/stores/walletMenuStore'
 import { useWalletStore } from '@/stores/walletStore'
 import { usePerpsAuth } from '@/modules/perps/composables/usePerpsAuth'

--- a/tests/unit/modules/perps/components/PerpsStatusBanner.spec.ts
+++ b/tests/unit/modules/perps/components/PerpsStatusBanner.spec.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { ref, computed } from 'vue'
+import { createI18n } from 'vue-i18n'
+import enPerps from '@/i18n/locales/perps/en.json'
+
+const statusCode = ref<number | null>(null)
+const isPerpsRestricted = ref(false)
+
+vi.mock('@/modules/perps/composables/usePerpsStatus', () => ({
+  usePerpsStatus: () => ({
+    statusCode,
+    isServiceUnavailable: computed(
+      () => statusCode.value !== null && statusCode.value >= 500,
+    ),
+    isLoadingStatus: ref(false),
+    refetch: vi.fn(),
+  }),
+}))
+
+vi.mock('@/modules/perps/composables/usePerpsRestriction', () => ({
+  usePerpsRestriction: () => ({
+    isPerpsRestricted,
+    perpsHelpUrl: 'https://help.example.test/restrictions',
+  }),
+}))
+
+// Real strings, so a renamed or missing key fails the test instead of silently
+// rendering the key path.
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  fallbackLocale: 'en',
+  messages: { en: enPerps },
+})
+
+const mountBanner = async () => {
+  const PerpsStatusBanner = (
+    await import('@/modules/perps/components/PerpsStatusBanner.vue')
+  ).default
+  return mount(PerpsStatusBanner, { global: { plugins: [i18n] } })
+}
+
+describe('PerpsStatusBanner', () => {
+  beforeEach(() => {
+    statusCode.value = null
+    isPerpsRestricted.value = false
+  })
+
+  it('renders nothing before the first response', async () => {
+    const banner = await mountBanner()
+    expect(banner.find('[role="status"]').exists()).toBe(false)
+  })
+
+  it('renders nothing on 200', async () => {
+    statusCode.value = 200
+    const banner = await mountBanner()
+    expect(banner.find('[role="status"]').exists()).toBe(false)
+  })
+
+  it('renders nothing on 429', async () => {
+    statusCode.value = 429
+    const banner = await mountBanner()
+    expect(banner.find('[role="status"]').exists()).toBe(false)
+  })
+
+  it('announces the outage on 500', async () => {
+    statusCode.value = 500
+    const banner = await mountBanner()
+
+    expect(banner.find('[role="status"]').exists()).toBe(true)
+    expect(banner.text()).toContain(enPerps.perps.status.unavailable)
+  })
+
+  it('is amber', async () => {
+    statusCode.value = 500
+    const banner = await mountBanner()
+
+    const shell = banner.get('[role="status"]')
+    expect(shell.classes()).toContain('bg-warning-10')
+    expect(banner.get('svg').classes()).toContain('text-warning')
+  })
+
+  it('yields to the jurisdiction block, which outranks service availability', async () => {
+    statusCode.value = 500
+    isPerpsRestricted.value = true
+    const banner = await mountBanner()
+
+    expect(banner.find('[role="status"]').exists()).toBe(false)
+  })
+})

--- a/tests/unit/modules/perps/composables/usePerpsStatus.spec.ts
+++ b/tests/unit/modules/perps/composables/usePerpsStatus.spec.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { effectScope } from 'vue'
+
+// Implementation is swapped per test rather than using mockResolvedValue, whose
+// vitest typings infer `never` for this signature.
+const getStatus = vi.fn(
+  (): Promise<{ success: boolean; result: { marketStatus: string } }> =>
+    Promise.resolve({ success: true, result: { marketStatus: 'open' } }),
+)
+
+// Mocked so the spec never constructs the real client (and never hits the API).
+vi.mock('@/modules/perps/configs', () => ({
+  perpsClient: { getStatus: () => getStatus() },
+}))
+
+const respondsOk = () =>
+  getStatus.mockImplementation(() =>
+    Promise.resolve({ success: true, result: { marketStatus: 'open' } }),
+  )
+
+// Status lives in module scope and is shared across consumers, so every case
+// needs a freshly imported module graph.
+//
+// `PerpsHttpError` has to come from that same graph: the composable narrows with
+// `instanceof`, and a class imported at the top of this file would be a
+// different identity after `resetModules`, so every error would look like a
+// response-less failure. Hence `respondsWith` is handed back per import rather
+// than defined once at module scope.
+const freshImport = async () => {
+  vi.resetModules()
+  const { PerpsHttpError } = await import('@/modules/perps/sdk/client')
+  const mod = await import('@/modules/perps/composables/usePerpsStatus')
+  return {
+    ...mod,
+    /** What the real client does for a non-2xx: throw, carrying the status. */
+    respondsWith: (status: number) =>
+      getStatus.mockImplementation(() =>
+        Promise.reject(new PerpsHttpError(status, `HTTP ${status}`)),
+      ),
+  }
+}
+
+describe('usePerpsStatus', () => {
+  beforeEach(() => {
+    getStatus.mockReset()
+    respondsOk()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.resetModules()
+  })
+
+  it('reads as available before the first response, so the banner never flashes on load', async () => {
+    const { usePerpsStatus } = await freshImport()
+    // Never settles: this is the pre-resolution window.
+    getStatus.mockImplementation(() => new Promise(() => {}))
+
+    const { statusCode, isServiceUnavailable } = usePerpsStatus()
+
+    expect(statusCode.value).toBeNull()
+    expect(isServiceUnavailable.value).toBe(false)
+  })
+
+  it('stays available on 200', async () => {
+    const { usePerpsStatus, fetchPerpsStatus } = await freshImport()
+    respondsOk()
+    const { statusCode, isServiceUnavailable } = usePerpsStatus()
+
+    await fetchPerpsStatus()
+
+    expect(statusCode.value).toBe(200)
+    expect(isServiceUnavailable.value).toBe(false)
+  })
+
+  it('stays available on 429 — a throttle means the service answered', async () => {
+    const { usePerpsStatus, fetchPerpsStatus, respondsWith } =
+      await freshImport()
+    respondsWith(429)
+    const { statusCode, isServiceUnavailable } = usePerpsStatus()
+
+    await fetchPerpsStatus()
+
+    expect(statusCode.value).toBe(429)
+    expect(isServiceUnavailable.value).toBe(false)
+  })
+
+  it('reports unavailable on 500', async () => {
+    const { usePerpsStatus, fetchPerpsStatus, respondsWith } =
+      await freshImport()
+    respondsWith(500)
+    const { statusCode, isServiceUnavailable } = usePerpsStatus()
+
+    await fetchPerpsStatus()
+
+    expect(statusCode.value).toBe(500)
+    expect(isServiceUnavailable.value).toBe(true)
+  })
+
+  it('reports unavailable for any other server error', async () => {
+    const { usePerpsStatus, fetchPerpsStatus, respondsWith } =
+      await freshImport()
+    // 502/503 are the same outage class as the documented 500.
+    respondsWith(503)
+    const { isServiceUnavailable } = usePerpsStatus()
+
+    await fetchPerpsStatus()
+
+    expect(isServiceUnavailable.value).toBe(true)
+  })
+
+  it('stays available for a client error that is not a server outage', async () => {
+    const { usePerpsStatus, fetchPerpsStatus, respondsWith } =
+      await freshImport()
+    respondsWith(404)
+    const { isServiceUnavailable } = usePerpsStatus()
+
+    await fetchPerpsStatus()
+
+    expect(isServiceUnavailable.value).toBe(false)
+  })
+
+  it('stays available when the request never reaches a response', async () => {
+    const { usePerpsStatus, fetchPerpsStatus } = await freshImport()
+    // Offline / DNS / CORS: no HTTP status, so nothing to substantiate an
+    // outage notice with — this is the user's connection, not the service.
+    getStatus.mockImplementation(() =>
+      Promise.reject(new Error('Failed to fetch')),
+    )
+    const { statusCode, isServiceUnavailable } = usePerpsStatus()
+
+    await fetchPerpsStatus()
+
+    expect(statusCode.value).toBeNull()
+    expect(isServiceUnavailable.value).toBe(false)
+  })
+
+  it('clears the banner once the service recovers', async () => {
+    const { usePerpsStatus, fetchPerpsStatus, respondsWith } =
+      await freshImport()
+    respondsWith(500)
+    const { isServiceUnavailable } = usePerpsStatus()
+    await fetchPerpsStatus()
+    expect(isServiceUnavailable.value).toBe(true)
+
+    respondsOk()
+    await fetchPerpsStatus()
+
+    expect(isServiceUnavailable.value).toBe(false)
+  })
+
+  it('polls while a consumer is alive and stops once the scope is disposed', async () => {
+    vi.useFakeTimers()
+    const { usePerpsStatus } = await freshImport()
+
+    const scope = effectScope()
+    scope.run(() => usePerpsStatus())
+    expect(getStatus).toHaveBeenCalledTimes(1) // immediate fetch on entry
+
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(getStatus).toHaveBeenCalledTimes(2)
+
+    scope.stop()
+    await vi.advanceTimersByTimeAsync(180_000)
+    expect(getStatus).toHaveBeenCalledTimes(2)
+  })
+
+  it('shares one poll timer across concurrent consumers', async () => {
+    vi.useFakeTimers()
+    const { usePerpsStatus } = await freshImport()
+
+    const first = effectScope()
+    const second = effectScope()
+    first.run(() => usePerpsStatus())
+    second.run(() => usePerpsStatus())
+
+    // Second consumer joins the existing timer instead of starting its own.
+    expect(getStatus).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(getStatus).toHaveBeenCalledTimes(2)
+
+    // One consumer leaving must not stop polling for the other.
+    first.stop()
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(getStatus).toHaveBeenCalledTimes(3)
+
+    second.stop()
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(getStatus).toHaveBeenCalledTimes(3)
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added region-restriction notices for perpetual trading, including learn-more links and localized messaging.
  * Restricted users now see disabled trading controls and cannot authenticate for perpetuals.
  * Added service-unavailable status messaging for perpetuals.
  * Added reusable unavailable-state cards and consistent blocked-content behavior across trading, swap, and purchase flows.
  * Added analytics tracking for learn-more interactions.

* **Bug Fixes**
  * Improved handling of restricted regions and temporary service outages without redirecting users away from perpetuals.

* **Tests**
  * Added coverage for restriction handling, unavailable states, authentication safeguards, and shared UI components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->