### PR TITLE
[MEW-2214] feat: replace multi-address delete inline confirm with modal

### DIFF
--- a/src/components/core_layouts/wallet/ManageAccountsCard.vue
+++ b/src/components/core_layouts/wallet/ManageAccountsCard.vue
@@ -56,7 +56,6 @@
           location="right"
           teleport
           menu-radius-class="rounded-16"
-          @update:open="open => { if (!open) confirmingDelete = false }"
         >
           <template #menu-button="{ toggleMenu }">
             <button data-test="menu-button" class="w-6 h-6 flex items-center justify-center text-white hover:text-white/70 transition-colors" @click="toggleMenu">
@@ -65,7 +64,6 @@
           </template>
           <template #menu-content="{ toggleMenu }">
             <manage-accounts-menu
-              v-if="!confirmingDelete"
               :kind="account.kind"
               :is-active="true"
               :toggle="toggleMenu"
@@ -75,20 +73,8 @@
               @paper="$emit('paper')"
               @explorer="$emit('explorer')"
               @disconnect="$emit('disconnect')"
-              @remove="onRemove"
+              @remove="$emit('delete')"
             />
-            <div v-else class="p-3 flex items-center gap-2">
-              <button
-                data-test="delete-confirm"
-                class="text-error text-s-12"
-                @click="$emit('delete'); confirmingDelete = false; toggleMenu()"
-              >
-                {{ $t('common.confirm') }}
-              </button>
-              <button data-test="delete-cancel" class="text-s-12" @click="confirmingDelete = false">
-                {{ $t('common.cancel') }}
-              </button>
-            </div>
           </template>
         </app-pop-up-menu>
       </div>
@@ -165,8 +151,6 @@ const emit = defineEmits<{
   connect: []
 }>()
 
-const confirmingDelete = ref(false)
-
 // Action feedback: spin the sync icon briefly, swap copy → check briefly.
 const spinning = ref(false)
 const copied = ref(false)
@@ -180,10 +164,6 @@ const onCopy = (): void => {
   emit('copy')
   copied.value = true
   setTimeout(() => (copied.value = false), 1500)
-}
-
-const onRemove = (): void => {
-  confirmingDelete.value = true
 }
 
 const mewCardUrl = computed(

--- a/src/components/core_layouts/wallet/ManageAccountsDeleteModal.vue
+++ b/src/components/core_layouts/wallet/ManageAccountsDeleteModal.vue
@@ -14,9 +14,9 @@
       </div>
     </template>
     <template #content>
-      <!-- AppDialog's title wrapper already contributes pb-2 (8px); pt-6 here
-           makes the total header↔content gap 32px per design. -->
-      <div class="flex items-center justify-end gap-2 px-6 pt-6 pb-6">
+      <!-- AppDialog's title wrapper already contributes pb-2 (8px); pt-10 here
+           makes the total description↔buttons gap 48px per design. -->
+      <div class="flex items-center justify-end gap-2 px-6 pt-10 pb-6">
         <button
           data-test="delete-modal-cancel"
           class="h-12 px-4 text-s-16 font-semibold text-black"

--- a/src/components/core_layouts/wallet/ManageAccountsDeleteModal.vue
+++ b/src/components/core_layouts/wallet/ManageAccountsDeleteModal.vue
@@ -1,0 +1,50 @@
+<template>
+  <app-dialog
+    v-model:is-open="isOpen"
+    class="w-full sm:max-w-[400px] sm:mx-auto"
+  >
+    <template #title>
+      <div class="flex flex-col gap-1 px-6 pt-6 pr-12">
+        <h1 class="text-s-20 font-bold text-black leading-[22px] tracking-[-0.4px]">
+          {{ $t('multi_address.remove.title') }}
+        </h1>
+        <p class="text-s-16 text-[#575757] leading-[22px]">
+          {{ $t('multi_address.remove.subtitle', { name: accountName }) }}
+        </p>
+      </div>
+    </template>
+    <template #content>
+      <!-- AppDialog's title wrapper already contributes pb-2 (8px); pt-6 here
+           makes the total header↔content gap 32px per design. -->
+      <div class="flex flex-col gap-3 px-6 pt-6 pb-6">
+        <button
+          data-test="delete-modal-confirm"
+          class="h-12 w-full rounded-[24px] bg-[#e40c58] text-white text-s-16 font-semibold transition-colors"
+          @click="confirm"
+        >
+          {{ $t('multi_address.remove.confirm') }}
+        </button>
+        <button
+          data-test="delete-modal-cancel"
+          class="h-12 w-full rounded-[24px] bg-[#f5f5f5] text-black text-s-16 font-semibold transition-colors"
+          @click="isOpen = false"
+        >
+          {{ $t('multi_address.remove.cancel') }}
+        </button>
+      </div>
+    </template>
+  </app-dialog>
+</template>
+
+<script setup lang="ts">
+import AppDialog from '@/components/AppDialog.vue'
+
+const isOpen = defineModel<boolean>('isOpen', { default: false })
+defineProps<{ accountName?: string }>()
+const emit = defineEmits<{ confirm: [] }>()
+
+const confirm = (): void => {
+  emit('confirm')
+  isOpen.value = false
+}
+</script>

--- a/src/components/core_layouts/wallet/ManageAccountsDeleteModal.vue
+++ b/src/components/core_layouts/wallet/ManageAccountsDeleteModal.vue
@@ -5,11 +5,11 @@
   >
     <template #title>
       <div class="flex flex-col gap-1 px-6 pt-6 pr-12">
-        <h1 class="text-s-20 font-bold text-black leading-[22px] tracking-[-0.4px]">
-          {{ $t('multi_address.remove.title', { name: accountName }) }}
+        <h1 class="text-s-20 font-bold text-black leading-[22px] tracking-[-0.4px] break-words">
+          {{ $t('multi_address.remove.title', { name: displayName }) }}
         </h1>
-        <p class="text-s-16 text-[#575757] leading-[22px]">
-          {{ $t('multi_address.remove.subtitle', { name: accountName }) }}
+        <p class="text-s-16 text-[#575757] leading-[22px] break-words">
+          {{ $t('multi_address.remove.subtitle', { name: displayName }) }}
         </p>
       </div>
     </template>
@@ -37,11 +37,17 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
 import AppDialog from '@/components/AppDialog.vue'
+import { truncate } from '@/utils/filters'
 
 const isOpen = defineModel<boolean>('isOpen', { default: false })
-defineProps<{ accountName?: string }>()
+const props = defineProps<{ accountName?: string }>()
 const emit = defineEmits<{ confirm: [] }>()
+
+// Cap absurdly long custom names so the modal stays readable; break-words on the
+// text then wraps whatever remains instead of overflowing the dialog.
+const displayName = computed(() => truncate(props.accountName ?? '', 32))
 
 const confirm = (): void => {
   emit('confirm')

--- a/src/components/core_layouts/wallet/ManageAccountsDeleteModal.vue
+++ b/src/components/core_layouts/wallet/ManageAccountsDeleteModal.vue
@@ -6,7 +6,7 @@
     <template #title>
       <div class="flex flex-col gap-1 px-6 pt-6 pr-12">
         <h1 class="text-s-20 font-bold text-black leading-[22px] tracking-[-0.4px]">
-          {{ $t('multi_address.remove.title') }}
+          {{ $t('multi_address.remove.title', { name: accountName }) }}
         </h1>
         <p class="text-s-16 text-[#575757] leading-[22px]">
           {{ $t('multi_address.remove.subtitle', { name: accountName }) }}
@@ -16,20 +16,20 @@
     <template #content>
       <!-- AppDialog's title wrapper already contributes pb-2 (8px); pt-6 here
            makes the total header↔content gap 32px per design. -->
-      <div class="flex flex-col gap-3 px-6 pt-6 pb-6">
-        <button
-          data-test="delete-modal-confirm"
-          class="h-12 w-full rounded-[24px] bg-[#e40c58] text-white text-s-16 font-semibold transition-colors"
-          @click="confirm"
-        >
-          {{ $t('multi_address.remove.confirm') }}
-        </button>
+      <div class="flex items-center justify-end gap-2 px-6 pt-6 pb-6">
         <button
           data-test="delete-modal-cancel"
-          class="h-12 w-full rounded-[24px] bg-[#f5f5f5] text-black text-s-16 font-semibold transition-colors"
+          class="h-12 px-4 text-s-16 font-semibold text-black"
           @click="isOpen = false"
         >
           {{ $t('multi_address.remove.cancel') }}
+        </button>
+        <button
+          data-test="delete-modal-confirm"
+          class="h-12 px-6 rounded-full bg-[#e40c58] text-white text-s-16 font-semibold transition-colors"
+          @click="confirm"
+        >
+          {{ $t('multi_address.remove.confirm') }}
         </button>
       </div>
     </template>

--- a/src/components/core_layouts/wallet/ManageAccountsDeleteModal.vue
+++ b/src/components/core_layouts/wallet/ManageAccountsDeleteModal.vue
@@ -16,7 +16,7 @@
     <template #content>
       <!-- AppDialog's title wrapper already contributes pb-2 (8px); pt-10 here
            makes the total description↔buttons gap 48px per design. -->
-      <div class="flex items-center justify-end gap-2 px-6 pt-10 pb-6">
+      <div class="flex items-center justify-end gap-4 px-6 pt-10 pb-6">
         <button
           data-test="delete-modal-cancel"
           class="h-12 px-4 text-s-16 font-semibold text-black"

--- a/src/components/core_layouts/wallet/ManageAccountsMenu.vue
+++ b/src/components/core_layouts/wallet/ManageAccountsMenu.vue
@@ -124,7 +124,6 @@ const emit = defineEmits<(e: MenuAction) => void>()
 
 const select = (action: MenuAction): void => {
   emit(action)
-  // "remove" opens an inline confirm in the parent, so keep the menu open.
-  if (action !== 'remove') props.toggle?.()
+  props.toggle?.()
 }
 </script>

--- a/src/components/core_layouts/wallet/ManageAccountsRow.vue
+++ b/src/components/core_layouts/wallet/ManageAccountsRow.vue
@@ -68,7 +68,6 @@
       location="right"
       teleport
       menu-radius-class="rounded-16"
-      @update:open="open => { if (!open) confirmingDelete = false }"
     >
       <template #menu-button="{ toggleMenu }">
         <button data-test="menu-button" class="p-1" @click="toggleMenu">
@@ -77,7 +76,6 @@
       </template>
       <template #menu-content="{ toggleMenu }">
         <manage-accounts-menu
-          v-if="!confirmingDelete"
           :kind="account.kind"
           :is-active="isActive"
           :toggle="toggleMenu"
@@ -87,20 +85,8 @@
           @paper="$emit('paper')"
           @explorer="$emit('explorer')"
           @disconnect="$emit('disconnect')"
-          @remove="onRemove"
+          @remove="$emit('delete')"
         />
-        <div v-else class="p-3 flex items-center gap-2">
-          <button
-            data-test="delete-confirm"
-            class="text-error text-s-12"
-            @click="$emit('delete'); confirmingDelete = false; toggleMenu()"
-          >
-            {{ $t('common.confirm') }}
-          </button>
-          <button data-test="delete-cancel" class="text-s-12" @click="confirmingDelete = false">
-            {{ $t('common.cancel') }}
-          </button>
-        </div>
       </template>
     </app-pop-up-menu>
   </div>
@@ -140,8 +126,6 @@ const emit = defineEmits<{
   'visibility-change': [visible: boolean]
 }>()
 
-const confirmingDelete = ref(false)
-
 // Report when this row enters/leaves the popup's scroll viewport so the parent
 // can lazily (re)fetch its balance. rootMargin prefetches just-below-fold rows.
 const rowRef = ref<HTMLElement | null>(null)
@@ -151,8 +135,4 @@ useIntersectionObserver(
   ([entry]) => emit('visibility-change', entry?.isIntersecting ?? false),
   { root: scrollRootRef, rootMargin: '100px' },
 )
-
-const onRemove = (): void => {
-  confirmingDelete.value = true
-}
 </script>

--- a/src/components/core_layouts/wallet/TheManageAccounts.vue
+++ b/src/components/core_layouts/wallet/TheManageAccounts.vue
@@ -666,11 +666,12 @@ const onDeleteRequest = (acc: SavedAccount): void => {
   openDialog.value = false
   deleteOpen.value = true
 }
-const onDeleteConfirm = (): void => {
+const onDeleteConfirm = async (): Promise<void> => {
   const acc = deleteTarget.value
   if (!acc) return
+  // Record the event only after the address is actually removed.
+  await deleteAccount(acc)
   void analytics.trackMultiAddressEvent(MultiAddressEvent.DELETED)
-  void deleteAccount(acc)
 }
 const onDisconnect = (): void => {
   // Keep the popup open so the user stays in the manage-accounts context.

--- a/src/components/core_layouts/wallet/TheManageAccounts.vue
+++ b/src/components/core_layouts/wallet/TheManageAccounts.vue
@@ -95,7 +95,7 @@
                     @paper="onPaper(activeAccount)"
                     @explorer="openExplorer(activeAccount)"
                     @disconnect="onDisconnect"
-                    @delete="onDelete(activeAccount)"
+                    @delete="onDeleteRequest(activeAccount)"
                     @connect="onConnect"
                   />
                   <!-- No connected address for the selected network: keep the popup
@@ -165,7 +165,7 @@
                               @paper="onPaper(acc)"
                               @explorer="openExplorer(acc)"
                               @disconnect="onDisconnect"
-                              @delete="onDelete(acc)"
+                              @delete="onDeleteRequest(acc)"
                             />
                           </transition-group>
                         </div>
@@ -270,6 +270,11 @@
       :name-taken="isRenameNameTaken"
       @save="onRenameSave"
     />
+    <manage-accounts-delete-modal
+      v-model:is-open="deleteOpen"
+      :account-name="deleteTarget?.addressName"
+      @confirm="onDeleteConfirm"
+    />
   </teleport>
 </template>
 <script setup lang="ts">
@@ -285,6 +290,7 @@ import ManageAccountsNetworkView from '@/components/core_layouts/wallet/ManageAc
 import ManageAccountsConnectAddressView from '@/components/core_layouts/wallet/ManageAccountsConnectAddressView.vue'
 import ThePaperWallet from '@/components/core_layouts/wallet/ThePaperWallet.vue'
 import ManageAccountsRenameModal from '@/components/core_layouts/wallet/ManageAccountsRenameModal.vue'
+import ManageAccountsDeleteModal from '@/components/core_layouts/wallet/ManageAccountsDeleteModal.vue'
 import ExpandTransition from '@/components/transitions/ExpandTransition.vue'
 import { useWatchOnlyStore } from '@/stores/watchOnlyStore'
 import { useDetectedAddress } from '@/composables/useDetectedAddress'
@@ -550,6 +556,8 @@ const openPaperWallet = ref(false)
 const paperTarget = ref<SavedAccount | null>(null)
 const renameOpen = ref(false)
 const renameTarget = ref<SavedAccount | null>(null)
+const deleteOpen = ref(false)
+const deleteTarget = ref<SavedAccount | null>(null)
 const hasBackfilled = ref(false)
 const detectedMessage = ref('')
 
@@ -651,7 +659,16 @@ const onSelect = (acc: SavedAccount): void => {
   // View the address (read-only) and update the active card; keep the popup open.
   void switchTo(acc)
 }
-const onDelete = (acc: SavedAccount): void => {
+// Delete opens a confirmation modal (Figma 8304-7964): close the popup, then open
+// the modal for the chosen account. Confirming removes the address.
+const onDeleteRequest = (acc: SavedAccount): void => {
+  deleteTarget.value = acc
+  openDialog.value = false
+  deleteOpen.value = true
+}
+const onDeleteConfirm = (): void => {
+  const acc = deleteTarget.value
+  if (!acc) return
   void analytics.trackMultiAddressEvent(MultiAddressEvent.DELETED)
   void deleteAccount(acc)
 }

--- a/src/i18n/locales/multi_address/en.json
+++ b/src/i18n/locales/multi_address/en.json
@@ -53,10 +53,10 @@
       "duplicate": "Name already in use, please type a different one"
     },
     "remove": {
-      "title": "Remove address?",
-      "subtitle": "\"{name}\" will be removed from your saved addresses. You can add it again at any time.",
+      "title": "Remove {name}?",
+      "subtitle": "This will remove {name} from your saved addresses. You can add it again anytime by reconnecting it.",
       "confirm": "Remove address",
-      "cancel": "Cancel"
+      "cancel": "Close"
     },
     "menu": {
       "rename": "Rename",

--- a/src/i18n/locales/multi_address/en.json
+++ b/src/i18n/locales/multi_address/en.json
@@ -52,6 +52,12 @@
       "save": "Save",
       "duplicate": "Name already in use, please type a different one"
     },
+    "remove": {
+      "title": "Remove address?",
+      "subtitle": "\"{name}\" will be removed from your saved addresses. You can add it again at any time.",
+      "confirm": "Remove address",
+      "cancel": "Cancel"
+    },
     "menu": {
       "rename": "Rename",
       "copy": "Copy address",

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,7 @@ import {
   isRainbowKitNotFoundError,
   isTransactionReceiptTimeoutError,
   isTrezorHandshakeError,
+  isWalletConnectSubscribeInterruptedError,
 } from '@/sentry/extensionNoise'
 import { isTransientRpcError } from '@/modules/trade/composables/transientRpcError'
 
@@ -95,6 +96,11 @@ if (dsn && process.env.NODE_ENV === 'production') {
         isTransactionReceiptTimeoutError(originalException) ||
         isTransientRpcError(originalException) ||
         isTrezorHandshakeError(originalException) ||
+        // WalletConnect relay "Connection interrupted while trying to subscribe"
+        // — a transient relay-WebSocket drop thrown inside @walletconnect/core,
+        // no app frame, already handled by the connect flow (APP-MEW-WEB-61 /
+        // MEW-2240).
+        isWalletConnectSubscribeInterruptedError(originalException) ||
         // iOS injected-script "Maximum call stack" RangeErrors with no app
         // frame — external, unactionable noise (APP-MEW-WEB-BB / MEW-2065).
         isForeignStackOverflow(event)

--- a/src/sentry/extensionNoise.ts
+++ b/src/sentry/extensionNoise.ts
@@ -186,3 +186,24 @@ export function isTransactionReceiptTimeoutError(err: unknown): boolean {
   }
   return false
 }
+
+/**
+ * Whether an error is the WalletConnect relay "Connection interrupted while
+ * trying to subscribe" rejection. Thrown entirely inside `@walletconnect/core`'s
+ * Relayer when the relay WebSocket (`wss://relay.walletconnect.org`) disconnects
+ * mid-(re)connect while it is subscribing to a session topic — an
+ * `onunhandledrejection` that reaches the global Sentry `beforeSend` with no MEW
+ * frame in the stack. The connect flow already handles it (the user can retry),
+ * so it is transient, unactionable network noise (APP-MEW-WEB-61 / MEW-2240).
+ * MEW code never throws this message, so matching on the library-specific
+ * message is safe. Distinct from the sibling `/Subscribing to \w+ failed/` and
+ * "connection is closed" shapes already suppressed elsewhere. Handles both the
+ * Error-object and bare-string payload shapes.
+ */
+export function isWalletConnectSubscribeInterruptedError(err: unknown): boolean {
+  const MESSAGE = 'Connection interrupted while trying to subscribe'
+  if (typeof err === 'string') return err.includes(MESSAGE)
+  if (!err || typeof err !== 'object') return false
+  const message = (err as { message?: unknown }).message
+  return typeof message === 'string' && message.includes(MESSAGE)
+}

--- a/tests/unit/components/wallet/ManageAccountsCard.spec.ts
+++ b/tests/unit/components/wallet/ManageAccountsCard.spec.ts
@@ -62,11 +62,9 @@ describe('ManageAccountsCard', () => {
     expect(w.emitted('rename')![0]).toEqual([])
   })
 
-  it('emits delete only after inline confirm', async () => {
+  it('emits delete when Remove is clicked (confirmation happens in a modal)', async () => {
     const w = factory()
     await w.get('[data-test="menu-remove"]').trigger('click')
-    expect(w.emitted('delete')).toBeUndefined()
-    await w.get('[data-test="delete-confirm"]').trigger('click')
     expect(w.emitted('delete')).toHaveLength(1)
   })
 

--- a/tests/unit/components/wallet/ManageAccountsDeleteModal.spec.ts
+++ b/tests/unit/components/wallet/ManageAccountsDeleteModal.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import ManageAccountsDeleteModal from '@/components/core_layouts/wallet/ManageAccountsDeleteModal.vue'
+
+// AppDialog teleports; stub it to render the title + content slots inline and
+// surface its is-open model so we can assert the modal closes.
+const stubs = {
+  AppDialog: {
+    name: 'AppDialog',
+    props: ['isOpen'],
+    template: '<div :data-open="isOpen"><slot name="title" /><slot name="content" /></div>',
+  },
+}
+
+const factory = (props = {}) =>
+  mount(ManageAccountsDeleteModal, {
+    props: { isOpen: true, accountName: 'Address 1', ...props },
+    global: { stubs, mocks: { $t: (k: string) => k } },
+  })
+
+describe('ManageAccountsDeleteModal', () => {
+  it('emits confirm and closes when the remove button is clicked', async () => {
+    const w = factory()
+    await w.get('[data-test="delete-modal-confirm"]').trigger('click')
+    expect(w.emitted('confirm')).toHaveLength(1)
+    expect(w.emitted('update:isOpen')?.at(-1)).toEqual([false])
+  })
+
+  it('closes without confirming when cancel is clicked', async () => {
+    const w = factory()
+    await w.get('[data-test="delete-modal-cancel"]').trigger('click')
+    expect(w.emitted('confirm')).toBeUndefined()
+    expect(w.emitted('update:isOpen')?.at(-1)).toEqual([false])
+  })
+})

--- a/tests/unit/components/wallet/ManageAccountsDeleteModal.spec.ts
+++ b/tests/unit/components/wallet/ManageAccountsDeleteModal.spec.ts
@@ -32,4 +32,18 @@ describe('ManageAccountsDeleteModal', () => {
     expect(w.emitted('confirm')).toBeUndefined()
     expect(w.emitted('update:isOpen')?.at(-1)).toEqual([false])
   })
+
+  it('truncates a ridiculously long name so the modal cannot overflow', () => {
+    const longName = 'a'.repeat(200)
+    const w = mount(ManageAccountsDeleteModal, {
+      props: { isOpen: true, accountName: longName },
+      global: {
+        stubs,
+        // Echo the interpolated name so we can assert what reaches the template.
+        mocks: { $t: (_k: string, p?: { name: string }) => p?.name ?? '' },
+      },
+    })
+    expect(w.text()).toContain('a'.repeat(32) + '...')
+    expect(w.text()).not.toContain(longName)
+  })
 })

--- a/tests/unit/components/wallet/ManageAccountsMenu.spec.ts
+++ b/tests/unit/components/wallet/ManageAccountsMenu.spec.ts
@@ -57,11 +57,11 @@ describe('ManageAccountsMenu', () => {
     expect(toggle).toHaveBeenCalledTimes(6)
   })
 
-  it('emits remove but keeps the menu open (inline confirm lives in the parent)', async () => {
+  it('emits remove and closes the menu (confirmation lives in a modal)', async () => {
     const toggle = vi.fn()
     const w = factory({ toggle })
     await w.get('[data-test="menu-remove"]').trigger('click')
     expect(w.emitted('remove')).toHaveLength(1)
-    expect(toggle).not.toHaveBeenCalled()
+    expect(toggle).toHaveBeenCalledTimes(1)
   })
 })

--- a/tests/unit/components/wallet/ManageAccountsRow.spec.ts
+++ b/tests/unit/components/wallet/ManageAccountsRow.spec.ts
@@ -116,22 +116,10 @@ describe('ManageAccountsRow', () => {
     expect(w.emitted('rename')![0]).toEqual([])
   })
 
-  it('emits delete only after inline confirm', async () => {
+  it('emits delete when Remove is clicked (confirmation happens in a modal)', async () => {
     const w = factory()
     await w.get('[data-test="menu-remove"]').trigger('click')
-    expect(w.emitted('delete')).toBeUndefined()
-    await w.get('[data-test="delete-confirm"]').trigger('click')
     expect(w.emitted('delete')).toHaveLength(1)
-  })
-
-  it('resets the delete confirm when the menu closes (e.g. outside click)', async () => {
-    const w = factory()
-    await w.get('[data-test="menu-remove"]').trigger('click') // confirmingDelete = true
-    expect(w.find('[data-test="delete-confirm"]').exists()).toBe(true)
-    // AppPopUpMenu closing (outside click) surfaces update:open=false
-    w.findComponent({ name: 'AppPopUpMenu' }).vm.$emit('update:open', false)
-    await w.vm.$nextTick()
-    expect(w.find('[data-test="delete-confirm"]').exists()).toBe(false)
   })
 
   it('shows Disconnect only for a signing (connected) row and emits disconnect', async () => {

--- a/tests/unit/components/wallet/TheManageAccounts.spec.ts
+++ b/tests/unit/components/wallet/TheManageAccounts.spec.ts
@@ -53,6 +53,11 @@ const stubs = {
     props: ['isOpen', 'currentName'],
     template: '<div data-test="rename-modal" :data-open="isOpen" @click="$emit(\'save\', \'Renamed\')" />',
   },
+  ManageAccountsDeleteModal: {
+    name: 'ManageAccountsDeleteModal',
+    props: ['isOpen', 'accountName'],
+    template: '<div data-test="delete-modal" :data-open="isOpen" @click="$emit(\'confirm\')" />',
+  },
   ManageAccountsCard: {
     name: 'ManageAccountsCard',
     props: ['account', 'balance'],
@@ -99,6 +104,19 @@ describe('TheManageAccounts', () => {
     expect(w.emitted('update:openDialog')?.at(-1)).toEqual([false])
     await w.get('[data-test="rename-modal"]').trigger('click') // stub emits save
     expect(renameAccount).toHaveBeenCalled()
+  })
+
+  it('opens the delete modal on a row delete request, closes the popup, and confirming calls deleteAccount', async () => {
+    const w = factory()
+    w.findAllComponents({ name: 'ManageAccountsRow' })[0].vm.$emit('delete')
+    await w.vm.$nextTick()
+    // The confirmation lives in a modal; the popup closes so it isn't behind it.
+    expect(w.get('[data-test="delete-modal"]').attributes('data-open')).toBe('true')
+    expect(w.emitted('update:openDialog')?.at(-1)).toEqual([false])
+    // Nothing removed until the user confirms in the modal.
+    expect(deleteAccount).not.toHaveBeenCalled()
+    await w.get('[data-test="delete-modal"]').trigger('click') // stub emits confirm
+    expect(deleteAccount).toHaveBeenCalledTimes(1)
   })
 
   it('disconnects the wallet but keeps the popup open when the card emits disconnect', async () => {

--- a/tests/unit/sentry/extensionNoise.spec.ts
+++ b/tests/unit/sentry/extensionNoise.spec.ts
@@ -12,6 +12,7 @@ import {
   isRainbowKitNotFoundError,
   isTransactionReceiptTimeoutError,
   isTrezorHandshakeError,
+  isWalletConnectSubscribeInterruptedError,
 } from '@/sentry/extensionNoise'
 
 describe('isExtensionOrProviderError', () => {
@@ -403,6 +404,52 @@ describe('isRainbowKitNotFoundError', () => {
     expect(isRainbowKitNotFoundError(undefined)).toBe(false)
     expect(isRainbowKitNotFoundError({ message: 42 })).toBe(false)
     expect(isRainbowKitNotFoundError('something else')).toBe(false)
+  })
+})
+
+describe('isWalletConnectSubscribeInterruptedError', () => {
+  const MSG = 'Connection interrupted while trying to subscribe'
+
+  it('drops the @walletconnect/core relay rejection (APP-MEW-WEB-61)', () => {
+    // The exact production trigger: the relay WebSocket disconnects mid-connect
+    // and the Relayer rejects with `new Error(...)`.
+    expect(isWalletConnectSubscribeInterruptedError(new Error(MSG))).toBe(true)
+  })
+
+  it('is true for the serialized production payload (plain object with message)', () => {
+    expect(isWalletConnectSubscribeInterruptedError({ message: MSG })).toBe(true)
+  })
+
+  it('is true for a bare-string rejection', () => {
+    expect(isWalletConnectSubscribeInterruptedError(MSG)).toBe(true)
+    expect(isWalletConnectSubscribeInterruptedError(`Error: ${MSG}`)).toBe(true)
+  })
+
+  it('does NOT over-match the sibling "Subscribing to X failed" shape', () => {
+    expect(
+      isWalletConnectSubscribeInterruptedError(
+        new Error('Subscribing to abc123 failed, please try again'),
+      ),
+    ).toBe(false)
+  })
+
+  it('is false for a genuine app error', () => {
+    expect(
+      isWalletConnectSubscribeInterruptedError(
+        new TypeError("Cannot read properties of undefined (reading 'x')"),
+      ),
+    ).toBe(false)
+    expect(
+      isWalletConnectSubscribeInterruptedError(new Error('Connection is closed')),
+    ).toBe(false)
+  })
+
+  it('is false for non-matching inputs', () => {
+    expect(isWalletConnectSubscribeInterruptedError(null)).toBe(false)
+    expect(isWalletConnectSubscribeInterruptedError(undefined)).toBe(false)
+    expect(isWalletConnectSubscribeInterruptedError({})).toBe(false)
+    expect(isWalletConnectSubscribeInterruptedError({ message: 42 })).toBe(false)
+    expect(isWalletConnectSubscribeInterruptedError('something else')).toBe(false)
   })
 })
 


### PR DESCRIPTION
## Summary

The saved-address delete flow in the multi-address account manager used an **inline confirm** swapped into the overflow (`...`) menu — duplicated in both the list row and the active-account card. This replaces it with a **modal confirmation** per Figma.

Now a single `ManageAccountsDeleteModal` (AppDialog) is hosted in `TheManageAccounts`, mirroring the existing rename-modal pattern:
- **Remove** in the `...` menu closes the popup and opens the confirmation modal.
- The address is removed only when the user confirms; **Cancel** / close dismisses with no change.
- The `DELETED` analytics event now fires on actual deletion instead of on menu-open.

## Changes
- New `ManageAccountsDeleteModal.vue` + `multi_address.remove.*` i18n keys.
- `ManageAccountsRow` / `ManageAccountsCard`: dropped the inline `confirmingDelete` state; `Remove` emits `delete` directly.
- `ManageAccountsMenu`: `remove` now closes the menu like every other action.
- `TheManageAccounts`: hosts the modal, splits delete into request (opens modal) + confirm (removes).

## Test plan
- `pnpm vitest run tests/unit/components/wallet/*` → 51 passing (new delete-modal spec + updated row/card/menu/parent specs).
- `pnpm vue-tsc --noEmit` clean, ESLint clean.

## Note for review
Modal copy/styling use the design-system dialog + destructive button; exact strings/visuals to be confirmed against the Figma during design review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a confirmation modal before removing a saved account.
  * The dialog displays the account name and provides Confirm and Cancel actions.
  * Long account names are shortened for clearer display.
  * Account menus close when removal is selected, while deletion occurs only after confirmation.
* **Localization**
  * Added English text for the account-removal confirmation dialog.
* **Bug Fixes**
  * Prevented accounts from being deleted immediately without confirmation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->