### PR TITLE
fix: swap "route not found" when proceeding before the quote resolves (MEW-2110)

### DIFF
--- a/changelog/fix-swap-empty-quoteid.md
+++ b/changelog/fix-swap-empty-quoteid.md
@@ -1,0 +1,1 @@
+fix: prevent a "route not found" error when proceeding with a swap before its quote resolved

--- a/src/modules/swap/components/SwapOfferModal.vue
+++ b/src/modules/swap/components/SwapOfferModal.vue
@@ -262,7 +262,7 @@
           class="w-full"
           @click="proceedWithSwap"
           :is-loading="loadingModel"
-          :disabled="!!gasFeeError"
+          :disabled="!!gasFeeError || !swapGasFeeQuote?.quoteId"
         >
           {{ btnText }}
         </app-base-button>
@@ -524,6 +524,11 @@ watch(
 
 // Let parent know when the swap is to be proceeded
 const proceedWithSwap = () => {
+  // Guard against proceeding without a resolved quote: an empty quoteId would
+  // build a malformed unsigned-tx URL (…/multi-quotes//unsigned -> 404). The
+  // button is disabled in this state; this also ignores any stray click.
+  const quoteId = props.swapGasFeeQuote?.quoteId
+  if (!quoteId) return
   isProceeding.value = true
   loadingModel.value = true
   if (
@@ -532,7 +537,7 @@ const proceedWithSwap = () => {
   ) {
     showApproveMessage.value = true
   }
-  emits('update:proceedWithSwap', props.swapGasFeeQuote?.quoteId || '')
+  emits('update:proceedWithSwap', quoteId)
 }
 const declineSwap = () => {
   emits('update:declineSwap')

--- a/src/providers/ethereum/baseEvmWallet.ts
+++ b/src/providers/ethereum/baseEvmWallet.ts
@@ -66,6 +66,10 @@ class BaseEvmWallet implements WalletInterface {
   getMultipleSignableTransactions = async (
     feeObj: SignableTransactionParams,
   ): Promise<GetUnsignedEvmMultiTransactionResponse> => {
+    // An empty quoteId builds `…/multi-quotes//unsigned`, which the API answers
+    // with a bare ROUTE_NOT_FOUND 404 ("check the url"). Fail loudly here so a
+    // missing quote is surfaced as a real error, never a malformed request.
+    if (!feeObj.quoteId) throw new Error('Missing swap quote id')
     const response =
       await fetchWithRetry<GetUnsignedEvmMultiTransactionResponse>(
         `/v1/evm/chains/${this.chainId}/multi-quotes/${feeObj.quoteId}/unsigned?noInjectErrors=false&priority=${feeObj.priority}`,
@@ -81,6 +85,7 @@ class BaseEvmWallet implements WalletInterface {
   getSignableTransaction = async (
     feeObj: SignableTransactionParams,
   ): Promise<EthereumSignableTransactionResponse> => {
+    if (!feeObj.quoteId) throw new Error('Missing swap quote id')
     return fetchWithRetry<EthereumSignableTransactionResponse>(
       `/v1/evm/chains/${this.chainId}/quotes/${feeObj.quoteId}/unsigned?noInjectErrors=false&priority=${feeObj.priority}`,
     )

--- a/tests/unit/providers/ethereum/baseEvmWallet.spec.ts
+++ b/tests/unit/providers/ethereum/baseEvmWallet.spec.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import type { SignableTransactionParams } from '@/providers/common/types'
+
+// Mock the network layer so we can assert whether a request was issued at all.
+const fetchWithRetryMock = vi.fn()
+vi.mock('@/mew_api/fetchWithRetry', () => ({
+  fetchWithRetry: (...args: unknown[]) => fetchWithRetryMock(...args),
+}))
+
+// Importing the wallet transitively pulls in the store layer, which reaches the
+// analytics module and its hardware-wallet SDK — unavailable under jsdom.
+vi.mock('@/analytics', () => ({ analytics: {} }))
+
+import BaseEvmWallet from '@/providers/ethereum/baseEvmWallet'
+
+const params = (quoteId: string): SignableTransactionParams =>
+  ({ quoteId, priority: 'REGULAR' }) as unknown as SignableTransactionParams
+
+describe('BaseEvmWallet — empty quoteId guard (MEW-2110)', () => {
+  beforeEach(() => fetchWithRetryMock.mockReset())
+
+  it('getMultipleSignableTransactions throws and does NOT hit the API when quoteId is empty', async () => {
+    const wallet = new BaseEvmWallet('1')
+    await expect(
+      wallet.getMultipleSignableTransactions(params('')),
+    ).rejects.toThrow()
+    // The bug: an empty quoteId builds `…/multi-quotes//unsigned` -> ROUTE_NOT_FOUND.
+    expect(fetchWithRetryMock).not.toHaveBeenCalled()
+  })
+
+  it('getSignableTransaction throws and does NOT hit the API when quoteId is empty', async () => {
+    const wallet = new BaseEvmWallet('1')
+    await expect(
+      wallet.getSignableTransaction(params('')),
+    ).rejects.toThrow()
+    expect(fetchWithRetryMock).not.toHaveBeenCalled()
+  })
+
+  it('getMultipleSignableTransactions requests the unsigned tx when quoteId is present', async () => {
+    fetchWithRetryMock.mockResolvedValue({ serialized: [] })
+    const wallet = new BaseEvmWallet('1')
+    await wallet.getMultipleSignableTransactions(params('019fd336-5140-777d-ab1a-02c6e895f0de'))
+    expect(fetchWithRetryMock).toHaveBeenCalledTimes(1)
+    expect(fetchWithRetryMock).toHaveBeenCalledWith(
+      expect.stringContaining(
+        '/multi-quotes/019fd336-5140-777d-ab1a-02c6e895f0de/unsigned',
+      ),
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Proceeding with a swap could surface a raw `route not found. please check the url and try again.` error (see screenshot in the ticket — ETH→USDC via ParaSwap, Enkrypt access).

Reproduced directly against prod: the message is a bare `ROUTE_NOT_FOUND` 404 the API returns when the unsigned-tx request is built with an **empty** `quoteId`, i.e. `…/multi-quotes//unsigned`. (A valid-but-stale UUID returns `TRANSACTION_NOT_FOUND`; `undefined` returns `INVALID_UUID` — only the empty segment produces this exact string.)

## Root cause

The Best-offer modal emitted `swapGasFeeQuote?.quoteId || ''`, sending an empty string when `swapGasFeeQuote` was momentarily `undefined` — a **frontend state race**, not a backend problem. Confirmed with a Node `@enkryptcom/swap` repro that both `getSwap` (returns a proper `type: evm` tx with `gasLimit`+`data`) and `POST /multi-quotes` (returns a valid `quoteId`, HTTP 201) are healthy for ParaSwap ETH→USDC.

## Fix (defense-in-depth)

- **Wallet provider (`baseEvmWallet`)** — `getMultipleSignableTransactions` / `getSignableTransaction` throw a clear error on an empty `quoteId` before issuing the request. This is the single chokepoint every EVM swap tx-build routes through, so a malformed URL can never reach the API.
- **Best-offer modal (`SwapOfferModal`)** — the *Proceed* button is disabled until a `quoteId` is resolved, and the `|| ''` fallback is dropped so a stray click is ignored.

## Tests

- `tests/unit/providers/ethereum/baseEvmWallet.spec.ts` — an empty `quoteId` throws and issues **no** request; a present `quoteId` builds the correct `…/unsigned` URL.
- `pnpm vue-tsc --noEmit -p tsconfig.app.json` — clean.

## Follow-up (out of scope here)

Deeper race hardening in `ModuleSwap` — stop a `getSwap()`-returns-`null` path from clobbering a valid `swapGasFeeQuote`, and make `swapForEvm` open the offer modal only once a `quoteId` is obtained. With this guard the user now gets a disabled button + retry instead of the raw error, so it's a robustness improvement rather than a crash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented swaps from proceeding before a valid gas-fee quote is available.
  * Disabled the proceed action when the quote is missing.
  * Added validation to prevent invalid swap requests and related “route not found” errors.
* **Tests**
  * Added coverage for valid and missing quote IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->