### PR TITLE
fix: [MEW-2206] skip expected swap quote reverts in Sentry

### DIFF
--- a/src/modules/swap/ModuleSwap.vue
+++ b/src/modules/swap/ModuleSwap.vue
@@ -329,6 +329,7 @@ import configs from '@/configs'
 import { isSignableWallet, isUserRejectionError } from '@/utils/walletUtils'
 import { captureException } from '@sentry/vue'
 import { SENTRY_MODULE_TAGS } from '@/sentry/constants'
+import { isExpectedSwapQuoteError } from '@/modules/swap/swapErrors'
 
 const isDevMode = configs.IS_DEV_MODE
 const MAX_PRICE_IMPACT = 10
@@ -1017,10 +1018,12 @@ const swapForEvm = async () => {
     bestOfferSelectionOpen.value = true
   } catch (e: any) {
     generalError.value = e?.message || t('swap.error.fetching-gas-fees')
-    // "Pair not available" is an expected, user-facing condition (the selected
-    // pair has no route/quote). Keep the throw so generalError + analytics are
-    // handled here as designed, but skip the Sentry report to avoid noise.
-    const isPairNotAvailable = e?.message === t('swap.error.pair-not-available')
+    // Expected, user-facing swap conditions (no route/quote, thin liquidity,
+    // slippage / on-chain revert) surface via generalError; skip the Sentry
+    // report to avoid noise. See Sentry APP-MEW-WEB-EV.
+    const isExpectedError =
+      e?.message === t('swap.error.pair-not-available') ||
+      isExpectedSwapQuoteError(e?.message)
     if (isDevMode) {
       console.error('Error fetching gas fees:', e)
     } else {
@@ -1028,7 +1031,7 @@ const swapForEvm = async () => {
         ...analyticsPayload,
         errorMsg: generalError.value,
       })
-      if (!isPairNotAvailable) {
+      if (!isExpectedError) {
         captureException(e, {
           ...SENTRY_MODULE_TAGS.SWAP,
           extra: {
@@ -1525,7 +1528,7 @@ watch(
       generalError.value = err?.message || 'Error fetching gas fees'
       const isExpectedQuoteError =
         err?.message === t('swap.error.pair-not-available') ||
-        /insufficient funds/i.test(err?.message ?? '')
+        isExpectedSwapQuoteError(err?.message)
       if (isDevMode) {
         console.error('Error fetching gas fees:', err)
       } else {

--- a/src/modules/swap/swapErrors.ts
+++ b/src/modules/swap/swapErrors.ts
@@ -1,0 +1,18 @@
+// Locale-independent markers of expected swap-quote conditions: the aggregator
+// couldn't produce a usable quote/gas estimate for the current input (thin
+// liquidity, slippage / return below minimum, or not enough funds for gas).
+// These are surfaced to the user via `generalError`; they are user/on-chain
+// state, never an app defect, so they must NOT be reported to Sentry.
+// Sentry APP-MEW-WEB-EV — `execution reverted (InsufficientReturnAmount())`.
+const EXPECTED_QUOTE_ERROR_RE = /insufficient funds|execution reverted/i
+
+/**
+ * True when a caught swap gas-fee / quote error is an expected on-chain or
+ * user-state condition that should be shown to the user but not sent to Sentry.
+ *
+ * Covers only locale-independent patterns; the self-thrown, translated
+ * "pair not available" message is matched separately at the call site (it needs
+ * the active locale via `t()`).
+ */
+export const isExpectedSwapQuoteError = (message?: string): boolean =>
+  EXPECTED_QUOTE_ERROR_RE.test(message ?? '')

--- a/tests/unit/modules/swap/swapErrors.spec.ts
+++ b/tests/unit/modules/swap/swapErrors.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+
+import { isExpectedSwapQuoteError } from '@/modules/swap/swapErrors'
+
+describe('isExpectedSwapQuoteError', () => {
+  it('flags the on-chain revert seen in Sentry APP-MEW-WEB-EV', () => {
+    expect(
+      isExpectedSwapQuoteError(
+        'Quote failed: execution reverted (InsufficientReturnAmount())',
+      ),
+    ).toBe(true)
+  })
+
+  it('flags any execution-reverted quote failure (case-insensitive)', () => {
+    expect(isExpectedSwapQuoteError('Execution Reverted')).toBe(true)
+  })
+
+  it('flags insufficient-funds conditions', () => {
+    expect(
+      isExpectedSwapQuoteError('insufficient funds for intrinsic gas'),
+    ).toBe(true)
+  })
+
+  it('does NOT flag a genuine error (still reported to Sentry)', () => {
+    expect(isExpectedSwapQuoteError('Cannot read properties of undefined')).toBe(
+      false,
+    )
+    expect(isExpectedSwapQuoteError('Network request failed')).toBe(false)
+  })
+
+  it('handles missing/empty messages', () => {
+    expect(isExpectedSwapQuoteError()).toBe(false)
+    expect(isExpectedSwapQuoteError('')).toBe(false)
+  })
+})


### PR DESCRIPTION
## What was wrong

When a user requests a swap quote on an EVM network and the on-chain simulation reverts during gas-fee estimation (thin liquidity, slippage, or the return amount would fall below the minimum), the aggregator throws `Quote failed: execution reverted (InsufficientReturnAmount())`. The app already caught this and showed the user an inline error — but it **also** reported it to Sentry as if it were a crash. It isn't: it's an expected on-chain / user-state condition. This produced ongoing Sentry noise (256+ occurrences) that buries real bugs.

## What changed

The swap module already skips reporting *some* expected quote errors to Sentry (e.g. "pair not available", "insufficient funds"), but the two EVM gas-fee catch blocks had drifted apart and neither covered on-chain reverts. This PR extracts a single shared helper `isExpectedSwapQuoteError()` and uses it at both catch sites, so:

- On-chain reverts (`execution reverted` / `InsufficientReturnAmount`) and insufficient-funds conditions are now consistently **shown to the user but not sent to Sentry**.
- Genuine, unexpected errors are still reported as before.
- The two catch blocks now share one predicate, so they can't silently drift again.

No user-visible behavior changes — the inline swap error still appears exactly as today. Only the Sentry reporting is filtered.

## How to test

1. Open the app, connect any wallet, go to `/portfolio` → Swap panel (network: Ethereum).
2. Enter a swap whose quote can't be honored on-chain (e.g. a large amount into an illiquid pair, or a pair that returns below minimum) so the gas-fee/quote step fails.
3. Confirm the inline swap error still shows to the user (unchanged behavior).
4. Confirm a normal, valid swap quote still loads offers correctly.

## Sentry

https://myetherwallet-inc.sentry.io/issues/7377705398/ (APP-MEW-WEB-EV)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of expected swap quote and gas-fee errors.
  - Preserved clear user-facing error messages for missing routes, low liquidity, slippage, insufficient funds, and on-chain reverts.
  - Reduced unnecessary error reporting for expected transaction conditions.

- **Tests**
  - Added coverage for common swap failures, including execution reverts, insufficient funds, genuine errors, and missing messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->