### PR TITLE
fix: [MEW-2173] drop purchase-info 403 sentry noise

### DIFF
--- a/changelog/fix-5716.md
+++ b/changelog/fix-5716.md
@@ -1,0 +1,1 @@
+fix: drop purchase-info 403 sentry noise (Home)

--- a/changelog/fix-5716.md
+++ b/changelog/fix-5716.md
@@ -1,1 +1,0 @@
-fix: drop purchase-info 403 sentry noise (Home)

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,7 @@ import rippleDirective from '@/directives/ripple'
 import { autoAnimatePlugin } from '@formkit/auto-animate/vue'
 import configs from '@/configs'
 import {
+  isBenignPurchaseInfoForbidden,
   isExtensionOrProviderError,
   isForeignStackOverflow,
   isInvalidWalletAddressError,
@@ -94,7 +95,11 @@ if (dsn && process.env.NODE_ENV === 'production') {
         isTrezorHandshakeError(originalException) ||
         // iOS injected-script "Maximum call stack" RangeErrors with no app
         // frame — external, unactionable noise (APP-MEW-WEB-BB / MEW-2065).
-        isForeignStackOverflow(event)
+        isForeignStackOverflow(event) ||
+        // Purchase-info 403 from a region/wallet the fiat-purchase backend
+        // denies — expected, already-handled business rule, not an app bug
+        // (APP-MEW-WEB-1F5 / MEW-2173).
+        isBenignPurchaseInfoForbidden(event)
       )
         return null
       return event

--- a/src/sentry/extensionNoise.ts
+++ b/src/sentry/extensionNoise.ts
@@ -1,3 +1,5 @@
+import configs from '@/configs'
+
 // Benign EIP-1193 provider error codes. These originate from the user's wallet
 // (injected extension provider), not from app code, and are pure Sentry noise:
 //  4001  user rejected the request
@@ -164,4 +166,30 @@ export function isTransactionReceiptTimeoutError(err: unknown): boolean {
     cur = e.cause
   }
   return false
+}
+
+/**
+ * Whether a Sentry event is the MEW purchase-info endpoint
+ * (`configs.MEW_PURCHASE_API`, e.g. `/v5/purchase/info`) answering 403.
+ *
+ * The purchase backend returns 403 when fiat purchase is unavailable to the
+ * caller's region/wallet (a business rule, not an app bug). `fetchPurchaseInfo`
+ * (`src/stores/purchaseStore.ts`) already handles the failure silently — Buy/
+ * Sell just render with no assets — so every occurrence reaching Sentry via the
+ * shared `useFetchMewApi` error reporter is unactionable noise
+ * (APP-MEW-WEB-1F5 / MEW-2173).
+ *
+ * Matched on the event's `mew_api_url` / `mew_api_status` tags (set by
+ * `describeMewApiFetchError`), not the message, so it drops only this exact
+ * endpoint + status pair — a 403 from any other MEW API route is still
+ * reported.
+ */
+export function isBenignPurchaseInfoForbidden(event: unknown): boolean {
+  if (!event || typeof event !== 'object') return false
+  const tags = (event as { tags?: Record<string, unknown> }).tags
+  if (!tags) return false
+  return (
+    tags.mew_api_url === configs.MEW_PURCHASE_API &&
+    tags.mew_api_status === '403'
+  )
 }

--- a/tests/unit/sentry/extensionNoise.spec.ts
+++ b/tests/unit/sentry/extensionNoise.spec.ts
@@ -4,6 +4,7 @@ import {
   WaitForTransactionReceiptTimeoutError,
 } from 'viem'
 import {
+  isBenignPurchaseInfoForbidden,
   isExtensionOrProviderError,
   isForeignStackOverflow,
   isInvalidWalletAddressError,
@@ -12,6 +13,7 @@ import {
   isTransactionReceiptTimeoutError,
   isTrezorHandshakeError,
 } from '@/sentry/extensionNoise'
+import configs from '@/configs'
 
 describe('isExtensionOrProviderError', () => {
   it('is true for the EIP-1193 4900 "disconnected" rejection from an extension', () => {
@@ -367,6 +369,53 @@ describe('isTransactionReceiptTimeoutError', () => {
     expect(
       isTransactionReceiptTimeoutError('WaitForTransactionReceiptTimeoutError'),
     ).toBe(false)
+  })
+})
+
+describe('isBenignPurchaseInfoForbidden', () => {
+  it('is true for the production tag pair: purchase/info + 403', () => {
+    // The exact production shape: tags set by describeMewApiFetchError in the
+    // shared useFetchMewApi onFetchError handler.
+    expect(
+      isBenignPurchaseInfoForbidden({
+        tags: {
+          mew_api_url: configs.MEW_PURCHASE_API,
+          mew_api_status: '403',
+        },
+      }),
+    ).toBe(true)
+  })
+
+  it('is false for a different status on the same endpoint', () => {
+    expect(
+      isBenignPurchaseInfoForbidden({
+        tags: {
+          mew_api_url: configs.MEW_PURCHASE_API,
+          mew_api_status: '500',
+        },
+      }),
+    ).toBe(false)
+  })
+
+  it('is false for a 403 on a different MEW API endpoint (not swallowed)', () => {
+    expect(
+      isBenignPurchaseInfoForbidden({
+        tags: {
+          mew_api_url: `${configs.MEW_API_URL}/v1/some/other/route`,
+          mew_api_status: '403',
+        },
+      }),
+    ).toBe(false)
+  })
+
+  it('is false when tags are missing or the event has no tags', () => {
+    expect(isBenignPurchaseInfoForbidden({})).toBe(false)
+    expect(isBenignPurchaseInfoForbidden({ tags: {} })).toBe(false)
+  })
+
+  it('is false for non-object inputs', () => {
+    expect(isBenignPurchaseInfoForbidden(null)).toBe(false)
+    expect(isBenignPurchaseInfoForbidden(undefined)).toBe(false)
   })
 })
 


### PR DESCRIPTION
## What was wrong

Sentry issue [APP-MEW-WEB-1F5](https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-1F5) ("Error: Forbidden", culprit `Home`) fired 358 times in 14 days. All 358 sampled occurrences trace to the same single cause: the app calls the purchase-info endpoint (`/v5/purchase/info`) on every Home page load, and the purchase backend answers 403 for callers in regions/wallets where fiat purchase isn't offered — an expected business rule, not an app bug. The app already handles this failure silently (Buy/Sell just show no assets), but the shared MEW-API error reporter (`useFetchMewApi`) still forwarded every one of these 403s to Sentry as a generic "Forbidden" error, with no user-facing impact.

## What changed

Added a narrow Sentry `beforeSend` noise filter (`isBenignPurchaseInfoForbidden` in `src/sentry/extensionNoise.ts`, wired in `src/main.ts`) that drops only events tagged with this exact endpoint (`configs.MEW_PURCHASE_API`) and status (`403`). It follows the existing pattern already used for other known-benign noise sources in the same file. A 403 from any *other* MEW API route is unaffected and still reported normally, so this doesn't mask a genuine authorization bug elsewhere.

No user-visible behavior changes — this only affects what reaches Sentry.

## How to test

This can't be smoke-tested against production behavior locally (the 403 depends on the caller's real-world region as evaluated by the purchase backend), so verification is via the added unit tests:

```
pnpm vitest run tests/unit/sentry/extensionNoise.spec.ts
```

All 44 tests pass, including 5 new cases for `isBenignPurchaseInfoForbidden` (matches the exact production tag pair; does not match a different status on the same endpoint; does not match a 403 on a different endpoint; false on missing tags / non-object input).

`pnpm vue-tsc --noEmit -p tsconfig.app.json` and `pnpm lint` are both clean on the touched files.

## Assumptions (no user confirmation obtained — filed via automated Sentry sweep)

- Treated this as pure Sentry noise rather than a functional bug: `fetchPurchaseInfo` (`src/stores/purchaseStore.ts`) already catches and silently no-ops on this failure, so there is no broken UI to fix — only an over-broad Sentry capture.
- Scoped the filter to the exact `(url, status)` pair rather than suppressing all 403s app-wide, so a real auth bug on a different endpoint would still surface.
- Left the dev server running from the worktree; this PR stays in draft.

## Sentry issue

https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-1F5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary error reporting for expected 403 responses from the purchase-information endpoint.
  * Continued reporting other API 403 responses normally.

* **Tests**
  * Added coverage for matching purchase-information responses, mismatched statuses or endpoints, missing event details, and invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->