### PR TITLE
fix: [MEW-2178] drop Ledger BLE GATT-disconnect noise from Sentry

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,7 @@ import rippleDirective from '@/directives/ripple'
 import { autoAnimatePlugin } from '@formkit/auto-animate/vue'
 import configs from '@/configs'
 import {
+  isBluetoothGattDisconnectedError,
   isExtensionOrProviderError,
   isForeignStackOverflow,
   isInvalidWalletAddressError,
@@ -87,6 +88,7 @@ if (dsn && process.env.NODE_ENV === 'production') {
     beforeSend(event, hint) {
       const originalException = hint?.originalException
       if (
+        isBluetoothGattDisconnectedError(originalException) ||
         isExtensionOrProviderError(originalException) ||
         isInvalidWalletAddressError(originalException) ||
         isMetaMaskSdkDecryptError(originalException) ||

--- a/src/sentry/extensionNoise.ts
+++ b/src/sentry/extensionNoise.ts
@@ -186,3 +186,25 @@ export function isTransactionReceiptTimeoutError(err: unknown): boolean {
   }
   return false
 }
+
+/**
+ * Whether an error is a Web Bluetooth "GATT Server is disconnected"
+ * DOMException. Chrome throws this (`NetworkError`, code 19) whenever a GATT
+ * operation runs after the device has disconnected. The Ledger BLE transport
+ * (`@ledgerhq/hw-transport-web-ble`) triggers it when its RxJS monitor teardown
+ * fire-and-forgets `characteristic.stopNotifications()` after the device drops
+ * mid-handshake (powered off / out of range / Bluetooth toggled). Since that
+ * call is detached from any promise the app awaits, it surfaces as an unhandled
+ * rejection, and the connect flow already shows the user a "Failed to connect"
+ * toast — so it is external, unactionable Sentry noise. The frames are bundled
+ * into our own `/assets/index-*.js`, so denyUrls can't catch it; matched on the
+ * browser-native (minification-proof) message instead.
+ */
+export function isBluetoothGattDisconnectedError(err: unknown): boolean {
+  if (typeof err === 'string') return /GATT Server is disconnected/i.test(err)
+  if (!err || typeof err !== 'object') return false
+  const message = (err as { message?: unknown }).message
+  return (
+    typeof message === 'string' && /GATT Server is disconnected/i.test(message)
+  )
+}

--- a/tests/unit/sentry/extensionNoise.spec.ts
+++ b/tests/unit/sentry/extensionNoise.spec.ts
@@ -4,6 +4,7 @@ import {
   WaitForTransactionReceiptTimeoutError,
 } from 'viem'
 import {
+  isBluetoothGattDisconnectedError,
   isExtensionOrProviderError,
   isForeignStackOverflow,
   isInvalidWalletAddressError,
@@ -403,6 +404,60 @@ describe('isRainbowKitNotFoundError', () => {
     expect(isRainbowKitNotFoundError(undefined)).toBe(false)
     expect(isRainbowKitNotFoundError({ message: 42 })).toBe(false)
     expect(isRainbowKitNotFoundError('something else')).toBe(false)
+  })
+})
+
+describe('isBluetoothGattDisconnectedError', () => {
+  it('is true for the exact Chrome DOMException from the Ledger BLE teardown', () => {
+    // The exact production trigger (APP-MEW-WEB-1AY): the Ledger BLE transport
+    // fire-and-forgets stopNotifications() after the GATT server disconnected.
+    expect(
+      isBluetoothGattDisconnectedError({
+        name: 'NetworkError',
+        code: 19,
+        message:
+          "Failed to execute 'stopNotifications' on 'BluetoothRemoteGATTCharacteristic': GATT Server is disconnected. Cannot perform GATT operations. (Re)connect first with `device.gatt.connect`.",
+      }),
+    ).toBe(true)
+  })
+
+  it('is true for a real DOMException instance', () => {
+    expect(
+      isBluetoothGattDisconnectedError(
+        new Error(
+          "Failed to execute 'readValue' on 'BluetoothRemoteGATTCharacteristic': GATT Server is disconnected.",
+        ),
+      ),
+    ).toBe(true)
+  })
+
+  it('is true for a bare-string rejection', () => {
+    expect(
+      isBluetoothGattDisconnectedError(
+        'NetworkError: GATT Server is disconnected. Cannot perform GATT operations.',
+      ),
+    ).toBe(true)
+  })
+
+  it('is false for a genuine app error', () => {
+    expect(
+      isBluetoothGattDisconnectedError(
+        new TypeError("Cannot read properties of undefined (reading 'x')"),
+      ),
+    ).toBe(false)
+    // A different BLE error we do NOT want to blanket-suppress.
+    expect(
+      isBluetoothGattDisconnectedError(
+        new Error('GATT operation already in progress'),
+      ),
+    ).toBe(false)
+  })
+
+  it('is false for non-object inputs', () => {
+    expect(isBluetoothGattDisconnectedError(null)).toBe(false)
+    expect(isBluetoothGattDisconnectedError(undefined)).toBe(false)
+    expect(isBluetoothGattDisconnectedError({ message: 42 })).toBe(false)
+    expect(isBluetoothGattDisconnectedError('something else')).toBe(false)
   })
 })
 


### PR DESCRIPTION
## What was wrong

Sentry issue [APP-MEW-WEB-1AY](https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-1AY) was firing an unhandled promise rejection (78 events, **0 users impacted**) whenever a user tried to connect a Ledger over **Bluetooth** on the `/access` route and the device dropped mid-handshake (powered off / out of range / Bluetooth toggled).

The throwing call lives inside the third-party `@ledgerhq/hw-transport-web-ble` library: its RxJS monitor teardown fire-and-forgets `characteristic.stopNotifications()`, and when the GATT server is already disconnected Chrome rejects with a `DOMException` (`NetworkError`, code 19: "GATT Server is disconnected. Cannot perform GATT operations."). Because that call is detached from any promise the app awaits, it surfaces as an unhandled rejection rather than being caught by the connect flow's `try/catch`.

The user already sees a "Failed to connect. Check your wallet for errors" toast (confirmed in the Sentry state snapshot), so this is external, unactionable noise — not an app bug we can guard at the source.

## What changed

- Added a narrow `isBluetoothGattDisconnectedError` predicate to `src/sentry/extensionNoise.ts`, matching the browser-native (minification-proof) message `GATT Server is disconnected`.
- Wired it into the existing `beforeSend` drop list in `src/main.ts` — same pattern as the Trezor-handshake / provider-not-found / rainbowkit predicates.
- Added unit tests covering the exact production payload, a `DOMException`-instance shape, the bare-string shape, and negative cases (genuine app errors, other BLE errors, non-object inputs).

The crash slips past the existing `denyUrls`/`ignoreErrors` filters because its stack frames are bundled into our own `/assets/index-*.js` (Sentry treats it first-party), which is why a `beforeSend` predicate is required.

## How to test

This is a Sentry-side change with no user-visible UI impact — it only stops a noise event from being reported. To sanity-check the connect flow still behaves normally:

1. Go to `/access` → **Browse hardware wallets** → **Ledger** → choose **Bluetooth** (Chrome desktop, Web Bluetooth).
2. Cancel the BLE picker, or let a paired device drop mid-connect.
3. Expected: the "Failed to connect. Check your wallet for errors" toast still appears and the app stays responsive (unchanged behavior). The only difference is the GATT-disconnect rejection is no longer sent to Sentry in production.

Unit tests: `pnpm vitest run tests/unit/sentry/extensionNoise.spec.ts` (48 passing).

## Assumptions

- Classified as unactionable third-party/hardware noise rather than an app bug: the throwing `stopNotifications()` is inside the Ledger BLE library's detached observable teardown, so MEW cannot wrap it at the source, and the connect failure is already surfaced to the user.
- The matcher is intentionally narrow (`GATT Server is disconnected`) so genuine in-app errors and other BLE conditions (e.g. "GATT operation already in progress") are unaffected.

Sentry: https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-1AY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary error reporting for expected Bluetooth device disconnection events.
  * Improved recognition of Bluetooth GATT disconnection messages across supported error formats.

* **Tests**
  * Added coverage for Bluetooth disconnection errors, standard errors, strings, unrelated errors, and invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->