### PR TITLE
MEW-2182: Fix /access?type=default 404 — redirect to Home preserving params

### DIFF
--- a/src/router/routesDefault.ts
+++ b/src/router/routesDefault.ts
@@ -34,6 +34,21 @@ const DefaultRoutes = <RouteNameCollection>[
     },
   },
   {
+    // The landing page deep-links to `/access?type=…` to prompt a wallet
+    // connect. The connect flow is now a dialog on Home (the standalone view
+    // lives at `/portfolio/access`), so send users to Home and let it open the
+    // dialog from `type` (see ViewHome). Preserves the query; a missing/blank
+    // type falls back to the default connect view.
+    path: '/access',
+    redirect: to => ({
+      name: ROUTES_MAIN.HOME.NAME,
+      query: { ...to.query, type: (to.query.type as string) || 'default' },
+    }),
+    meta: {
+      noAuth: true,
+    },
+  },
+  {
     // The wallet portfolio moved off the root; requires a connected wallet
     // (the guard bounces disconnected users to '/'). Its connect/create and
     // token/stock-info children keep their own `noAuth` where they had it.

--- a/src/router/routesDefault.ts
+++ b/src/router/routesDefault.ts
@@ -40,10 +40,18 @@ const DefaultRoutes = <RouteNameCollection>[
     // dialog from `type` (see ViewHome). Preserves the query; a missing/blank
     // type falls back to the default connect view.
     path: '/access',
-    redirect: to => ({
-      name: ROUTES_MAIN.HOME.NAME,
-      query: { ...to.query, type: (to.query.type as string) || 'default' },
-    }),
+    redirect: to => {
+      // `type` may be absent, an array (repeated param), or whitespace-only —
+      // ViewHome only acts on a valid string, so normalize to a trimmed
+      // non-empty string, falling back to the default connect view.
+      const raw = to.query.type
+      const type =
+        typeof raw === 'string' && raw.trim() ? raw.trim() : 'default'
+      return {
+        name: ROUTES_MAIN.HOME.NAME,
+        query: { ...to.query, type },
+      }
+    },
     meta: {
       noAuth: true,
     },

--- a/src/views/ViewHome.vue
+++ b/src/views/ViewHome.vue
@@ -1,12 +1,37 @@
 <script setup lang="ts">
-import { onMounted } from 'vue'
+import { onMounted, watch } from 'vue'
+import { useRoute } from 'vue-router'
 import ModuleHome from '@/modules/home/ModuleHome.vue'
 import { useStocksStore } from '@/stores/stocksStore'
+import { useAccessStore } from '@/stores/accessStore'
+import {
+  ACCESS_WALLET_VIEWS,
+  type WalletView,
+} from '@/modules/access/common/walletConfigs'
 
 const stocksStore = useStocksStore()
+const route = useRoute()
+const accessStore = useAccessStore()
 
 onMounted(() => {
   stocksStore.fetchStockOverview()
 })
+
+// The landing page deep-links to `/access?type=…` to prompt a wallet connect;
+// that route redirects here, so open the connect dialog for the requested view.
+// Mirrors ViewAccessWallet's onMounted so the `type` param keeps working.
+watch(
+  () => route.query.type,
+  type => {
+    if (
+      typeof type === 'string' &&
+      ACCESS_WALLET_VIEWS.includes(type as WalletView)
+    ) {
+      accessStore.openAccessDialog()
+      accessStore.setCurrentView(type as WalletView)
+    }
+  },
+  { immediate: true },
+)
 </script>
 <template><ModuleHome /></template>

--- a/tests/unit/router/accessRedirect.spec.ts
+++ b/tests/unit/router/accessRedirect.spec.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { RouteLocationNormalized } from 'vue-router'
+
+// routesDefault pulls this in at module load; stub it so importing the routes
+// doesn't drag in the trading-restriction composable and its deps.
+vi.mock('@/composables/useTradingRestriction', () => ({
+  fetchTradingRestriction: vi.fn(),
+}))
+// routesAccess/routesCreate import walletConfigs, which transitively loads the
+// Ledger hw-wallet module (fails under jsdom) — stub the lists they need.
+vi.mock('@/modules/access/common/walletConfigs', () => ({
+  ACCESS_WALLET_VIEWS: ['default', 'ledger'],
+  ACCESS_WALLET_VIEWS_DEFAULT: 'default',
+  CREATE_WALLET_VIEWS: ['default'],
+}))
+
+import DefaultRoutes from '@/router/routesDefault'
+
+const accessRoute = DefaultRoutes.find(r => r.path === '/access')
+const redirect = accessRoute?.redirect as (
+  to: Pick<RouteLocationNormalized, 'query'>,
+) => unknown
+
+describe('/access route (MEW-2182)', () => {
+  it('exists as a top-level route so /access no longer 404s', () => {
+    expect(accessRoute).toBeTruthy()
+    expect(typeof redirect).toBe('function')
+  })
+
+  it('redirects /access?type=default to Home, preserving the type', () => {
+    expect(redirect({ query: { type: 'default' } })).toEqual({
+      name: 'Home',
+      query: { type: 'default' },
+    })
+  })
+
+  it('defaults a missing type to the default connect view', () => {
+    expect(redirect({ query: {} })).toEqual({
+      name: 'Home',
+      query: { type: 'default' },
+    })
+  })
+
+  it('preserves the requested type and any other query params', () => {
+    expect(redirect({ query: { type: 'ledger', ref: 'landing' } })).toEqual({
+      name: 'Home',
+      query: { type: 'ledger', ref: 'landing' },
+    })
+  })
+})

--- a/tests/unit/router/accessRedirect.spec.ts
+++ b/tests/unit/router/accessRedirect.spec.ts
@@ -47,4 +47,25 @@ describe('/access route (MEW-2182)', () => {
       query: { type: 'ledger', ref: 'landing' },
     })
   })
+
+  it('falls back to default for a repeated (array) type param', () => {
+    expect(redirect({ query: { type: ['ledger', 'trezor'] } })).toEqual({
+      name: 'Home',
+      query: { type: 'default' },
+    })
+  })
+
+  it('falls back to default for a whitespace-only type', () => {
+    expect(redirect({ query: { type: '   ' } })).toEqual({
+      name: 'Home',
+      query: { type: 'default' },
+    })
+  })
+
+  it('trims surrounding whitespace from a valid type', () => {
+    expect(redirect({ query: { type: '  ledger  ' } })).toEqual({
+      name: 'Home',
+      query: { type: 'ledger' },
+    })
+  })
 })

--- a/tests/unit/views/ViewHome.spec.ts
+++ b/tests/unit/views/ViewHome.spec.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+
+const openAccessDialog = vi.fn()
+const setCurrentView = vi.fn()
+vi.mock('@/stores/accessStore', () => ({
+  useAccessStore: () => ({ openAccessDialog, setCurrentView }),
+}))
+const fetchStockOverview = vi.fn()
+vi.mock('@/stores/stocksStore', () => ({
+  useStocksStore: () => ({ fetchStockOverview }),
+}))
+// ModuleHome is the whole home page — stub it out, this spec only covers
+// ViewHome's /access connect-dialog wiring.
+vi.mock('@/modules/home/ModuleHome.vue', () => ({
+  default: { template: '<div data-test="module-home-stub" />' },
+}))
+
+// walletConfigs transitively imports the Ledger hw-wallet module, which fails
+// to load under jsdom — stub it to the plain list ViewHome needs.
+vi.mock('@/modules/access/common/walletConfigs', () => ({
+  ACCESS_WALLET_VIEWS: [
+    'default',
+    'ledger',
+    'trezor',
+    'keystore',
+    'mnemonic',
+    'private_key',
+    'wallet_connect',
+    'web3_wallet',
+  ],
+}))
+
+let query: Record<string, unknown> = {}
+vi.mock('vue-router', () => ({ useRoute: () => ({ query }) }))
+
+import ViewHome from '@/views/ViewHome.vue'
+
+describe('ViewHome — /access connect deep-link (MEW-2182)', () => {
+  beforeEach(() => {
+    openAccessDialog.mockClear()
+    setCurrentView.mockClear()
+    fetchStockOverview.mockClear()
+    query = {}
+  })
+
+  it('opens the connect dialog for a valid ?type on mount', () => {
+    query = { type: 'default' }
+    mount(ViewHome)
+    expect(openAccessDialog).toHaveBeenCalledTimes(1)
+    expect(setCurrentView).toHaveBeenCalledWith('default')
+  })
+
+  it('selects the requested wallet view from ?type', () => {
+    query = { type: 'ledger' }
+    mount(ViewHome)
+    expect(setCurrentView).toHaveBeenCalledWith('ledger')
+  })
+
+  it('does not open the dialog without a valid ?type', () => {
+    query = {}
+    mount(ViewHome)
+    expect(openAccessDialog).not.toHaveBeenCalled()
+
+    query = { type: 'bogus' }
+    mount(ViewHome)
+    expect(openAccessDialog).not.toHaveBeenCalled()
+  })
+
+  it('still fetches the stock overview on mount', () => {
+    mount(ViewHome)
+    expect(fetchStockOverview).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Summary

The landing page deep-links users to `/access?type=default` to prompt a wallet connect, but that route rendered the **404 page**.

**Root cause:** the access flow (`ViewAccessWallet`) is nested under the Portfolio route, so its real path is `/portfolio/access`. A top-level `/access` no longer matched any route and fell through to the `:pathMatch(.*)*` catch-all → 404.

## Changes
- **`router/routesDefault.ts`** — added a top-level `/access` route that redirects to Home, **preserving the query** (and defaulting a missing/blank `type` to `default`).
- **`views/ViewHome.vue`** — reads the `type` query param and opens the connect-wallet dialog for that view (mirrors `ViewAccessWallet`'s `onMounted`), so the param and its behavior are preserved.
- The existing `/portfolio/access` flow is untouched.

## Behavior
- `/access?type=default` → Home (`/`) with the connect dialog open (default view). No more 404.
- `/access?type=ledger` (any `ACCESS_WALLET_VIEWS` value) → selects that connect view.
- `/access` (no type) → defaults to the default connect view.
- Unrelated `?type` values / other query params are preserved and ignored safely.

## Tests
- `tests/unit/router/accessRedirect.spec.ts` — redirect target, default injection, param preservation.
- `tests/unit/views/ViewHome.spec.ts` — opens the dialog for a valid `?type`, ignores invalid/absent, still fetches the overview.

`pnpm vitest run` (both specs) green · `pnpm vue-tsc --noEmit` clean · eslint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added a public `/access` entry point that redirects to Home.
  * Preserves other access parameters and defaults missing, repeated, or invalid view types safely.
  * Supports deep links that open the access dialog and select the requested wallet view automatically.
  * Valid wallet view types are applied immediately and when the URL changes.
* **Tests**
  * Added coverage for redirects, parameter handling, deep-link behavior, invalid values, and stock overview loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->