### PR TITLE
fix: show real swap minimum instead of generic "amount too low" [MEW-2109]

### DIFF
--- a/changelog/fix-5697.md
+++ b/changelog/fix-5697.md
@@ -1,0 +1,1 @@
+fix: show the required minimum in the swap "amount too low" error instead of a bare message

--- a/src/i18n/locales/swap/en.json
+++ b/src/i18n/locales/swap/en.json
@@ -27,7 +27,7 @@
       "more-than-zero": "Amount must be greater than 0.",
       "insufficient-balance-for-fees": "Not enough {symbol} to cover network fees.",
       "insufficient-native": "Insufficient {symbol} balance.",
-      "minimum-amount": "Amount too low.",
+      "minimum-amount": "Amount too low. Minimum amount is {amount} {symbol}.",
       "maximum-amount": "Amount too high.",
       "no-quotes": "No quotes available for selected token pair",
       "fetching-quotes": "Error fetching quotes. Please try again.",

--- a/src/i18n/locales/swap/es.json
+++ b/src/i18n/locales/swap/es.json
@@ -27,7 +27,7 @@
       "more-than-zero": "La cantidad debe ser mayor que 0.",
       "insufficient-balance-for-fees": "No tienes suficiente {symbol} para cubrir las comisiones de red.",
       "insufficient-native": "Saldo de {symbol} insuficiente.",
-      "minimum-amount": "Cantidad demasiado baja.",
+      "minimum-amount": "Cantidad demasiado baja. La cantidad mínima es {amount} {symbol}.",
       "maximum-amount": "Cantidad demasiado alta.",
       "no-quotes": "No hay cotizaciones disponibles para el par de tokens seleccionado",
       "fetching-quotes": "Error al obtener las cotizaciones. Inténtalo de nuevo.",

--- a/src/i18n/locales/swap/zh.json
+++ b/src/i18n/locales/swap/zh.json
@@ -27,7 +27,7 @@
       "more-than-zero": "数量必须大于 0。",
       "insufficient-balance-for-fees": "{symbol} 不足以支付网络费用。",
       "insufficient-native": "{symbol} 余额不足。",
-      "minimum-amount": "数量过低。",
+      "minimum-amount": "数量过低。最低数量为 {amount} {symbol}。",
       "maximum-amount": "数量过高。",
       "no-quotes": "所选代币对暂无可用报价",
       "fetching-quotes": "获取报价出错。请重试。",

--- a/src/modules/swap/ModuleSwap.vue
+++ b/src/modules/swap/ModuleSwap.vue
@@ -308,6 +308,7 @@ import {
   supportedSwapEnums,
 } from '@/providers/ethereum/chainToEnum'
 import { formatUnits, parseUnits } from 'viem'
+import { smallestMinFromDisplay } from '@/modules/swap/swapMinAmount'
 import dataTxAction from '@/utils/dataTxAction'
 import {
   type Chain,
@@ -562,7 +563,11 @@ const fromAmountError = computed(() => {
     const max = BigInt(
       selectedQuote.value.minMax?.maximumFrom.toString() || '0',
     )
-    if (baseAmount < min) return t('swap.error.minimum-amount')
+    if (baseAmount < min)
+      return t('swap.error.minimum-amount', {
+        amount: smallestMinFromDisplay([min], decimals),
+        symbol: fromTokenSelected.value.symbol,
+      })
     if (baseAmount > max) return t('swap.error.maximum-amount')
   }
 
@@ -1091,10 +1096,17 @@ const fetchQuotes = async () => {
       selectedQuote.value = providers.value[0] || undefined
       if (providers.value.length === 0) {
         qoutesError.value = true
-        // if no providers were selected after filter minimum
-        // fromValue is probably too low
+        // No provider's minimum was met. Tell the user the actual minimum
+        // required (smallest across the returned quotes, in the from-token's
+        // units) instead of a bare "amount too low" (MEW-2109).
         if (quotes.length > 0) {
-          generalError.value = t('swap.error.minimum-amount')
+          generalError.value = t('swap.error.minimum-amount', {
+            amount: smallestMinFromDisplay(
+              quotes.map(q => BigInt(q.minMax.minimumFrom.toString())),
+              fromDecimals,
+            ),
+            symbol: fromTokenSelected.value?.symbol,
+          })
         }
         const event = bestSwapLoadingOpen.value
           ? SwapEventError.OFFER_ERROR

--- a/src/modules/swap/ModuleSwap.vue
+++ b/src/modules/swap/ModuleSwap.vue
@@ -338,6 +338,8 @@ import { SENTRY_MODULE_TAGS } from '@/sentry/constants'
 
 const isDevMode = configs.IS_DEV_MODE
 const MAX_PRICE_IMPACT = 10
+// Fallback token precision when a token omits `decimals` (ETH/most ERC20 = 18).
+const DEFAULT_TOKEN_DECIMALS = 18
 // --- Stores ---
 const walletMenu = useWalletMenuStore()
 const { walletPanel } = storeToRefs(walletMenu)
@@ -519,7 +521,7 @@ const fromAmountError = computed(() => {
   if (!fromTokenSelected.value) return ''
 
   // Validate Decimals
-  const decimals = fromTokenSelected.value.decimals || 18
+  const decimals = fromTokenSelected.value.decimals ?? DEFAULT_TOKEN_DECIMALS
   if (BigNumber(fromAmount.value).toFixed().split('.')[1]?.length > decimals) {
     return t('swap.error.too-many-decimals')
   }
@@ -1080,7 +1082,8 @@ const fetchQuotes = async () => {
     })
 
     if (quotes && quotes.length > 0) {
-      const fromDecimals = fromTokenSelected.value?.decimals || 18
+      const fromDecimals =
+        fromTokenSelected.value?.decimals ?? DEFAULT_TOKEN_DECIMALS
       const fromAmountBase = parseUnits(fromAmount.value, fromDecimals)
 
       providers.value = quotes

--- a/src/modules/swap/swapMinAmount.ts
+++ b/src/modules/swap/swapMinAmount.ts
@@ -1,15 +1,18 @@
+import BigNumber from 'bignumber.js'
 import { formatUnits } from 'viem'
 
-import { formatFloatingPointValue } from '@/utils/numberFormatHelper'
+// Display precision by magnitude (mirrors formatFloatingPointValue's tiers).
+const displayDecimalsFor = (value: BigNumber): number =>
+  value.gte(1) ? 2 : value.gte(0.0001) ? 4 : 8
 
 /**
  * Display string for the smallest provider minimum among the given quote
  * minimums, expressed in the from-token's own units.
  *
- * When every swap quote requires more than the user entered, MEW shows the
- * real minimum they need instead of a bare "amount too low" (MEW-2109). The
- * minimums come from the SDK in the from-token's base units, so they must be
- * formatted with that token's decimals — not a hardcoded 18.
+ * Rounded UP at display precision so the shown amount is never below the real
+ * minimum — otherwise a user who types the displayed value hits "amount too
+ * low" again (MEW-2109). The minimums arrive in the token's base units, so they
+ * are formatted with that token's decimals — never a fixed 18.
  */
 export const smallestMinFromDisplay = (
   mins: bigint[],
@@ -17,5 +20,7 @@ export const smallestMinFromDisplay = (
 ): string => {
   if (!mins.length) return '0'
   const smallest = mins.reduce((a, b) => (b < a ? b : a))
-  return formatFloatingPointValue(formatUnits(smallest, decimals)).value
+  const human = new BigNumber(formatUnits(smallest, decimals))
+  const dp = Math.min(displayDecimalsFor(human), decimals)
+  return human.decimalPlaces(dp, BigNumber.ROUND_CEIL).toFixed()
 }

--- a/src/modules/swap/swapMinAmount.ts
+++ b/src/modules/swap/swapMinAmount.ts
@@ -1,0 +1,21 @@
+import { formatUnits } from 'viem'
+
+import { formatFloatingPointValue } from '@/utils/numberFormatHelper'
+
+/**
+ * Display string for the smallest provider minimum among the given quote
+ * minimums, expressed in the from-token's own units.
+ *
+ * When every swap quote requires more than the user entered, MEW shows the
+ * real minimum they need instead of a bare "amount too low" (MEW-2109). The
+ * minimums come from the SDK in the from-token's base units, so they must be
+ * formatted with that token's decimals — not a hardcoded 18.
+ */
+export const smallestMinFromDisplay = (
+  mins: bigint[],
+  decimals: number,
+): string => {
+  if (!mins.length) return '0'
+  const smallest = mins.reduce((a, b) => (b < a ? b : a))
+  return formatFloatingPointValue(formatUnits(smallest, decimals)).value
+}

--- a/tests/unit/modules/swap/swapMinAmount.spec.ts
+++ b/tests/unit/modules/swap/swapMinAmount.spec.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+
+import { smallestMinFromDisplay } from '@/modules/swap/swapMinAmount'
+
+describe('smallestMinFromDisplay', () => {
+  it('formats a single provider minimum in the token decimals (PYUSD, 6dp)', () => {
+    // Changelly minimumFrom for PYUSD->ETH = 50.013709 PYUSD in base units (MEW-2109)
+    expect(smallestMinFromDisplay([50013709n], 6)).toBe('50.01')
+  })
+
+  it('picks the smallest minimum across providers', () => {
+    expect(smallestMinFromDisplay([60000000n, 50013709n], 6)).toBe('50.01')
+  })
+
+  it('handles 18-decimal tokens', () => {
+    expect(smallestMinFromDisplay([1500000000000000000n], 18)).toBe('1.5')
+  })
+
+  it('returns "0" when there are no minimums', () => {
+    expect(smallestMinFromDisplay([], 6)).toBe('0')
+  })
+})

--- a/tests/unit/modules/swap/swapMinAmount.spec.ts
+++ b/tests/unit/modules/swap/swapMinAmount.spec.ts
@@ -1,19 +1,32 @@
 import { describe, it, expect } from 'vitest'
+import { parseUnits } from 'viem'
 
 import { smallestMinFromDisplay } from '@/modules/swap/swapMinAmount'
 
 describe('smallestMinFromDisplay', () => {
-  it('formats a single provider minimum in the token decimals (PYUSD, 6dp)', () => {
-    // Changelly minimumFrom for PYUSD->ETH = 50.013709 PYUSD in base units (MEW-2109)
-    expect(smallestMinFromDisplay([50013709n], 6)).toBe('50.01')
+  it('rounds the minimum UP so the shown amount is never below it (PYUSD, 6dp)', () => {
+    // Changelly minimumFrom for PYUSD->ETH = 50.013709 PYUSD in base units (MEW-2109).
+    // 50.01 would still be below the minimum, so it must round up to 50.02.
+    const min = 50013709n
+    const display = smallestMinFromDisplay([min], 6)
+    expect(display).toBe('50.02')
+    // The displayed value, re-entered, must clear the base-unit minimum.
+    expect(parseUnits(display, 6) >= min).toBe(true)
   })
 
   it('picks the smallest minimum across providers', () => {
-    expect(smallestMinFromDisplay([60000000n, 50013709n], 6)).toBe('50.01')
+    expect(smallestMinFromDisplay([60000000n, 50013709n], 6)).toBe('50.02')
   })
 
   it('handles 18-decimal tokens', () => {
     expect(smallestMinFromDisplay([1500000000000000000n], 18)).toBe('1.5')
+  })
+
+  it('preserves zero-decimal tokens (no fractional inflation)', () => {
+    const min = 100n
+    const display = smallestMinFromDisplay([min], 0)
+    expect(display).toBe('100')
+    expect(parseUnits(display, 0) >= min).toBe(true)
   })
 
   it('returns "0" when there are no minimums', () => {


### PR DESCRIPTION
## Summary

When every swap quote's `minimumFrom` exceeds the entered amount, the swap was blocked with a bare **"Amount too low."** with no indication of what amount would actually work.

In practice this fires when the only surviving provider is a **high-minimum bridge** (e.g. Changelly, ~50 PYUSD) while the DEX aggregators (0x / 1inch / ParaSwap, min ≈ 0) return no quote for the pair. For the reported case (Ethereum **PYUSD → ETH**, 46.59 PYUSD) Enkrypt completes the same swap because it uses a DEX route.

This PR surfaces the **real minimum required** instead of the generic message, so the user knows the exact amount to use.

## Changes

- New pure helper `src/modules/swap/swapMinAmount.ts` → `smallestMinFromDisplay(mins, decimals)`: smallest provider minimum, formatted in the **from-token's own decimals** (via `formatUnits` + `formatFloatingPointValue`).
- `ModuleSwap.vue`: both call sites of `swap.error.minimum-amount` now pass `{ amount, symbol }` (the `fetchQuotes` no-provider branch and the `fromAmountError` computed).
- i18n `swap.error.minimum-amount` reworded with params in **en / es / zh**, e.g. `"Amount too low. Minimum amount is 50.01 PYUSD."`

## Notes

- Not a decimals bug — verified by replaying the quote layer against our RPC: a healthy environment returns 4 providers and the swap works. The block only appears when DEX aggregators return nothing, leaving only the high-minimum provider.
- This is the interim UX fix. Broader options under discussion with the team: excluding Changelly from same-network Swap (reserve for Bridge), and investigating the backend/RPC 403/404s that drop DEX quotes.

## Testing

- `pnpm vitest run tests/unit/modules/swap/swapMinAmount.spec.ts` → 4/4 (PYUSD 6-dp, smallest-of-many, 18-dp, empty).
- `pnpm vue-tsc --noEmit -p tsconfig.app.json` → exit 0.
- ESLint on changed files → 0.
- Manual: same-network swap with a normal amount shows a quote (no false error); a below-minimum case now shows the required minimum.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Swap errors now show the required minimum amount and token.
  * When no quotes meet minimum requirements, the error displays the smallest applicable minimum.
  * Minimum amounts are formatted and rounded for clearer display across token precision levels.
  * Updated messaging is available in English, Spanish, and Chinese.

* **Documentation**
  * Added a changelog entry describing the improved swap error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->