### PR TITLE
fix: keep header More dropdown above the trade drawer (MEW-2113)

### DIFF
--- a/changelog/fix-5699.md
+++ b/changelog/fix-5699.md
@@ -1,0 +1,1 @@
+- Fixed the header "More" dropdown being hidden behind the trade drawer (MEW-2113)

--- a/changelog/fix-5699.md
+++ b/changelog/fix-5699.md
@@ -1,1 +1,0 @@
-- Fixed the header "More" dropdown being hidden behind the trade drawer (MEW-2113)

--- a/src/components/AppSelect.vue
+++ b/src/components/AppSelect.vue
@@ -189,9 +189,12 @@ const targetValue = ref<HTMLElement | null>(null)
  */
 const selected = defineModel<AppSelectOption>('selected', { required: false })
 /**
- * controls the open state of the select dropdown
+ * Open state of the dropdown, exposed as `v-model:open` so an ancestor can
+ * react to it. TheHeader uses this to lift its z-index while a header dropdown
+ * is open, otherwise the popover is clipped behind sibling drawers (MEW-2113).
+ * Defaults to false, so callers that don't bind `open` are unaffected.
  */
-const openSelect = ref(false)
+const openSelect = defineModel<boolean>('open', { default: false })
 
 /**
  * @method toggleSelect

--- a/src/components/core_layouts/TheHeader.vue
+++ b/src/components/core_layouts/TheHeader.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="flex items-center w-full h-[68px] sm:h-[76px] fixed top-0 px-5 md-header:px-5 bg-white shadow-[0px_3px_12px_-6px_rgba(0,0,0,0.32)]"
-    :class="isSearchOpen ? 'z-[201]' : 'z-10'"
+    :class="isHeaderOverlayOpen ? 'z-[201]' : 'z-10'"
   >
     <div class="flex w-full justify-between items-center mx-auto gap-3">
       <!-- LOGO -->
@@ -49,6 +49,7 @@
         </div>
         <app-select
           v-if="!showMobileMenu && !isLearnCollapsed"
+          v-model:open="isLearnOpen"
           :options="learnMenuList"
           :placeholder="$t('learn')"
           use-link
@@ -67,6 +68,7 @@
         <app-select
           v-if="!showMobileMenu"
           v-model:selected="selectedOption"
+          v-model:open="isMoreOpen"
           :options="moreMenuOptions"
           :placeholder="$t('common.more')"
           use-vue-router
@@ -188,6 +190,19 @@ const { isEvmChain, isBitcoinChain } = storeToRefs(chainStore)
 const { isMobile, isXS, isXLMinAndUp } = useAppBreakpoints()
 const { isTradingRestrictedInRegion } = useTradingRestriction()
 const { isOpen: isSearchOpen, close: closeSearch } = useGlobalSearch()
+
+/**
+ * The header is `fixed z-10`, i.e. its own stacking context, so a dropdown's
+ * internal z-index can't rise above the sibling trade drawer (z-[49..51]). When
+ * any header overlay is open we lift the whole header to z-[201] — the same
+ * trick already used for search — so the popover paints above the drawer
+ * instead of being clipped behind it (MEW-2113).
+ */
+const isMoreOpen = ref(false)
+const isLearnOpen = ref(false)
+const isHeaderOverlayOpen = computed<boolean>(
+  () => isSearchOpen.value || isMoreOpen.value || isLearnOpen.value,
+)
 
 /** ------------------------------
  * Breakpoints determine menu visibility

--- a/tests/unit/components/AppSelect.spec.ts
+++ b/tests/unit/components/AppSelect.spec.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import AppSelect from '@/components/AppSelect.vue'
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  fallbackLocale: 'en',
+  messages: { en: { common: { select_an_option: 'Select an option' } } },
+})
+
+const options = [
+  { label: 'Verify message', value: 'verify' },
+  { label: 'Sign message', value: 'sign' },
+]
+
+const mountSelect = () =>
+  mount(AppSelect, {
+    props: { options },
+    global: { plugins: [i18n], stubs: { RouterLink: true } },
+  })
+
+// The header (MEW-2113) relies on `v-model:open` to know when a dropdown is
+// open so it can lift its z-index above the trade drawer. Guard that contract.
+describe('AppSelect open model (MEW-2113)', () => {
+  it('emits update:open(true) when the dropdown is toggled open', async () => {
+    const wrapper = mountSelect()
+    await wrapper.find('button').trigger('click')
+    expect(wrapper.emitted('update:open')?.at(-1)).toEqual([true])
+  })
+
+  it('emits update:open(false) when an option is selected', async () => {
+    const wrapper = mountSelect()
+    await wrapper.find('button').trigger('click') // open
+    await wrapper.findAll('[role="option"]')[0].trigger('click') // pick
+    expect(wrapper.emitted('update:open')?.at(-1)).toEqual([false])
+  })
+})


### PR DESCRIPTION
## Summary

The header "More" (Más) dropdown was rendered **behind** the right-side trade drawer ("Operar"), clipping its items.

### Root cause
`TheHeader.vue` is `fixed z-10`, which makes it its own stacking context. The dropdown popover lives inside `AppSelect.vue` with `absolute z-[500]`, but that `500` only ranks it *within the header's* `z-10` context. The trade drawer (`LayoutWallet.vue`) is a **sibling** of the header with `z-[49]/z-[50]/z-[51]` — all `> 10` — so the whole drawer paints in front of the whole header, covering the dropdown regardless of its internal `z-[500]`.

### Fix
Reuse the pattern the header already uses for global search (`isSearchOpen ? 'z-[201]' : 'z-10'`): lift the whole header above the drawer while a header dropdown is open.

- `AppSelect.vue`: `openSelect` is now exposed as `v-model:open` (`defineModel`). Additive and defaulted to `false`, so existing callers are unaffected.
- `TheHeader.vue`: binds `v-model:open` on the More and Learn dropdowns and lifts the header to `z-[201]` via `isHeaderOverlayOpen` (search **or** More **or** Learn open).

Learn is covered too since it is the same component in the same stacking trap.

## Testing
- `tests/unit/components/AppSelect.spec.ts` (new, 2/2) — guards the `v-model:open` contract the header relies on.
- `vue-tsc --noEmit -p tsconfig.app.json` → exit 0.
- eslint on changed files → clean.
- Manual: open the "Operar" drawer, then hover/click "More" — dropdown renders fully above the drawer, all items visible/clickable, including below the responsive thresholds where Learn/Earn fold into "More". Global search overlay still works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the “More” header dropdown appearing behind the trade drawer.
  * Improved header layering when Search, Learn, or More menus are open.

* **Enhancements**
  * Added support for observing and controlling dropdown open states.
  * Ensured dropdowns close correctly after selecting an option.

* **Tests**
  * Added coverage for dropdown opening, closing, and state updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->