### PR TITLE
fix: 🐛 treat webkit syntaxerror domexception as transient swap init e…

### DIFF
--- a/src/composables/swapInitError.ts
+++ b/src/composables/swapInitError.ts
@@ -14,6 +14,10 @@ export function isTransientSwapInitError(e: unknown): boolean {
   // across V8/Firefox/Safari, so this excludes unrelated SyntaxErrors that
   // would otherwise be retried and silently dropped from Sentry.
   if (e instanceof SyntaxError) return msg.includes('json')
+  // WebKit's Response.json() on a non-JSON body throws a DOMException named
+  // "SyntaxError" (code 12) with "The string did not match the expected
+  // pattern" — same transient upstream case, but without "json" in the message.
+  if (e instanceof DOMException) return e.name === 'SyntaxError'
   return (
     msg.includes('network') ||
     msg.includes('failed to fetch') ||

--- a/tests/unit/composables/swapInitError.spec.ts
+++ b/tests/unit/composables/swapInitError.spec.ts
@@ -25,6 +25,27 @@ describe('isTransientSwapInitError', () => {
     ).toBe(false)
   })
 
+  it('is true for a WebKit SyntaxError DOMException (Response.json on a non-JSON body)', () => {
+    // Safari's Response.json() failure: DOMException named "SyntaxError"
+    // (code 12) whose message never mentions "json"
+    expect(
+      isTransientSwapInitError(
+        new DOMException(
+          'The string did not match the expected pattern.',
+          'SyntaxError',
+        ),
+      ),
+    ).toBe(true)
+  })
+
+  it('is false for a DOMException that is not a SyntaxError', () => {
+    expect(
+      isTransientSwapInitError(
+        new DOMException('The operation was aborted.', 'AbortError'),
+      ),
+    ).toBe(false)
+  })
+
   it('is true for network errors (various phrasings)', () => {
     expect(isTransientSwapInitError(new Error('Network Error'))).toBe(true)
     expect(isTransientSwapInitError(new TypeError('Failed to fetch'))).toBe(


### PR DESCRIPTION
### Fix

## What
Extends the transient swap-init error filter to cover WebKit's `DOMException` "SyntaxError", so Safari's `Response.json()` failures on non-JSON upstream bodies are retried and no longer reported to Sentry.

## Why
Sentry issue APP-MEW-WEB-7F (266 occurrences, Safari/iOS only): the MEW-1983 filter matched JSON-parse `SyntaxError`s by the word "json" in the message, but Safari's native `Response.json()` throws a `DOMException` named "SyntaxError" (code 12) with "The string did not match the expected pattern" — same transient upstream case, different error shape, so it slipped through the filter.

## How
- `isTransientSwapInitError` now treats a `DOMException` with `name === 'SyntaxError'` as transient
- Added unit tests for the Safari `DOMException` case and a non-SyntaxError `DOMException` counter-case

Fixes APP-MEW-WEB-7F


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of WebKit errors encountered during swap initialization.
  * Non-JSON response errors are now treated as temporary failures, while unrelated errors remain unaffected.

* **Tests**
  * Added coverage for WebKit syntax errors and unrelated DOM exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->