### PR TITLE
fix: [MEW-2198] guard transient Trezor BigInt signing error

### DIFF
--- a/src/modules/send/components/EvmTransactionConfirmation.vue
+++ b/src/modules/send/components/EvmTransactionConfirmation.vue
@@ -280,6 +280,7 @@ import {
   isSignableWallet,
   isUserRejectionError,
   getLocalizedWalletError,
+  isTransientTrezorError,
 } from '@/utils/walletUtils'
 import { captureException } from '@sentry/vue'
 import { SENTRY_MODULE_TAGS } from '@/sentry/constants'
@@ -499,16 +500,21 @@ const confirmTransaction = async () => {
       text: t('send.toast.tx-send-failed'),
       textSecondary: getLocalizedWalletError(errorMessage) ?? errorMessage,
     })
-    captureException(
-      e instanceof Error ? e : new Error(errorMessage || 'Unknown error'),
-      {
-        ...SENTRY_MODULE_TAGS.SEND,
-        extra: {
-          title: 'Error sending transaction',
-          errorMessage,
+    // A transient Trezor empty-payload signing failure (APP-MEW-WEB-56) is
+    // surfaced to the user as a friendly "reconnect" toast above and is safe to
+    // retry, so don't report it to Sentry as a crash.
+    if (!isTransientTrezorError(e)) {
+      captureException(
+        e instanceof Error ? e : new Error(errorMessage || 'Unknown error'),
+        {
+          ...SENTRY_MODULE_TAGS.SEND,
+          extra: {
+            title: 'Error sending transaction',
+            errorMessage,
+          },
         },
-      },
-    )
+      )
+    }
   }
 }
 

--- a/src/utils/walletUtils.ts
+++ b/src/utils/walletUtils.ts
@@ -84,9 +84,15 @@ export const getLocalizedWalletError = (
 /**
  * A transient Trezor Connect failure: the popup/iframe returned `success`
  * with an empty payload, so `@enkryptcom/hw-wallets` runs an unguarded
- * `Buffer.from(undefined)` and throws a cryptic TypeError (or "popup failed
- * to open"). Retrying usually succeeds, so this is safe to surface as a
+ * conversion on the missing field and throws a cryptic TypeError (or "popup
+ * failed to open"). Retrying usually succeeds, so this is safe to surface as a
  * friendly "reconnect" message rather than reporting it as noise.
+ *
+ * Known empty-payload shapes:
+ *  - signMessage:     `Buffer.from(undefined)` → "The first argument must be
+ *    one of type string, Buffer, ..." (MEW-2080).
+ *  - signTransaction: `BigInt(result.payload.v)` where `v` is undefined →
+ *    "Cannot convert undefined to a BigInt" (APP-MEW-WEB-56 / MEW-2198).
  */
 export const isTransientTrezorError = (error: unknown): boolean => {
   const message = (
@@ -94,6 +100,7 @@ export const isTransientTrezorError = (error: unknown): boolean => {
   ).toLowerCase()
   return (
     message.includes('popup failed to open') ||
-    message.includes('the first argument must be one of type string, buffer')
+    message.includes('the first argument must be one of type string, buffer') ||
+    message.includes('cannot convert undefined to a bigint')
   )
 }

--- a/tests/unit/utils/walletError.spec.ts
+++ b/tests/unit/utils/walletError.spec.ts
@@ -75,6 +75,17 @@ describe('getLocalizedWalletError (MEW-2049)', () => {
     ).toBe(friendly)
     expect(getLocalizedWalletError('popup failed to open')).toBe(friendly)
   })
+
+  // APP-MEW-WEB-56 (MEW-2198) — signTransaction sibling of the Buffer.from
+  // case: @enkryptcom/hw-wallets does an unguarded BigInt(result.payload.v)
+  // when Trezor Connect returns success with an empty payload (v undefined).
+  it('maps the transient Trezor BigInt signing error to a localized message', () => {
+    const friendly =
+      "Couldn't read your address from Trezor. Reconnect the device and try again."
+    expect(
+      getLocalizedWalletError('Cannot convert undefined to a BigInt'),
+    ).toBe(friendly)
+  })
 })
 
 describe('isTransientTrezorError (MEW-2080)', () => {
@@ -88,10 +99,18 @@ describe('isTransientTrezorError (MEW-2080)', () => {
     ).toBe(true)
     expect(isTransientTrezorError(new Error('popup failed to open'))).toBe(true)
     expect(isTransientTrezorError('popup failed to open')).toBe(true)
+    // APP-MEW-WEB-56 (MEW-2198) — signTransaction empty-payload TypeError
+    expect(
+      isTransientTrezorError(
+        new TypeError('Cannot convert undefined to a BigInt'),
+      ),
+    ).toBe(true)
   })
 
   it('does not flag unrelated errors', () => {
-    expect(isTransientTrezorError(new Error('Ledger locked 0x5515'))).toBe(false)
+    expect(isTransientTrezorError(new Error('Ledger locked 0x5515'))).toBe(
+      false,
+    )
     expect(isTransientTrezorError('some unrelated rpc error')).toBe(false)
     expect(isTransientTrezorError(undefined)).toBe(false)
     expect(isTransientTrezorError(null)).toBe(false)


### PR DESCRIPTION
## What was wrong

`TypeError: Cannot convert undefined to a BigInt` (Sentry APP-MEW-WEB-56) surfaced as an unhandled crash from the send flow. Trezor Connect can resolve `success` with an empty payload; `@enkryptcom/hw-wallets` then runs an unguarded `BigInt(result.payload.v)` during `signTransaction` and throws the cryptic message. This is the `signTransaction` sibling of the `signMessage` `Buffer.from(undefined)` case already handled by `isTransientTrezorError` (MEW-2080). Retrying after reconnecting the device usually succeeds, so it is a retryable transient condition, not a real crash — but it was being reported to Sentry as noise.

## What changed

- **`src/utils/walletUtils.ts`** — extend the shared `isTransientTrezorError` guard to also match `cannot convert undefined to a bigint`, alongside the existing empty-payload shapes. Root-cause fix in the one shared predicate all callers route through.
- **`src/modules/send/components/EvmTransactionConfirmation.vue`** — wrap the failure `captureException` in `if (!isTransientTrezorError(e))`, so the transient Trezor case still shows the friendly "reconnect and try again" toast (via `getLocalizedWalletError`) but is no longer reported to Sentry. Mirrors the existing guard in `ModuleAccessHardwareWallet`.
- **`tests/unit/utils/walletError.spec.ts`** — cover the new message shape.

## How to test

- `pnpm vitest run tests/unit/utils/walletError.spec.ts` → 9/9 pass.
- `pnpm vue-tsc --noEmit -p tsconfig.app.json` → clean.
- Manual: on a Trezor send that returns an empty signing payload, the send screen now shows the friendly reconnect toast instead of a raw crash, and no event is sent to Sentry.

## Assumptions

- Diagnosed from source (matched the proven MEW-2080 sibling pattern); the production-only Trezor empty-payload shape can't be forced through the dev server or a unit test, so verification is source + the existing transient-error precedent plus the new unit coverage.

Sentry: https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-56

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of transient Trezor signing errors during transaction confirmation.
  - Prevented expected empty-payload signing failures from being reported as application errors.
  - Preserved error reporting for other transaction confirmation failures.
  - Added recognition for additional Trezor error messages related to missing transaction values.
- **Tests**
  - Added coverage to verify detection and localization of the transient signing error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->