### PR TITLE
fix: [MEW-2186] defer chart teardown to avoid detached-canvas crash

### DIFF
--- a/src/components/ChartPrice.vue
+++ b/src/components/ChartPrice.vue
@@ -1,6 +1,11 @@
 <template>
   <div class="inline-block">
-    <Line :data="chartData" :options="chartOptions" :plugins="plugins" />
+    <Line
+      :data="chartData"
+      :options="chartOptions"
+      :plugins="plugins"
+      :destroy-delay="CHART_DESTROY_DELAY_MS"
+    />
   </div>
 </template>
 
@@ -29,6 +34,16 @@ import type { WebTokenPriceChartInterval } from '@/mew_api/types'
 import BigNumber from 'bignumber.js'
 
 const { formatFiat, currencySymbol, rate } = useCurrency()
+
+/**
+ * Defer Chart.js teardown so vue-chartjs's queued `nextTick(() => chart.update())`
+ * (scheduled when reactive data/options change) runs BEFORE `chart.destroy()`.
+ * Without a delay, destroy nulls `chart.canvas`, then the pending update walks the
+ * responsive-resize path and dereferences `null.ownerDocument` -> unhandled
+ * TypeError on teardown (timeframe toggle / route change), seen on Safari.
+ * See Sentry APP-MEW-WEB-1FZ.
+ */
+const CHART_DESTROY_DELAY_MS = 300
 
 const props = withDefaults(
   defineProps<{


### PR DESCRIPTION
## What was wrong

On the token info price chart (`/portfolio/token/<symbol>`), vue-chartjs schedules `nextTick(() => chart.update())` whenever reactive `data`/`options` change. When the chart is torn down mid-update — toggling the timeframe filter (1D/7D/1M/…) to an uncached interval flips the parent `v-if` off, or navigating away — `onUnmounted` runs `chart.destroy()`, which nulls `chart.canvas` (Chart.js 4). The queued microtask then calls `chart.update()` on the destroyed chart, whose responsive-resize path dereferences `canvas.ownerDocument` on a null canvas:

```
TypeError: null is not an object (evaluating 'i.ownerDocument')
```

Unhandled (surfaces as `onunhandledrejection`), 29 events, observed on Safari 16.5. Sentry: `APP-MEW-WEB-1FZ`.

## What changed

`src/components/ChartPrice.vue`:
- Set vue-chartjs **`destroy-delay`** on the shared `<Line>` so `.destroy()` is deferred (via `setTimeout`) past the pending `nextTick(update)` microtask. The queued `update()` then runs against a still-alive (merely detached) canvas — harmless — instead of a destroyed one.

`ChartPrice.vue` is the shared price chart, so this covers **token-info, perps and stocks** charts at once.

## How to test

1. Open a token info page (`/portfolio/token/<symbol>`) in Safari.
2. Rapidly toggle the timeframe filter (1D → 7D → 1M …) and navigate away mid-load.
3. No `null is not an object (evaluating 'i.ownerDocument')` in the console / Sentry; chart renders and tears down cleanly.

`vue-tsc` + eslint clean. No unit test — the crash is a browser teardown-timing race (Safari) that jsdom can't reproduce.

## Sentry

https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-1FZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart stability during reactive updates and timeframe or route changes.
  * Prevented intermittent Safari errors by delaying chart teardown briefly during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->