### PR TITLE
feat: perps market-info chart lookback filters (MEW-2175)

### DIFF
--- a/src/modules/perps/ModulePerpInfo.vue
+++ b/src/modules/perps/ModulePerpInfo.vue
@@ -65,7 +65,7 @@
       <div class="flex items-center justify-end mb-4 px-4 lg:px-10 sm:mb-4">
         <app-btn-group
           v-model:selected="selectedInterval"
-          :btn-list="isXS ? chartIntervals.slice(0, 2) : chartIntervals"
+          :btn-list="isXS ? chartIntervals.slice(0, 3) : chartIntervals"
           size="xs"
         >
           <template #btn-content="{ data }">
@@ -75,7 +75,7 @@
             <app-select
               v-if="isXS"
               v-model:selected="selectedInterval"
-              :options="chartIntervals.slice(2)"
+              :options="chartIntervals.slice(3)"
               position="-right-1"
               class="text-s-12"
             >
@@ -971,6 +971,11 @@ import { EllipsisVerticalIcon, ChevronRightIcon } from '@heroicons/vue/24/solid'
 import AppTokenLogo from '@/components/AppTokenLogo.vue'
 import AppBtnText from '@/components/AppBtnText.vue'
 import ChartPrice from '@/components/ChartPrice.vue'
+import type { WebTokenPriceChartInterval } from '@/mew_api/types'
+import {
+  PERPS_CHART_INTERVALS,
+  getPerpsChartRange,
+} from './utils/chart'
 
 import {
   ArrowTrendingDownIcon,
@@ -1622,37 +1627,31 @@ watch(selectedManageAction, action => {
   selectedManageAction.value = undefined
 })
 
-// Chart
-const chartIntervals = [
-  { label: '1m', value: '1' },
-  { label: '5m', value: '5' },
-  { label: '1h', value: '60' },
-  { label: '4h', value: '240' },
-  { label: '1d', value: '1D' },
-  { label: '1w', value: '1W' },
-]
-const selectedInterval = ref(chartIntervals[2])
+// Chart — lookback filters (1D/7D/1M/3M/1Y/ALL), matching the crypto/stocks
+// info charts. See ./utils/chart for the period → window/resolution mapping.
+interface ChartInterval {
+  label: string
+  value: WebTokenPriceChartInterval
+}
+const chartIntervals = computed<ChartInterval[]>(() =>
+  PERPS_CHART_INTERVALS.map(value => ({
+    label: t(`common.chart_${value.toLowerCase()}`),
+    value,
+  })),
+)
+const selectedInterval = ref<ChartInterval>(chartIntervals.value[0])
+watch(chartIntervals, options => {
+  selectedInterval.value =
+    options.find(opt => opt.value === selectedInterval.value.value) ||
+    options[0]
+})
 const chartLoading = ref(false)
 const chartLabels = ref<number[]>([])
 const chartPoints = ref<number[]>([])
 
 const chartCache = new Map<string, { labels: number[]; points: number[] }>()
 
-const chartTimeFrame = computed(() => {
-  const v = selectedInterval.value.value
-  if (v === '1D') return '1D' as const
-  if (v === '1W') return '7D' as const
-  const mins = parseInt(v)
-  if (mins <= 60) return '1D' as const
-  if (mins <= 480) return '7D' as const
-  return '1M' as const
-})
-
-const getResolutionSeconds = (res: string): number => {
-  if (res === '1D') return 86400
-  if (res === '1W') return 604800
-  return parseInt(res) * 60
-}
+const chartTimeFrame = computed(() => selectedInterval.value.value)
 
 const fetchChart = async () => {
   const cacheKey = `${props.market}-${selectedInterval.value.value}`
@@ -1665,12 +1664,12 @@ const fetchChart = async () => {
 
   chartLoading.value = true
   try {
-    const to = Math.floor(Date.now() / 1000)
-    const resSecs = getResolutionSeconds(selectedInterval.value.value)
-    const from = to - resSecs * 200
+    const { from, to, resolution } = getPerpsChartRange(
+      selectedInterval.value.value,
+    )
     const data = await perpsClient.getHistory(
       props.market,
-      selectedInterval.value.value,
+      resolution,
       from,
       to,
     )

--- a/src/modules/perps/utils/chart.ts
+++ b/src/modules/perps/utils/chart.ts
@@ -1,0 +1,46 @@
+import type { WebTokenPriceChartInterval } from '@/mew_api/types'
+
+/**
+ * Lookback filters for the perps market-info price chart. Mirrors the
+ * crypto/stocks info charts (1D/7D/1M/3M/1Y/ALL) instead of the old candle
+ * resolutions — on a line chart the lookback range is what's meaningful.
+ *
+ * Each period maps to a lookback window (in seconds) plus the candle
+ * resolution passed to the Ondo history endpoint, chosen to keep the returned
+ * bar count small (well under any UDF bar cap).
+ *
+ * ponytail: ALL uses a fixed ~5y window — perps exposes no inception date in
+ * the app; widen the window if markets older than that appear.
+ */
+export const PERPS_CHART_INTERVALS: WebTokenPriceChartInterval[] = [
+  '1D',
+  '7D',
+  '1M',
+  '3M',
+  '1Y',
+  'ALL',
+]
+
+const RANGE: Record<
+  WebTokenPriceChartInterval,
+  { seconds: number; resolution: string }
+> = {
+  '1D': { seconds: 86400, resolution: '5' }, // 5m  → 288 bars
+  '7D': { seconds: 604800, resolution: '60' }, // 1h  → 168 bars
+  '1M': { seconds: 2592000, resolution: '240' }, // 4h  → 180 bars
+  '3M': { seconds: 7776000, resolution: '1D' }, // 1d  → 90 bars
+  '1Y': { seconds: 31536000, resolution: '1D' }, // 1d  → 365 bars
+  ALL: { seconds: 157680000, resolution: '1W' }, // 1w  → ~260 bars (~5y)
+}
+
+/**
+ * Resolve a lookback filter to the `{ from, to, resolution }` args for
+ * `perpsClient.getHistory`. `now` (unix seconds) is injectable for tests.
+ */
+export function getPerpsChartRange(
+  interval: WebTokenPriceChartInterval,
+  now: number = Math.floor(Date.now() / 1000),
+): { from: number; to: number; resolution: string } {
+  const { seconds, resolution } = RANGE[interval]
+  return { from: now - seconds, to: now, resolution }
+}

--- a/tests/unit/modules/perps/utils/chart.spec.ts
+++ b/tests/unit/modules/perps/utils/chart.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import {
+  PERPS_CHART_INTERVALS,
+  getPerpsChartRange,
+} from '@/modules/perps/utils/chart'
+
+describe('perps chart lookback filters', () => {
+  it('exposes the same lookback filters as crypto/stocks, in order', () => {
+    expect(PERPS_CHART_INTERVALS).toEqual([
+      '1D',
+      '7D',
+      '1M',
+      '3M',
+      '1Y',
+      'ALL',
+    ])
+  })
+
+  it('maps each filter to a from/to window ending at `now`', () => {
+    const now = 1_700_000_000
+    const cases: Array<[(typeof PERPS_CHART_INTERVALS)[number], number, string]> =
+      [
+        ['1D', 86400, '5'],
+        ['7D', 604800, '60'],
+        ['1M', 2592000, '240'],
+        ['3M', 7776000, '1D'],
+        ['1Y', 31536000, '1D'],
+        ['ALL', 157680000, '1W'],
+      ]
+    for (const [interval, seconds, resolution] of cases) {
+      const range = getPerpsChartRange(interval, now)
+      expect(range).toEqual({ from: now - seconds, to: now, resolution })
+    }
+  })
+
+  it('keeps every window under ~400 candles (well below the UDF bar cap)', () => {
+    const secondsPerBar: Record<string, number> = {
+      '5': 300,
+      '60': 3600,
+      '240': 14400,
+      '1D': 86400,
+      '1W': 604800,
+    }
+    for (const interval of PERPS_CHART_INTERVALS) {
+      const { from, to, resolution } = getPerpsChartRange(interval, 0)
+      const bars = (to - from) / secondsPerBar[resolution]
+      expect(bars).toBeLessThanOrEqual(400)
+    }
+  })
+
+  it('defaults `now` to the current time when omitted', () => {
+    const before = Math.floor(Date.now() / 1000)
+    const { to } = getPerpsChartRange('1D')
+    const after = Math.floor(Date.now() / 1000)
+    expect(to).toBeGreaterThanOrEqual(before)
+    expect(to).toBeLessThanOrEqual(after)
+  })
+})


### PR DESCRIPTION
## Summary

Replaces the candle-resolution breakdowns (`1m / 5m / 1h / 4h / 1d / 1w`) on the perps **Market info** price chart with the **lookback filters** used by the crypto and stocks info charts: `1D / 7D / 1M / 3M / 1Y / ALL`.

All three drawers already render the same shared `ChartPrice.vue` (a line chart). On a line chart, candle granularity isn't meaningful to the user — the lookback range is. This aligns perps with crypto/stocks.

## Changes

- **`src/modules/perps/utils/chart.ts`** (new) — `getPerpsChartRange(interval, now?)` maps each lookback period to a `{ from, to, resolution }` window for `perpsClient.getHistory`, picking a candle resolution that keeps the returned bar count small (≤ ~365, well under any UDF bar cap). `PERPS_CHART_INTERVALS` is the ordered filter list.
- **`src/modules/perps/ModulePerpInfo.vue`** — filters now come from `PERPS_CHART_INTERVALS` with `common.chart_*` labels; `time-frame` is passed straight to `ChartPrice` (which already types/formats all six timeframes); XS shows the first 3 as buttons + the rest in the "More" dropdown (matching crypto/stocks). Removed the now-dead `getResolutionSeconds` and the derived `chartTimeFrame` mapping.
- **`tests/unit/modules/perps/utils/chart.spec.ts`** (new) — covers the filter list, the period→window/resolution mapping, the bar-count ceiling, and the `now` default.

No backend / endpoint / shared-component changes. No new i18n keys.

## Trade-off

Switching to lookback filters removes the ability to pick intraday candle granularity (1m/5m). Acceptable while the chart is a line chart. Follow-up tracked on the ticket: add a candlestick (OHLC) chart later — the history endpoint already returns full OHLCV — at which point the resolution filters become meaningful again.

## Testing

- `pnpm vitest run tests/unit/modules/perps/utils/chart.spec.ts` — 4/4 pass
- `pnpm vue-tsc --noEmit -p tsconfig.app.json` — clean
- `eslint` on changed files — clean
- Manual smoke test on the perps market-info page — filters render, each loads the correct lookback window, axis/tooltip format per timeframe, XS responsive behavior confirmed

_Note: 9 pre-existing failures in `usePerpsRestriction` / `usePerpsToasts` specs are unrelated to this change (confirmed red on `feat/v7-develop` without these edits)._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added chart interval options for 1 day, 7 days, 1 month, 3 months, 1 year, and all available history.
  - On extra-small screens, the three most common intervals are now shown directly, with additional options available in an overflow menu.
  - Chart data now uses consistent time ranges and resolutions for each selected interval.

- **Tests**
  - Added coverage for interval ordering, date ranges, resolutions, and default time handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->