### PR TITLE
devop: set trading restriction as soon as the user lands

### DIFF
--- a/src/composables/useTradingRestriction.ts
+++ b/src/composables/useTradingRestriction.ts
@@ -2,6 +2,7 @@ import { ref } from 'vue'
 import { captureException } from '@sentry/vue'
 import { isTradingRestricted } from '@/modules/trade/providers/ondoHelpers'
 import { SENTRY_MODULE_TAGS } from '@/sentry/constants'
+import { useGlobalStore } from '@/stores/globalStore'
 import Configs from '@/configs'
 
 const isDevMode = Configs.IS_DEV_MODE
@@ -9,11 +10,28 @@ const isDevMode = Configs.IS_DEV_MODE
 const isTradingRestrictedInRegion = ref<boolean>(true)
 let fetchPromise: Promise<boolean> | null = null
 
+/**
+ * Mirror the resolved geo verdict into the global store, which is what pushes
+ * the `isRegionRestricted` Amplitude user property. Kept in a try/catch because
+ * this runs from a router guard: reporting must never be able to break
+ * navigation, and the store is only reachable once pinia is installed.
+ */
+const reportRestriction = (restricted: boolean): void => {
+  try {
+    useGlobalStore().setIsTradingRestrictedInRegion(restricted)
+  } catch (e) {
+    if (isDevMode) {
+      console.error('Failed to report trading restriction:', e)
+    }
+  }
+}
+
 export function fetchTradingRestriction(): Promise<boolean> {
   if (!fetchPromise) {
     fetchPromise = isTradingRestricted()
       .then(result => {
         isTradingRestrictedInRegion.value = result
+        reportRestriction(result)
         return result
       })
       .catch(e => {
@@ -29,6 +47,9 @@ export function fetchTradingRestriction(): Promise<boolean> {
           })
         }
         isTradingRestrictedInRegion.value = true
+        // Fail closed, and report it as such — a geo check that could not be
+        // resolved is treated as restricted everywhere else too.
+        reportRestriction(true)
         fetchPromise = null
         return true
       })

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ import App from './App.vue'
 import router from './router'
 import { Provider } from './providers'
 import { analytics, initAnalytics } from './analytics'
+import { fetchTradingRestriction } from '@/composables/useTradingRestriction'
 import rippleDirective from '@/directives/ripple'
 import { autoAnimatePlugin } from '@formkit/auto-animate/vue'
 import configs from '@/configs'
@@ -170,7 +171,17 @@ app.use(autoAnimatePlugin)
 // Initialize analytics only after the router's initial navigation has resolved,
 // so the first auto-captured Page Viewed event includes the active route.
 // (Right after app.use(router) the current route is still START_LOCATION.)
-void router.isReady().then(() => initAnalytics())
+//
+// The region check runs once here, on initial landing, so the
+// `isRegionRestricted` user property is reported no matter which page the user
+// entered on — not just the pages that consume the restriction themselves. It is
+// chained after init so the identify call is not buffered pre-initialization,
+// and it is a no-op for latency: the singleton dedupes with the earlier calls
+// from TheHeader and the perps route guard, whichever fires first.
+void router.isReady().then(async () => {
+  await initAnalytics()
+  void fetchTradingRestriction()
+})
 
 // Provide analytics for legacy inject() usage in Vue components
 app.provide(Provider.ANALYTICS, analytics)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Trading restriction results and errors are now reported more reliably without interrupting navigation.
  - Analytics setup now completes after routing is ready.
  - Trading restriction checks are triggered during application startup.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->