### PR TITLE
fix: [MEW-2180] backstop expected trade quote/order errors in beforeSend

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,7 @@ import rippleDirective from '@/directives/ripple'
 import { autoAnimatePlugin } from '@formkit/auto-animate/vue'
 import configs from '@/configs'
 import {
+  isExpectedTradeClientError,
   isExtensionOrProviderError,
   isForeignStackOverflow,
   isInvalidWalletAddressError,
@@ -81,12 +82,19 @@ if (dsn && process.env.NODE_ENV === 'production') {
     // confirm within the timeout — a network condition the app already handles),
     // and the external "not found rainbowkit" rejection emitted by a wallet's
     // injected in-app-browser detection script (not app code — our bundle never
-    // throws it). These surface as serialized plain objects or bare strings with
-    // no parsed frames, so denyUrls can't catch them — inspect the original
-    // exception instead. Genuine app errors are unaffected.
+    // throws it). Also a global backstop for trade quote/order errors already
+    // flagged `expectedClientError` / `transientNetworkError` (1inch 4xx /
+    // network hiccups) — the per-call-site catch in useTradeQuote /
+    // useTradeExecution already skips its own captureException for these, but
+    // they kept reaching Sentry anyway (APP-MEW-WEB-1F8 / MEW-2180), so this
+    // drops them here too regardless of call site or build. These surface as
+    // serialized plain objects or bare strings with no parsed frames, so
+    // denyUrls can't catch them — inspect the original exception instead.
+    // Genuine app errors are unaffected.
     beforeSend(event, hint) {
       const originalException = hint?.originalException
       if (
+        isExpectedTradeClientError(originalException) ||
         isExtensionOrProviderError(originalException) ||
         isInvalidWalletAddressError(originalException) ||
         isMetaMaskSdkDecryptError(originalException) ||

--- a/src/sentry/extensionNoise.ts
+++ b/src/sentry/extensionNoise.ts
@@ -168,6 +168,27 @@ export function isForeignStackOverflow(event: unknown): boolean {
 }
 
 /**
+ * Whether an error is a trade quote/order failure already flagged as an
+ * expected 1inch 4xx client error or a transient axios network hiccup.
+ * `OneInchFusion.getQuote` / `submitOrder` (oneInchFusion.ts) set
+ * `expectedClientError` / `transientNetworkError` on the thrown error
+ * specifically so the per-call-site catch (`useTradeQuote`,
+ * `useTradeExecution`) can skip its own `captureException` — but that is a
+ * single, per-call-site check. This is a global backstop at the Sentry
+ * ingestion boundary: if either flag reaches `beforeSend` uncaught by that
+ * local check (APP-MEW-WEB-1F8 kept recurring across releases despite the
+ * flag being set), drop it here too instead of letting it through as noise.
+ */
+export function isExpectedTradeClientError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false
+  const e = err as {
+    expectedClientError?: unknown
+    transientNetworkError?: unknown
+  }
+  return e.expectedClientError === true || e.transientNetworkError === true
+}
+
+/**
  * Whether an error is a viem `WaitForTransactionReceiptTimeoutError` — thrown
  * when `waitForTransactionReceipt` times out because a submitted trade/swap tx
  * did not confirm within the timeout window (slow node, congestion, dropped tx,

--- a/tests/unit/sentry/extensionNoise.spec.ts
+++ b/tests/unit/sentry/extensionNoise.spec.ts
@@ -4,6 +4,7 @@ import {
   WaitForTransactionReceiptTimeoutError,
 } from 'viem'
 import {
+  isExpectedTradeClientError,
   isExtensionOrProviderError,
   isForeignStackOverflow,
   isInvalidWalletAddressError,
@@ -434,5 +435,59 @@ describe('isMetaMaskSdkDecryptError', () => {
     expect(isMetaMaskSdkDecryptError(null)).toBe(false)
     expect(isMetaMaskSdkDecryptError('aes/gcm: invalid ghash tag')).toBe(false)
     expect(isMetaMaskSdkDecryptError({})).toBe(false)
+  })
+})
+
+describe('isExpectedTradeClientError', () => {
+  it('is true for an OneInchFusion.getQuote 1inch 4xx error (expectedClientError)', () => {
+    // The exact shape OneInchFusion.getQuote throws for a 1inch Fusion 400
+    // (illiquid/unsupported pair, invalid params) — see APP-MEW-WEB-1F8.
+    const err = new Error('Bad Request') as Error & {
+      expectedClientError?: boolean
+    }
+    err.expectedClientError = true
+    expect(isExpectedTradeClientError(err)).toBe(true)
+  })
+
+  it('is true for a flagged transient axios network error', () => {
+    const err = new Error('Network Error') as Error & {
+      transientNetworkError?: boolean
+    }
+    err.transientNetworkError = true
+    expect(isExpectedTradeClientError(err)).toBe(true)
+  })
+
+  it('is true for the serialized production payload (plain object)', () => {
+    expect(
+      isExpectedTradeClientError({
+        message: 'Bad Request',
+        expectedClientError: true,
+      }),
+    ).toBe(true)
+  })
+
+  it('is false when the flag is explicitly false or absent', () => {
+    expect(
+      isExpectedTradeClientError(
+        Object.assign(new Error('Bad Request'), {
+          expectedClientError: false,
+        }),
+      ),
+    ).toBe(false)
+    expect(isExpectedTradeClientError(new Error('Some genuine 5xx failure'))).toBe(
+      false,
+    )
+  })
+
+  it('is false for a genuine app error carrying unrelated properties', () => {
+    expect(
+      isExpectedTradeClientError({ message: 'boom', code: 500 }),
+    ).toBe(false)
+  })
+
+  it('is false for non-object inputs', () => {
+    expect(isExpectedTradeClientError(null)).toBe(false)
+    expect(isExpectedTradeClientError(undefined)).toBe(false)
+    expect(isExpectedTradeClientError('Bad Request')).toBe(false)
   })
 })


### PR DESCRIPTION
## What was wrong

Nothing is broken for the end user. This is a Sentry-noise cleanup: quote requests in the Trade widget (embedded on the Portfolio page) that 1inch rejects with an expected 4xx ("illiquid pair", "invalid params", etc.) or a transient network hiccup are already handled gracefully in the UI — the user sees an inline error and can retry. The app already flags these internally (`expectedClientError` / `transientNetworkError`) so a local check can skip reporting them to Sentry, but the flagged errors kept reaching Sentry anyway (issue APP-MEW-WEB-1F8 — 69 events over 14 days, still recurring on the current release), creating noise that obscures real bugs.

## What changed

Added a second, global safety net (in the same file/pattern already used for 7 other known-benign error categories — wallet-extension rejections, Trezor handshake failures, etc.) that also drops these already-flagged trade-quote/order errors before they reach Sentry, regardless of exactly which code path or build throws them. No user-facing behavior changes.

## How to test

This only affects what gets reported to Sentry — there is no visible UI change to smoke-test. Verification was via unit tests (49 passing in `tests/unit/sentry/extensionNoise.spec.ts`, including new cases for the added predicate), `vue-tsc --noEmit`, and lint, all green. If you want to sanity-check manually: open the Trade widget on `/portfolio`, request a quote for a pair 1inch can't quote (e.g. very low liquidity/unsupported token), confirm the existing inline error still shows as before — this PR does not touch that UI path, only Sentry reporting.

## Sentry issue

https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-1F8

## Assumptions (full-auto run, no user confirmation)

- Could not pin down *why* the existing per-call-site `expectedClientError`/`transientNetworkError` check (shipped in MEW-1956/MEW-2082) still let this through — live-probing 1inch's API to inspect the exact error shape is disallowed by policy, and the fix logic reads correctly for the reproduced shape by static trace. Treating this as "confirmed, fixable noise within the established `beforeSend` backstop pattern" per the sweep's guidance, rather than re-diagnosing the exact runtime mismatch (possible causes include a still-deploying build lag, since Sentry showed the same issue across five different release tags including the current one).
- Scoped the new predicate to the two known custom flags rather than matching on message text (e.g. "Bad Request"), since those flags are exclusively set in the trade module and won't risk masking unrelated bugs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary error reports by filtering expected trade-related client errors and transient network issues from monitoring.
  * Preserved reporting for unrelated, malformed, or unexpected errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->