### PR TITLE
fix: manage-accounts balance caching per address + collapsible group height

### DIFF
--- a/src/components/core_layouts/wallet/TheManageAccounts.vue
+++ b/src/components/core_layouts/wallet/TheManageAccounts.vue
@@ -596,9 +596,11 @@ const onRowVisibility = (acc: SavedAccount, visible: boolean): void => {
   }
 }
 
-// The cache is keyed per chain, so a network switch invalidates what's on screen
-// (IntersectionObserver won't re-fire since the rows didn't move) — re-fetch the
-// currently-visible rows for the newly-selected chain.
+// On a network switch the IntersectionObserver won't re-fire (rows don't move), so
+// re-evaluate the visible non-active rows. The cache/TTL is keyed per address, so
+// fresh balances are reused (no refetch — avoids rate-limiting the /balances API)
+// and only addresses whose TTL has expired refetch for the newly-selected chain.
+// The active address stays live via walletStore.
 watch(
   () => chainsStore.selectedChain?.name,
   () => {

--- a/src/components/transitions/ExpandTransition.vue
+++ b/src/components/transitions/ExpandTransition.vue
@@ -72,7 +72,11 @@ const resetStyles = (_element: Element) => {
   if (!height.value) return
   const element = _element as HTMLElement
   element.style.overflow = overflow.value
-  if (height.value != null) element.style.height = height.value
+  // Release the snapshotted height so the element goes back to height:auto and can
+  // grow/shrink with dynamic content after the transition (e.g. rows added or
+  // removed in a collapsible list). Keeping the fixed px height left the box the
+  // old size, so later content overflowed onto the next element or left a gap.
+  element.style.height = ''
   height.value = null
   overflow.value = ''
 }

--- a/src/composables/useAccountBalances.ts
+++ b/src/composables/useAccountBalances.ts
@@ -31,10 +31,13 @@ const NATIVE_TOKEN_CONTRACT = '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
 
 const STORAGE_KEY = 'multiAddressBalances'
 
-/** Cache key: per chain (name) + address so a balance persists across popup opens,
- *  page reloads and network switches. Lower-cased for stable matching. */
-const cacheKey = (chainName: string, address: string): string =>
-  `${chainName.toLowerCase()}:${address.toLowerCase()}`
+/** Cache key: per ADDRESS only (not per chain). A saved address is fetched at most
+ *  once per TTL regardless of the selected network — switching networks within the
+ *  TTL reuses the cached balance instead of refetching, which avoids rate-limiting
+ *  the /balances API when the user flips between networks. The selected chain still
+ *  drives the fetch URL, just not the cache identity. Lower-cased for stable matching. */
+const cacheKey = (_chainName: string, address: string): string =>
+  address.toLowerCase()
 
 /**
  * Per-address balance cache for the Manage Accounts popup.

--- a/tests/unit/composables/useAccountBalances.spec.ts
+++ b/tests/unit/composables/useAccountBalances.spec.ts
@@ -120,12 +120,34 @@ describe('useAccountBalances', () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
-  it('persists the cache to localStorage (keyed by chain + address, lower-cased)', async () => {
+  it('persists the cache to localStorage (keyed by address only, lower-cased)', async () => {
     fetchMock.mockResolvedValue({ result: [{ balance: '1', decimals: 0, price: 8 }] })
     const { fetchIfStale } = useAccountBalances()
     await fetchIfStale({ chainName: 'ETH', address: '0xAbC' })
     await nextTick()
     const stored = JSON.parse(localStorage.getItem('multiAddressBalances') || '{}')
-    expect(stored['eth:0xabc']).toMatchObject({ usdValue: 8, tokenCount: 1 })
+    expect(stored['0xabc']).toMatchObject({ usdValue: 8, tokenCount: 1 })
+  })
+
+  it('caches per address (not per chain): a network switch within the TTL is served from cache', async () => {
+    // Regression: previously the key was `${chain}:${address}`, so every network
+    // change was a cache miss → refetch (rate-limit risk). Now the same address is
+    // fetched at most once per TTL regardless of the selected network.
+    fetchMock.mockResolvedValue({ result: [{ balance: '1', decimals: 0, price: 5 }] })
+    const { fetchIfStale, cached } = useAccountBalances()
+    await fetchIfStale({ chainName: 'ETHEREUM', address: '0x1' })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    // Same address, different chain, still within TTL → no second request.
+    await fetchIfStale({ chainName: 'BSC', address: '0x1' })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    // The cached value is readable regardless of the chain name passed.
+    expect(cached('BSC', '0x1')).toEqual({ usdValue: 5, tokenCount: 1 })
+    // Past the TTL, a network switch does refetch (for the newly-selected chain).
+    vi.setSystemTime(BALANCE_TTL_MS + 1)
+    await fetchIfStale({ chainName: 'BSC', address: '0x1' })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      '/balances/BSC/0x1/?noInjectErrors=false&sparklines=true',
+    )
   })
 })


### PR DESCRIPTION
Two multi-address (Manage Accounts) popup fixes.

## 1. Balance cache per address (no refetch on network change within TTL)

The saved-address balance cache was keyed by `(chain, address)`, so every network switch was a cache miss and refetched every visible non-active address even when its TTL (2 min) hadn't expired — risking rate-limiting on the `/balances` API.

- Key the cache by **address only**: a saved address is fetched at most once per TTL regardless of the selected network.
- **Active / connected address** stays live via `walletStore` (unchanged).
- **Non-active addresses** are served from cache on a network switch while fresh; they only refetch once their TTL expires (the selected chain still drives the fetch URL).

**Trade-off:** within the TTL window a non-active address keeps showing its last-fetched balance even if you switch to another compatible network before it expires — intentional, to bound `/balances` traffic.

## 2. Collapsible group height follows dynamic content

`ExpandTransition.resetStyles` restored a fixed px height after the enter transition, so a collapsed element that later gained or lost children — e.g. the multi-address group lists when an address is saved or removed — kept its old height. Content overflowed onto the next group header (overlap) or left a gap between groups.

- Release the inline height after the transition so the element returns to `height:auto` and reflows with its content.
- Shared component, so it benefits every `ExpandTransition` usage; the post-expand natural height is unchanged for static content.

## Tests

- `useAccountBalances.spec.ts`: new case — same address across two chains served from cache within the TTL (one request) and refetches for the newly-selected chain once the TTL expires; persistence test updated to the address-only key.
- `vue-tsc` + `eslint` clean; balances / wallet suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)