### PR TITLE
fix: [MEW-2212] contain network logo in address trigger pill badge

### DIFF
--- a/src/components/core_layouts/wallet/AddressTriggerPill.vue
+++ b/src/components/core_layouts/wallet/AddressTriggerPill.vue
@@ -18,7 +18,7 @@
           :src="chainsStore.selectedChain.icon"
           alt=""
           aria-hidden="true"
-          class="absolute -bottom-1 -right-1 w-4 h-4 rounded-full border border-white object-cover bg-white"
+          class="absolute -bottom-1 -right-1 w-4 h-4 rounded-full border border-white object-contain bg-white"
         />
       </span>
       <span class="flex flex-col items-start flex-1 min-w-0 gap-0.5">


### PR DESCRIPTION
## Problem

In the multi-address dropdown trigger pill, the small network badge overlaid on the account blockie used `object-cover`. That crops the chain logo to fill the circle, making it look oversized/clipped (e.g. the ETH icon appearing too large).

## Fix

Switch the connected-state network badge from `object-cover` to `object-contain`, so the full chain logo renders inside the circle. This matches the empty-state badge in the same component, which already uses `object-contain`.

Single-line CSS class change in `AddressTriggerPill.vue`; no logic touched.

## Testing

- `pnpm vue-tsc --noEmit -p tsconfig.app.json` — green
- Manual smoke test: connected pill shows the network logo fully contained in the circle across networks; no size/position regression on the badge or pill.

## Before / After

- Before: network logo cropped to fill the circle (edges clipped).
- After: full network logo contained within the circle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the display of the selected chain icon in the connected wallet address pill by preserving its full proportions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->