### PR TITLE
fix: [MEW-2177] drop external QuotaExceededError noise in beforeSend

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,7 @@ import {
   isMetaMaskSdkDecryptError,
   isProviderNotFoundError,
   isRainbowKitNotFoundError,
+  isStorageQuotaExceededError,
   isTransactionReceiptTimeoutError,
   isTrezorHandshakeError,
 } from '@/sentry/extensionNoise'
@@ -92,6 +93,7 @@ if (dsn && process.env.NODE_ENV === 'production') {
         isMetaMaskSdkDecryptError(originalException) ||
         isProviderNotFoundError(originalException) ||
         isRainbowKitNotFoundError(originalException) ||
+        isStorageQuotaExceededError(originalException) ||
         isTransactionReceiptTimeoutError(originalException) ||
         isTransientRpcError(originalException) ||
         isTrezorHandshakeError(originalException) ||

--- a/src/sentry/extensionNoise.ts
+++ b/src/sentry/extensionNoise.ts
@@ -168,6 +168,28 @@ export function isForeignStackOverflow(event: unknown): boolean {
 }
 
 /**
+ * Whether an error is a storage `QuotaExceededError` (DOMException code 22).
+ *
+ * On the Home route (wallet not connected) the wallet-connection stack
+ * (WalletConnect / wagmi core) persists session state to IndexedDB during
+ * bootstrap. That write is fire-and-forget inside the library, so when the
+ * browser's per-origin storage quota is exhausted (Firefox private mode, a
+ * near-full disk, or strict privacy settings) the IndexedDB transaction
+ * rejects with "The current transaction exceeded its quota limitations." and
+ * bubbles to the global `onunhandledrejection` handler with no first-party
+ * frames. Our own synchronous `localStorage` writes are already guarded by
+ * `safeLocalStorage` (they degrade to an in-memory map on quota), so a quota
+ * error reaching Sentry is always this external, unactionable async noise.
+ * Matched via the DOMException `name` / legacy `code` (both quota-exclusive),
+ * so it survives minification and the serialized plain-object payload shape.
+ */
+export function isStorageQuotaExceededError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false
+  const e = err as { name?: unknown; code?: unknown }
+  return e.name === 'QuotaExceededError' || e.code === 22
+}
+
+/**
  * Whether an error is a viem `WaitForTransactionReceiptTimeoutError` — thrown
  * when `waitForTransactionReceipt` times out because a submitted trade/swap tx
  * did not confirm within the timeout window (slow node, congestion, dropped tx,

--- a/tests/unit/sentry/extensionNoise.spec.ts
+++ b/tests/unit/sentry/extensionNoise.spec.ts
@@ -10,6 +10,7 @@ import {
   isMetaMaskSdkDecryptError,
   isProviderNotFoundError,
   isRainbowKitNotFoundError,
+  isStorageQuotaExceededError,
   isTransactionReceiptTimeoutError,
   isTrezorHandshakeError,
 } from '@/sentry/extensionNoise'
@@ -142,6 +143,51 @@ describe('isProviderNotFoundError', () => {
     expect(isProviderNotFoundError(null)).toBe(false)
     expect(isProviderNotFoundError(undefined)).toBe(false)
     expect(isProviderNotFoundError('Provider not found.')).toBe(false)
+  })
+})
+
+describe('isStorageQuotaExceededError', () => {
+  it('is true for a real DOMException QuotaExceededError (async IndexedDB write)', () => {
+    // The exact production trigger: a third-party library's IndexedDB write
+    // rejects when the browser's per-origin quota is exhausted.
+    const err = new DOMException(
+      'The current transaction exceeded its quota limitations.',
+      'QuotaExceededError',
+    )
+    expect(isStorageQuotaExceededError(err)).toBe(true)
+  })
+
+  it('is true for the serialized production payload (plain object with name)', () => {
+    expect(
+      isStorageQuotaExceededError({
+        name: 'QuotaExceededError',
+        message: 'The current transaction exceeded its quota limitations.',
+      }),
+    ).toBe(true)
+  })
+
+  it('is true when only the legacy DOMException code 22 survives serialization', () => {
+    // Sentry tags this issue with `DOMException.code: 22` (QUOTA_EXCEEDED_ERR).
+    expect(isStorageQuotaExceededError({ code: 22, message: 'quota' })).toBe(
+      true,
+    )
+  })
+
+  it('is false for a genuine app error', () => {
+    expect(
+      isStorageQuotaExceededError(
+        new TypeError("Cannot read properties of undefined (reading 'x')"),
+      ),
+    ).toBe(false)
+    expect(
+      isStorageQuotaExceededError({ name: 'SomeOtherError', code: 1 }),
+    ).toBe(false)
+  })
+
+  it('is false for non-object inputs', () => {
+    expect(isStorageQuotaExceededError(null)).toBe(false)
+    expect(isStorageQuotaExceededError(undefined)).toBe(false)
+    expect(isStorageQuotaExceededError('QuotaExceededError')).toBe(false)
   })
 })
 


### PR DESCRIPTION
## What was wrong

Sentry logs a `QuotaExceededError: The current transaction exceeded its quota limitations.` (DOMException code 22) as an **unhandled promise rejection** on the Home page, even with no wallet connected. It has no stacktrace, ~60 occurrences over 4 months, 0 users impacted, and is confined to one quota-constrained browser (Firefox on Ubuntu). It is not a user-facing failure — pure error-tracking noise.

## What changed

Because it is a **promise rejection** (async), it cannot come from our own `localStorage` calls (those are synchronous and are already guarded by `safeLocalStorage`, degrading to an in-memory map on quota). We have no direct IndexedDB usage of our own, so the async quota error originates from a third-party wallet-connection library (WalletConnect / wagmi core) persisting session state to IndexedDB during bootstrap; that fire-and-forget write rejects when the browser's per-origin storage quota is exhausted, and the rejection bubbles to the global handler with no first-party frames.

This adds an `isStorageQuotaExceededError` predicate to `src/sentry/extensionNoise.ts` (matches DOMException `name === 'QuotaExceededError'` or legacy `code === 22`, both quota-exclusive) and drops it in the Sentry `beforeSend` hook in `src/main.ts`, alongside the existing external-noise filters. A genuine app error is unaffected.

## How to test

This is a Sentry-side noise filter with no user-visible behavior change — the smoke test is to confirm the app still works normally.

1. Open the dev server and load the Home page (`/`) with no wallet connected.
2. Confirm the app loads and behaves normally (connect a wallet, navigate around).
3. Unit coverage: `pnpm vitest run tests/unit/sentry/extensionNoise.spec.ts` (48 tests, includes the new `isStorageQuotaExceededError` cases for the real DOMException, the serialized `{ name }` payload, the bare `code: 22` payload, and negative cases).

## Assumptions

Ran full-auto without user confirmation. Diagnosed the source as an external async IndexedDB write (WalletConnect/wagmi) rather than an app-side storage leak, based on: the `onunhandledrejection` mechanism (rules out our synchronous localStorage), the absence of any direct IndexedDB usage in `src/`, `safeLocalStorage` already guarding our own writes, and the low-volume single-browser footprint (0 users impacted) indicating an environmental quota condition, not a bug reproducible across users.

## Sentry

https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-KC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced unnecessary error reporting by filtering out storage quota exceeded errors from Sentry.
  - Improved recognition of quota errors across modern and legacy browser formats.
  - Preserved reporting for genuine errors and invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->