### PR TITLE
fix: re-translate perps Long/Short toggle on locale change (MEW-2112)

### DIFF
--- a/changelog/fix-5700.md
+++ b/changelog/fix-5700.md
@@ -1,0 +1,1 @@
+fix: re-translate perps Long/Short toggle when the app language changes

--- a/changelog/fix-5700.md
+++ b/changelog/fix-5700.md
@@ -1,1 +1,0 @@
-fix: re-translate perps Long/Short toggle when the app language changes

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -93,10 +93,13 @@ export function usePerpsTradeForm() {
 
   // ── State ──────────────────────────────────────────────────
 
-  const orderSideButtons: OrderSideButton[] = [
+  // `computed` (not a plain array) so the labels re-translate when the user
+  // switches language after the trade form has mounted. A plain array froze
+  // `t()` at setup and left Long/Short stuck in the initial locale (MEW-2112).
+  const orderSideButtons = computed<OrderSideButton[]>(() => [
     { label: t('perps.trade.long'), value: 'buy' },
     { label: t('perps.trade.short'), value: 'sell' },
-  ]
+  ])
 
   const orderSide = ref<OrderSide>(
     walletMenuStore.selectedTradeOrderSide ?? 'buy',

--- a/tests/unit/modules/perps/composables/usePerpsTradeForm.spec.ts
+++ b/tests/unit/modules/perps/composables/usePerpsTradeForm.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { ref, reactive } from 'vue'
+import { ref, reactive, unref } from 'vue'
 import type { Ref } from 'vue'
 import type { Contract, PerpsBalance, Position, TradingPair } from '@/modules/perps/sdk/types'
 
@@ -18,9 +18,28 @@ function mockT(key: string, params?: Record<string, unknown>): string {
   return params ? `${key}::${JSON.stringify(params)}` : key
 }
 
-vi.mock('vue-i18n', () => ({
-  useI18n: () => ({ t: vi.fn(mockT) }),
-}))
+// A shared `t` spy backed by a reactive `localeTick` ref that stands in for
+// vue-i18n's reactive locale: reading it inside `t` means any `computed` that
+// calls `t()` tracks it and re-evaluates on a locale switch — exactly how the
+// real vue-i18n `t` behaves. This is what lets MEW-2112 assert the long/short
+// toggle re-translates. The ref is created inside the (hoisted) factory, which
+// runs at require time when the top-level `ref` import is already initialized
+// (same trick as the usePerpsMarkets mock below).
+const i18nMock = vi.hoisted(
+  () =>
+    ({ localeTick: null, tSpy: null }) as {
+      localeTick: { value: number }
+      tSpy: ReturnType<typeof vi.fn>
+    },
+)
+vi.mock('vue-i18n', () => {
+  i18nMock.localeTick = ref(0)
+  i18nMock.tSpy = vi.fn((key: string, params?: Record<string, unknown>) => {
+    void i18nMock.localeTick.value
+    return mockT(key, params)
+  })
+  return { useI18n: () => ({ t: i18nMock.tSpy }) }
+})
 
 vi.mock('vue-router', () => ({
   useRouter: () => ({ push: vi.fn() }),
@@ -236,10 +255,28 @@ describe('usePerpsTradeForm — i18n label keys (MEW-2012)', () => {
 
   it('builds orderSideButtons labels from the long/short i18n keys', () => {
     const form = usePerpsTradeForm()
-    expect(form.orderSideButtons).toEqual([
+    expect(unref(form.orderSideButtons)).toEqual([
       { label: 'perps.trade.long', value: 'buy' },
       { label: 'perps.trade.short', value: 'sell' },
     ])
+  })
+
+  it('re-translates the long/short toggle when the locale changes (MEW-2112)', () => {
+    const form = usePerpsTradeForm()
+    const labels = () => unref(form.orderSideButtons).map(b => b.label)
+    const longCalls = () =>
+      i18nMock.tSpy.mock.calls.filter(c => c[0] === 'perps.trade.long').length
+
+    expect(labels()).toEqual(['perps.trade.long', 'perps.trade.short'])
+    const before = longCalls()
+
+    // vue-i18n flips its reactive locale on a language switch.
+    i18nMock.localeTick.value++
+    labels() // consumer (the v-for) re-reads on re-render
+
+    // A `computed` re-invokes `t()` after the locale changes; the old plain
+    // array froze its labels at setup and never re-called `t` — that was the bug.
+    expect(longCalls()).toBeGreaterThan(before)
   })
 
   it('builds marketFilterTabs labels from i18n keys while keeping keys stable', () => {


### PR DESCRIPTION
## Summary

The perps **Long / Short** trade-direction toggle did not re-translate when the user switched the app language after the trade panel had mounted — the labels stayed in the initial locale (English by default), so a user on 中文 saw "Long/Short" instead of "做多/做空".

## Root cause

`orderSideButtons` in `usePerpsTradeForm.ts` was built as a **plain array**, so `t('perps.trade.long')` / `t('perps.trade.short')` were evaluated once at composable setup and frozen. vue-i18n's locale is reactive, but a plain array doesn't track it, so a later language switch never re-ran `t()`. (The zh/es translations already existed — this was never a missing-key issue.) Every other perps label uses `$t()` in-template or a `computed`, which is why only this toggle was affected.

## Fix

Make `orderSideButtons` a `computed`, so the labels re-evaluate on locale change like every other reactive label. The `v-for` consumer and the composable's return are unchanged (a computed ref auto-unwraps in the template).

## Testing

- `tests/unit/modules/perps/composables/usePerpsTradeForm.spec.ts` — added a reactivity test (a reactive-`t` spy asserts the toggle re-invokes `t()` after a locale flip); the existing key assertion switched to `unref`. **18/18 green.**
- `vue-tsc --noEmit -p tsconfig.app.json` — clean; eslint clean.
- Manual: perps trade panel, switch EN → 中文 / ES → Long/Short update live (做多/做空, Largo/Corto) without reload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Long and Short trade labels now update immediately when the app language changes.

- **Tests**
  - Added coverage to verify that trade-side labels are correctly retranslated after switching locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->