### PR TITLE
fix: 🐛 perps charts to be uniform to the whole app

### DIFF
--- a/src/modules/perps/ModulePerpInfo.vue
+++ b/src/modules/perps/ModulePerpInfo.vue
@@ -64,8 +64,9 @@
     <div class="py-6">
       <div class="flex items-center justify-end mb-4 px-4 lg:px-10 sm:mb-4">
         <app-btn-group
-          v-model:selected="selectedInterval"
-          :btn-list="isXS ? chartIntervals.slice(0, 2) : chartIntervals"
+          v-model:selected="selectedRange"
+          :disabled="chartLoading"
+          :btn-list="isXS ? chartRanges.slice(0, 3) : chartRanges"
           size="xs"
         >
           <template #btn-content="{ data }">
@@ -74,8 +75,8 @@
           <template #custom>
             <app-select
               v-if="isXS"
-              v-model:selected="selectedInterval"
-              :options="chartIntervals.slice(2)"
+              v-model:selected="selectedRange"
+              :options="chartRanges.slice(3)"
               position="-right-1"
               class="text-s-12"
             >
@@ -971,6 +972,7 @@ import { EllipsisVerticalIcon, ChevronRightIcon } from '@heroicons/vue/24/solid'
 import AppTokenLogo from '@/components/AppTokenLogo.vue'
 import AppBtnText from '@/components/AppBtnText.vue'
 import ChartPrice from '@/components/ChartPrice.vue'
+import type { WebTokenPriceChartInterval } from '@/mew_api/types'
 
 import {
   ArrowTrendingDownIcon,
@@ -1623,39 +1625,79 @@ watch(selectedManageAction, action => {
 })
 
 // Chart
-const chartIntervals = [
-  { label: '1m', value: '1' },
-  { label: '5m', value: '5' },
-  { label: '1h', value: '60' },
-  { label: '4h', value: '240' },
-  { label: '1d', value: '1D' },
-  { label: '1w', value: '1W' },
-]
-const selectedInterval = ref(chartIntervals[2])
+// The selection is how far back the chart goes — same as the token and stock
+// charts elsewhere in the app. Each range pairs its window with a candle
+// resolution that keeps the bar count in a readable range.
+const DAY_SECS = 24 * 60 * 60
+
+interface ChartRange {
+  label: string
+  value: WebTokenPriceChartInterval
+  /** Candle resolution passed to the history endpoint. */
+  resolution: string
+  /** How far back from now the chart reaches, in seconds. */
+  windowSecs: number
+}
+
+const chartRanges = computed<ChartRange[]>(() => [
+  {
+    label: t('common.chart_1d'),
+    value: '1D',
+    resolution: '5',
+    windowSecs: DAY_SECS,
+  },
+  {
+    label: t('common.chart_7d'),
+    value: '7D',
+    resolution: '60',
+    windowSecs: 7 * DAY_SECS,
+  },
+  {
+    label: t('common.chart_1m'),
+    value: '1M',
+    resolution: '240',
+    windowSecs: 30 * DAY_SECS,
+  },
+  {
+    label: t('common.chart_3m'),
+    value: '3M',
+    resolution: '1D',
+    windowSecs: 90 * DAY_SECS,
+  },
+  {
+    label: t('common.chart_1y'),
+    value: '1Y',
+    resolution: '1W',
+    windowSecs: 365 * DAY_SECS,
+  },
+  {
+    // Markets are far younger than this, so the response is the full history.
+    label: t('common.chart_all'),
+    value: 'ALL',
+    resolution: '1W',
+    windowSecs: 10 * 365 * DAY_SECS,
+  },
+])
+
+const selectedRange = ref<ChartRange>(chartRanges.value[0])
+
+// Labels are locale-dependent, so re-resolve the selection when they change.
+watch(chartRanges, ranges => {
+  selectedRange.value =
+    ranges.find(r => r.value === selectedRange.value.value) ?? ranges[0]
+})
+
 const chartLoading = ref(false)
 const chartLabels = ref<number[]>([])
 const chartPoints = ref<number[]>([])
 
 const chartCache = new Map<string, { labels: number[]; points: number[] }>()
 
-const chartTimeFrame = computed(() => {
-  const v = selectedInterval.value.value
-  if (v === '1D') return '1D' as const
-  if (v === '1W') return '7D' as const
-  const mins = parseInt(v)
-  if (mins <= 60) return '1D' as const
-  if (mins <= 480) return '7D' as const
-  return '1M' as const
-})
-
-const getResolutionSeconds = (res: string): number => {
-  if (res === '1D') return 86400
-  if (res === '1W') return 604800
-  return parseInt(res) * 60
-}
+const chartTimeFrame = computed(() => selectedRange.value.value)
 
 const fetchChart = async () => {
-  const cacheKey = `${props.market}-${selectedInterval.value.value}`
+  const { value: range, resolution, windowSecs } = selectedRange.value
+  const cacheKey = `${props.market}-${range}`
   const cached = chartCache.get(cacheKey)
   if (cached) {
     chartLabels.value = cached.labels
@@ -1666,11 +1708,10 @@ const fetchChart = async () => {
   chartLoading.value = true
   try {
     const to = Math.floor(Date.now() / 1000)
-    const resSecs = getResolutionSeconds(selectedInterval.value.value)
-    const from = to - resSecs * 200
+    const from = to - windowSecs
     const data = await perpsClient.getHistory(
       props.market,
-      selectedInterval.value.value,
+      resolution,
       from,
       to,
     )
@@ -1691,7 +1732,7 @@ const fetchChart = async () => {
   }
 }
 
-watch(selectedInterval, fetchChart)
+watch(() => selectedRange.value.value, fetchChart)
 watch(() => props.market, fetchChart, { immediate: true })
 
 // Clear chart cache every 5 minutes

--- a/src/modules/perps/composables/usePerpsPortfolioGraph.ts
+++ b/src/modules/perps/composables/usePerpsPortfolioGraph.ts
@@ -1,14 +1,37 @@
-import { ref, watch, effectScope } from 'vue'
+import { ref, computed, watch, effectScope } from 'vue'
 import { perpsClient } from '../configs'
 import { usePerpsAuth, onPerpsAuthReset } from './usePerpsAuth'
 import type { PortfolioGraphPoint } from '../sdk/types'
 
 export type GraphRange = '24h' | '7d' | '30d' | 'all'
 
-const _graphData = ref<PortfolioGraphPoint[]>([])
+const DAY_MS = 24 * 60 * 60 * 1000
+
+const RANGE_WINDOW_MS: Record<Exclude<GraphRange, 'all'>, number> = {
+  '24h': DAY_MS,
+  '7d': 7 * DAY_MS,
+  '30d': 30 * DAY_MS,
+}
+
+const _graphDataRaw = ref<PortfolioGraphPoint[]>([])
 const _graphLoading = ref(false)
 const _graphRange = ref<GraphRange>('30d')
 const _cache = ref<Map<GraphRange, PortfolioGraphPoint[]>>(new Map())
+
+// The API's `range` only picks the bucket size — every response spans the whole
+// account history. Trim it to the selected window so the selection means "how
+// far back", the same as every other chart in the app.
+const _graphData = computed<PortfolioGraphPoint[]>(() => {
+  const points = _graphDataRaw.value
+  const range = _graphRange.value
+  if (range === 'all' || points.length === 0) return points
+
+  const cutoff = Date.now() - RANGE_WINDOW_MS[range]
+  const windowed = points.filter(p => new Date(p.time).getTime() >= cutoff)
+  // An account with no recent activity can have no snapshot inside a short
+  // window — fall back to the latest points instead of an empty chart.
+  return windowed.length > 1 ? windowed : points.slice(-2)
+})
 
 let _initialized = false
 
@@ -20,24 +43,27 @@ export function usePerpsPortfolioGraph() {
 
   async function fetchGraph() {
     if (!token.value) {
-      _graphData.value = []
+      _graphDataRaw.value = []
       return
     }
 
     const cached = _cache.value.get(_graphRange.value)
     if (cached) {
-      _graphData.value = cached
+      _graphDataRaw.value = cached
       return
     }
 
     _graphLoading.value = true
     try {
       const res = await perpsClient.getPortfolioGraph(_graphRange.value)
-      const result = res.result ?? []
+      // Sorted so trimming to a window and reading the latest points is safe.
+      const result = (res.result ?? [])
+        .slice()
+        .sort((a, b) => new Date(a.time).getTime() - new Date(b.time).getTime())
       _cache.value.set(_graphRange.value, result)
-      _graphData.value = result
+      _graphDataRaw.value = result
     } catch {
-      _graphData.value = []
+      _graphDataRaw.value = []
     } finally {
       _graphLoading.value = false
     }
@@ -47,7 +73,7 @@ export function usePerpsPortfolioGraph() {
     _initialized = true
 
     onPerpsAuthReset(() => {
-      _graphData.value = []
+      _graphDataRaw.value = []
       _cache.value.clear()
     })
 
@@ -64,7 +90,7 @@ export function usePerpsPortfolioGraph() {
             _cache.value.clear()
             fetchGraph()
           } else {
-            _graphData.value = []
+            _graphDataRaw.value = []
             _cache.value.clear()
           }
         },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Perpetuals price charts now offer predefined time ranges from 1 day to all available history.
  * Portfolio graphs now support 24-hour, 7-day, and 30-day views.
* **Improvements**
  * Selected chart ranges remain consistent when changing the app language.
  * Graph data is displayed chronologically, with fallback points when limited data is available.
* **Bug Fixes**
  * Portfolio charts now clear outdated data after sign-out, failed requests, or unavailable account data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->