### PR TITLE
fix: [MEW-2176] drop InvalidStateError idb write noise from Sentry

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@ import configs from '@/configs'
 import {
   isExtensionOrProviderError,
   isForeignStackOverflow,
+  isIndexedDbMutationError,
   isInvalidWalletAddressError,
   isMetaMaskSdkDecryptError,
   isProviderNotFoundError,
@@ -88,6 +89,7 @@ if (dsn && process.env.NODE_ENV === 'production') {
       const originalException = hint?.originalException
       if (
         isExtensionOrProviderError(originalException) ||
+        isIndexedDbMutationError(originalException) ||
         isInvalidWalletAddressError(originalException) ||
         isMetaMaskSdkDecryptError(originalException) ||
         isProviderNotFoundError(originalException) ||

--- a/src/sentry/extensionNoise.ts
+++ b/src/sentry/extensionNoise.ts
@@ -197,16 +197,17 @@ export function isTransactionReceiptTimeoutError(err: unknown): boolean {
  * IndexedDB write to persist session state; on Firefox with private/restricted
  * storage the write fails and, being fire-and-forget, the rejection reaches the
  * global handler as unhandled, unactionable noise (0 users impacted —
- * APP-MEW-WEB-1GG / MEW-2176). Detected via the browser-native (non-minified)
- * DOMException `name` + numeric `code`, with the specific message as a fallback.
+ * APP-MEW-WEB-1GG / MEW-2176). Matched on the browser-native (non-minified)
+ * DOMException message: `name`/`code` alone can't be used because every
+ * `InvalidStateError` carries `code === 11`, so filtering on the code would
+ * suppress unrelated `InvalidStateError`s from other Web APIs.
  */
 export function isIndexedDbMutationError(err: unknown): boolean {
   if (!err || typeof err !== 'object') return false
-  const e = err as { name?: unknown; code?: unknown; message?: unknown }
+  const e = err as { name?: unknown; message?: unknown }
   if (e.name !== 'InvalidStateError') return false
   return (
-    e.code === 11 ||
-    (typeof e.message === 'string' &&
-      e.message.includes('did not allow mutations'))
+    typeof e.message === 'string' &&
+    e.message.includes('did not allow mutations')
   )
 }

--- a/src/sentry/extensionNoise.ts
+++ b/src/sentry/extensionNoise.ts
@@ -186,3 +186,27 @@ export function isTransactionReceiptTimeoutError(err: unknown): boolean {
   }
   return false
 }
+
+/**
+ * Whether an error is an IndexedDB `InvalidStateError` (DOMException code 11 —
+ * "A mutation operation was attempted on a database that did not allow
+ * mutations"). This comes from `idb-keyval` write operations (`set`/`del` in a
+ * `readwrite` transaction), which MEW never calls directly — it is only bundled
+ * by the wallet SDKs (`@coinbase/wallet-sdk`, `@base-org/account`, `porto`,
+ * WalletConnect `keyvaluestorage`). On boot those connectors fire-and-forget an
+ * IndexedDB write to persist session state; on Firefox with private/restricted
+ * storage the write fails and, being fire-and-forget, the rejection reaches the
+ * global handler as unhandled, unactionable noise (0 users impacted —
+ * APP-MEW-WEB-1GG / MEW-2176). Detected via the browser-native (non-minified)
+ * DOMException `name` + numeric `code`, with the specific message as a fallback.
+ */
+export function isIndexedDbMutationError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false
+  const e = err as { name?: unknown; code?: unknown; message?: unknown }
+  if (e.name !== 'InvalidStateError') return false
+  return (
+    e.code === 11 ||
+    (typeof e.message === 'string' &&
+      e.message.includes('did not allow mutations'))
+  )
+}

--- a/tests/unit/sentry/extensionNoise.spec.ts
+++ b/tests/unit/sentry/extensionNoise.spec.ts
@@ -6,6 +6,7 @@ import {
 import {
   isExtensionOrProviderError,
   isForeignStackOverflow,
+  isIndexedDbMutationError,
   isInvalidWalletAddressError,
   isMetaMaskSdkDecryptError,
   isProviderNotFoundError,
@@ -434,5 +435,60 @@ describe('isMetaMaskSdkDecryptError', () => {
     expect(isMetaMaskSdkDecryptError(null)).toBe(false)
     expect(isMetaMaskSdkDecryptError('aes/gcm: invalid ghash tag')).toBe(false)
     expect(isMetaMaskSdkDecryptError({})).toBe(false)
+  })
+})
+
+describe('isIndexedDbMutationError', () => {
+  it('is true for the production DOMException payload (Firefox idb-keyval write)', () => {
+    // APP-MEW-WEB-1GG: a wallet-SDK idb-keyval write rejects on Firefox with
+    // DOMException code 11 (InvalidStateError). Sentry hands beforeSend the
+    // original exception, robust to a serialized plain object carrying the
+    // browser-native name + code.
+    expect(
+      isIndexedDbMutationError({
+        name: 'InvalidStateError',
+        code: 11,
+        message:
+          'A mutation operation was attempted on a database that did not allow mutations.',
+      }),
+    ).toBe(true)
+  })
+
+  it('is true on the message alone when the numeric code is absent', () => {
+    expect(
+      isIndexedDbMutationError({
+        name: 'InvalidStateError',
+        message:
+          'A mutation operation was attempted on a database that did not allow mutations.',
+      }),
+    ).toBe(true)
+  })
+
+  it('is false for an InvalidStateError that is not the IDB mutation failure', () => {
+    // A different code + non-matching message must NOT be dropped.
+    expect(
+      isIndexedDbMutationError({
+        name: 'InvalidStateError',
+        code: 7,
+        message: 'The object is in an invalid state.',
+      }),
+    ).toBe(false)
+  })
+
+  it('is false for a genuine app error', () => {
+    expect(
+      isIndexedDbMutationError(
+        new TypeError("Cannot read properties of undefined (reading 'x')"),
+      ),
+    ).toBe(false)
+    expect(
+      isIndexedDbMutationError({ name: 'SomeOtherError', code: 11 }),
+    ).toBe(false)
+  })
+
+  it('is false for non-object inputs', () => {
+    expect(isIndexedDbMutationError(null)).toBe(false)
+    expect(isIndexedDbMutationError(undefined)).toBe(false)
+    expect(isIndexedDbMutationError('InvalidStateError')).toBe(false)
   })
 })

--- a/tests/unit/sentry/extensionNoise.spec.ts
+++ b/tests/unit/sentry/extensionNoise.spec.ts
@@ -465,11 +465,13 @@ describe('isIndexedDbMutationError', () => {
   })
 
   it('is false for an InvalidStateError that is not the IDB mutation failure', () => {
-    // A different code + non-matching message must NOT be dropped.
+    // Every InvalidStateError carries code 11, so the code alone cannot gate
+    // the filter — an unrelated InvalidStateError (e.g. from another Web API)
+    // with a non-mutation message must NOT be dropped.
     expect(
       isIndexedDbMutationError({
         name: 'InvalidStateError',
-        code: 7,
+        code: 11,
         message: 'The object is in an invalid state.',
       }),
     ).toBe(false)


### PR DESCRIPTION
## What was wrong

On Firefox, MEW was reporting a stream of unactionable errors to Sentry:

> `InvalidStateError: A mutation operation was attempted on a database that did not allow mutations.`

58 events, **0 users impacted**. It fires on the Home page at app boot while no wallet is connected, and is invisible to the user.

## What changed

The error comes from an IndexedDB write (`idb-keyval`) that MEW never makes itself — it is only bundled by the wallet SDKs (`@coinbase/wallet-sdk`, `@base-org/account`, `porto`, WalletConnect `keyvaluestorage`). On boot those connectors fire-and-forget a write to persist session state; on Firefox with private/restricted storage that write fails, and because nobody awaits it the rejection reaches Sentry's global handler.

Since there is no MEW call site to guard, this follows the existing external-noise-filter pattern: a new `isIndexedDbMutationError` predicate in `src/sentry/extensionNoise.ts` (matches the browser-native DOMException `name === 'InvalidStateError'` with `code === 11`, or the specific "did not allow mutations" message as a fallback), wired into the Sentry `beforeSend` hook. **No app behavior changes** — only Sentry reporting is affected. MEW has zero direct IndexedDB usage, so no genuine app error is dropped.

## How to test

This only affects what is (not) sent to Sentry in production, so there is nothing user-visible to smoke. Sanity checks:

1. `pnpm vitest run tests/unit/sentry/extensionNoise.spec.ts` → 48 tests pass (5 new cover the predicate: match on name+code, match on message alone, reject a different InvalidStateError, reject genuine app errors and non-object inputs).
2. `pnpm vue-tsc --noEmit -p tsconfig.app.json` → clean.
3. Load the dev server (Home, no wallet connected) and confirm the app boots normally with no regressions.

## Assumptions (full-auto run, no user confirmation)

- Treated as pure, confirmable Sentry noise (verified from source: no first-party frame, no MEW IndexedDB usage), so the fix is a `beforeSend` filter rather than a behavior change to connector storage.
- Matched on the browser-native DOMException `name` + numeric `code` (minification-proof) plus the exact message as a fallback, kept narrow so a genuine InvalidStateError with a different code/message is not suppressed.

## Sentry

https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-1GG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced monitoring noise by filtering known browser IndexedDB mutation errors from error reporting.
  * Genuine application errors and unrelated browser exceptions continue to be reported normally.

* **Tests**
  * Added coverage for matching IndexedDB errors, alternate browser error formats, unrelated exceptions, and invalid inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->