### PR TITLE
fix: [MEW-2183] drop Ledger LockedDeviceError (0x5515) as sentry noise

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,7 @@ import {
   isExtensionOrProviderError,
   isForeignStackOverflow,
   isInvalidWalletAddressError,
+  isLockedDeviceError,
   isMetaMaskSdkDecryptError,
   isProviderNotFoundError,
   isRainbowKitNotFoundError,
@@ -89,6 +90,9 @@ if (dsn && process.env.NODE_ENV === 'production') {
       if (
         isExtensionOrProviderError(originalException) ||
         isInvalidWalletAddressError(originalException) ||
+        // Ledger "locked device" (0x5515) — hardware/user-state error, already
+        // shown to the user as a toast; unactionable noise (APP-MEW-WEB-BH).
+        isLockedDeviceError(originalException) ||
         isMetaMaskSdkDecryptError(originalException) ||
         isProviderNotFoundError(originalException) ||
         isRainbowKitNotFoundError(originalException) ||

--- a/src/sentry/extensionNoise.ts
+++ b/src/sentry/extensionNoise.ts
@@ -186,3 +186,25 @@ export function isTransactionReceiptTimeoutError(err: unknown): boolean {
   }
   return false
 }
+
+/**
+ * Whether an error is a `@ledgerhq` `LockedDeviceError` — thrown by the Ledger
+ * transport (WebUSB / WebBLE) when the connected device is locked, i.e. the
+ * user hasn't entered their PIN or the device screensaver kicked in (APDU
+ * status `0x5515`). This is a hardware/user-state condition, not an app bug:
+ * the access/connect flow already catches it (`handled: yes`) and shows a
+ * friendly localized toast (`common.error.ledger_locked`), and the fix is
+ * entirely in the user's hands (unlock the device). So it is unactionable
+ * Sentry noise (APP-MEW-WEB-BH). Detected primarily via the `@ledgerhq`
+ * error `name` (set as a string literal, so it survives minification), with a
+ * message fallback for the `0x5515` / "locked device" shape in case the error
+ * was rethrown as a plain `Error`.
+ */
+export function isLockedDeviceError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false
+  const e = err as { name?: unknown; message?: unknown }
+  if (e.name === 'LockedDeviceError') return true
+  const message =
+    typeof e.message === 'string' ? e.message.toLowerCase() : ''
+  return message.includes('0x5515') || message.includes('locked device')
+}

--- a/tests/unit/sentry/extensionNoise.spec.ts
+++ b/tests/unit/sentry/extensionNoise.spec.ts
@@ -7,6 +7,7 @@ import {
   isExtensionOrProviderError,
   isForeignStackOverflow,
   isInvalidWalletAddressError,
+  isLockedDeviceError,
   isMetaMaskSdkDecryptError,
   isProviderNotFoundError,
   isRainbowKitNotFoundError,
@@ -434,5 +435,43 @@ describe('isMetaMaskSdkDecryptError', () => {
     expect(isMetaMaskSdkDecryptError(null)).toBe(false)
     expect(isMetaMaskSdkDecryptError('aes/gcm: invalid ghash tag')).toBe(false)
     expect(isMetaMaskSdkDecryptError({})).toBe(false)
+  })
+})
+
+describe('isLockedDeviceError', () => {
+  it('drops the @ledgerhq LockedDeviceError by name (APP-MEW-WEB-BH)', () => {
+    const err = new Error('Ledger device: Locked device (0x5515)')
+    err.name = 'LockedDeviceError'
+    expect(isLockedDeviceError(err)).toBe(true)
+  })
+
+  it('matches by name even without the 0x5515 message', () => {
+    expect(isLockedDeviceError({ name: 'LockedDeviceError' })).toBe(true)
+  })
+
+  it('matches the 0x5515 / "locked device" message shape on a plain Error', () => {
+    // Covers a rethrow that lost the original @ledgerhq error name.
+    expect(
+      isLockedDeviceError(new Error('Ledger device: Locked device (0x5515)')),
+    ).toBe(true)
+    expect(
+      isLockedDeviceError({ message: 'the LOCKED DEVICE needs unlocking' }),
+    ).toBe(true)
+  })
+
+  it('is false for a genuine unrelated app error', () => {
+    expect(
+      isLockedDeviceError(
+        new TypeError("Cannot read properties of undefined (reading 'x')"),
+      ),
+    ).toBe(false)
+    expect(isLockedDeviceError({ name: 'TransportStatusError' })).toBe(false)
+  })
+
+  it('handles non-error inputs', () => {
+    expect(isLockedDeviceError(null)).toBe(false)
+    expect(isLockedDeviceError(undefined)).toBe(false)
+    expect(isLockedDeviceError('Locked device (0x5515)')).toBe(false)
+    expect(isLockedDeviceError({ message: 42 })).toBe(false)
   })
 })


### PR DESCRIPTION
## What was wrong

When a user connects a **Ledger** hardware wallet whose device is **locked** (PIN not entered, or the device screensaver kicked in), the `@ledgerhq` transport throws `LockedDeviceError: Ledger device: Locked device (0x5515)`. The app already handles this gracefully — it catches the error and shows the user a friendly toast telling them to check their wallet — but it *also* reports the error to Sentry. That produced **314 events (0 users impacted)** of pure, unactionable noise: nothing engineering can fix, the user simply needs to unlock their device.

## What changed

Added a small `isLockedDeviceError` predicate to `src/sentry/extensionNoise.ts` and wired it into the Sentry `beforeSend` hook in `src/main.ts`, so a locked-device error is dropped before it reaches Sentry. One global predicate covers every reporting call site in the connect/access flow. The user-facing behavior is unchanged — the friendly "check your wallet" toast still shows. Unit tests added.

- `src/sentry/extensionNoise.ts` — new `isLockedDeviceError` (matches the `@ledgerhq` error `name === "LockedDeviceError"`, with a `0x5515` / "locked device" message fallback)
- `src/main.ts` — call it in `beforeSend`
- `tests/unit/sentry/extensionNoise.spec.ts` — coverage for name match, message-shape fallback, genuine-error negatives, and non-error inputs

## How to test

This is a Sentry-side noise filter, so there is no visible UI change to smoke — the goal is to confirm the app still behaves normally and the type-check/tests pass.

1. `pnpm vitest run tests/unit/sentry/extensionNoise.spec.ts` → all green (48 tests).
2. Open the dev server, go to **Access → Ledger**. Normal (unlocked) Ledger connect flows must still work exactly as before.
3. (Optional, real hardware) Attempt to connect with the Ledger **locked** — you should still see the "Failed to connect. Check your wallet for errors" toast, and the event should no longer appear in Sentry.

## Assumptions (full-auto run)

- Treated as unactionable Sentry noise (the error is `handled: yes`, already shown to the user, and only resolvable by the user unlocking the device). No change to the connect flow or the toast.
- Detection is `name`-first (survives minification since `@ledgerhq` sets `this.name = "LockedDeviceError"` as a literal), with a message fallback for rethrown plain-`Error` shapes.

## Sentry

https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-BH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced error reporting noise by excluding known Ledger locked-device errors from monitoring.
  * Improved recognition of locked-device errors across supported error formats.

* **Tests**
  * Added coverage for Ledger locked-device errors, unrelated errors, and non-error inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->