### PR TITLE
fix: apply global font smoothing to match Figma [MEW-2207]

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -49,6 +49,8 @@
  */
 :root {
   font-family: 'DM Sans', ui-sans-serif, system-ui, -apple-system, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
   --borderRadius: 5px;
   min-width: 320px;
   zoom: 1;


### PR DESCRIPTION
## Summary

The v7 app never applied font smoothing, so on macOS/WebKit text rendered with the OS default subpixel-antialiasing and looked heavier/thicker than the Figma designs (which use grayscale antialiasing).

`src/assets/main.css` set `font-family` and `color` on `:root` but never `-webkit-font-smoothing` / `-moz-osx-font-smoothing`, and no `antialiased` utility was applied globally.

## Change

Add the two smoothing declarations globally at `:root` in `src/assets/main.css` — single source of truth, affects home and the whole app:

```css
-webkit-font-smoothing: antialiased;
-moz-osx-font-smoothing: grayscale;
```

## Testing

- Visual smoke test: app-wide text now uses grayscale antialiasing and matches the Figma weight/rendering.
- No layout or color changes — CSS-only, two added declarations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved font rendering across the application for smoother, more consistent text appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->