### PR TITLE
[MEW-2210] fix: token logos on home (Market News, New Listings, Trending)

### DIFF
--- a/src/components/AppNewListingCard.vue
+++ b/src/components/AppNewListingCard.vue
@@ -57,7 +57,6 @@ const changeText = computed(() =>
         width="size-10"
         height="size-10"
         no-shadow
-        no-ring
         class="shrink-0"
       />
       <p

--- a/src/components/AppNewsCard.vue
+++ b/src/components/AppNewsCard.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { RouterLink, type RouteLocationRaw } from 'vue-router'
 import { ArrowTopRightOnSquareIcon } from '@heroicons/vue/20/solid'
 import AppTokenLogo from '@/components/AppTokenLogo.vue'
 import AppTokenSymbol from '@/components/AppTokenSymbol.vue'
@@ -12,6 +13,11 @@ const props = defineProps<{
   description?: string
   /** Related asset symbol shown as a token badge (e.g. "AAPL"). */
   ticker?: string
+  /** Resolved icon URL for `ticker`; falls back to initials when absent. */
+  tokenLogo?: string
+  /** In-app route for the ticker badge (e.g. the stock page); when absent the
+   * badge is a plain, non-clickable label. */
+  tokenTo?: RouteLocationRaw
   href?: string
   timestamp?: string | number
 }>()
@@ -26,25 +32,31 @@ const dateLabel = computed(
 </script>
 
 <template>
-  <a
-    :href="href"
-    target="_blank"
-    rel="noopener noreferrer"
+  <!--
+    Stretched-link card: the container is the positioned context, the title's
+    `::after` overlay makes the whole card open the article, and the ticker badge
+    sits above it (relative z-10) so it can be its own link to the stock page
+    without nesting one <a> inside another.
+  -->
+  <div
     data-test="news-card"
-    class="group relative flex h-[280px] flex-col justify-between overflow-hidden rounded-2xl bg-white p-6"
+    class="group relative flex h-[280px] flex-col justify-between gap-4 overflow-hidden rounded-2xl bg-white p-6"
   >
-    <div class="flex w-full flex-col gap-2">
+    <div class="flex w-full min-h-0 flex-col gap-2">
       <div class="flex items-center gap-1 text-s-14 leading-5 text-[#575757]">
         <span v-if="source">{{ source }}</span>
         <span v-if="source && dateLabel">•</span>
         <span v-if="dateLabel" data-test="news-date">{{ dateLabel }}</span>
       </div>
-      <p
+      <a
+        :href="href"
+        target="_blank"
+        rel="noopener noreferrer"
         data-test="news-title"
-        class="w-full text-[18px] font-semibold capitalize leading-6 tracking-[-0.36px] text-black group-hover:text-primary group-hover:underline"
+        class="w-full text-[18px] font-semibold capitalize leading-6 tracking-[-0.36px] text-black after:absolute after:inset-0 group-hover:text-primary group-hover:underline"
       >
         {{ title }}
-      </p>
+      </a>
       <p
         v-if="description"
         class="line-clamp-3 w-full text-s-16 leading-[22px] text-[#575757] group-hover:text-black"
@@ -53,17 +65,30 @@ const dateLabel = computed(
       </p>
     </div>
 
-    <div v-if="ticker" class="flex items-center gap-2">
-      <AppTokenLogo :symbol="ticker" :is-stock="true" width="w-6" height="h-6" />
+    <component
+      :is="tokenTo ? RouterLink : 'div'"
+      v-if="ticker"
+      :to="tokenTo"
+      data-test="news-ticker"
+      class="flex w-fit shrink-0 items-center gap-2"
+      :class="tokenTo ? 'relative z-10 transition-opacity hover:opacity-80' : ''"
+    >
+      <AppTokenLogo
+        :symbol="ticker"
+        :url="tokenLogo"
+        :is-stock="true"
+        width="w-6"
+        height="h-6"
+      />
       <AppTokenSymbol
         :symbol="ticker"
         :is-stock="true"
         class="!text-s-14 !font-normal !text-[#575757]"
       />
-    </div>
+    </component>
 
     <ArrowTopRightOnSquareIcon
-      class="absolute right-6 top-6 size-5 text-[#575757] opacity-0 transition-opacity group-hover:opacity-100"
+      class="pointer-events-none absolute right-6 top-6 size-5 text-[#575757] opacity-0 transition-opacity group-hover:opacity-100"
     />
-  </a>
+  </div>
 </template>

--- a/src/components/AppNewsCard.vue
+++ b/src/components/AppNewsCard.vue
@@ -40,9 +40,9 @@ const dateLabel = computed(
   -->
   <div
     data-test="news-card"
-    class="group relative flex h-[280px] flex-col justify-between gap-4 overflow-hidden rounded-2xl bg-white p-6"
+    class="group relative isolate flex h-[280px] flex-col justify-between gap-4 overflow-hidden rounded-2xl bg-white p-6"
   >
-    <div class="flex w-full min-h-0 flex-col gap-2">
+    <div class="flex w-full min-h-0 flex-1 flex-col gap-2 overflow-hidden">
       <div class="flex items-center gap-1 text-s-14 leading-5 text-[#575757]">
         <span v-if="source">{{ source }}</span>
         <span v-if="source && dateLabel">•</span>
@@ -53,7 +53,7 @@ const dateLabel = computed(
         target="_blank"
         rel="noopener noreferrer"
         data-test="news-title"
-        class="w-full text-[18px] font-semibold capitalize leading-6 tracking-[-0.36px] text-black after:absolute after:inset-0 group-hover:text-primary group-hover:underline"
+        class="line-clamp-3 w-full text-[18px] font-semibold capitalize leading-6 tracking-[-0.36px] text-black after:absolute after:inset-0 group-hover:text-primary group-hover:underline"
       >
         {{ title }}
       </a>

--- a/src/components/AppTokenListRow.vue
+++ b/src/components/AppTokenListRow.vue
@@ -41,7 +41,6 @@ const changeText = computed(() =>
       :is-stock="isStock"
       width="size-8"
       height="size-8"
-      no-ring
       no-shadow
       class="shrink-0"
     />

--- a/src/modules/home/sections/HomeMarketNews.vue
+++ b/src/modules/home/sections/HomeMarketNews.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
+import type { RouteLocationRaw } from 'vue-router'
 import { useStocksStore } from '@/stores/stocksStore'
+import { STOCK_INFO_ROUTE_NAMES } from '@/router/routeNames'
 import AppNewsCard from '@/components/AppNewsCard.vue'
 import AppPagination from '@/components/AppPagination.vue'
 
@@ -60,6 +62,24 @@ const newsDescription = (item: {
     ? t('homePage.news.readOnSource', { source })
     : t('homePage.news.readMore')
 }
+
+// News items carry only ticker symbols — resolve each to a stock icon URL from
+// the tradable-assets list in the store (fetched on app start) so the footer
+// badge shows the real logo instead of the initials avatar.
+const tokenLogo = (item: { tickers?: string[] }): string | undefined =>
+  stocksStore.stockIconBySymbol(item.tickers?.[0])
+
+// When the ticker maps to a tradable stock, link its badge to the stock page
+// (same destination as the New Listings cards); non-tradable tickers stay a
+// plain label.
+const tokenTo = (item: {
+  tickers?: string[]
+}): RouteLocationRaw | undefined => {
+  const symbol = stocksStore.stockTradableSymbol(item.tickers?.[0])
+  return symbol
+    ? { name: STOCK_INFO_ROUTE_NAMES.stocks, params: { symbol } }
+    : undefined
+}
 </script>
 
 <template>
@@ -84,6 +104,8 @@ const newsDescription = (item: {
             :date="dateLabel(n.timestamp)"
             :description="newsDescription(n)"
             :ticker="n.tickers?.[0]"
+            :token-logo="tokenLogo(n)"
+            :token-to="tokenTo(n)"
             :href="n.articleUrl"
           />
         </div>

--- a/src/stores/stocksStore.ts
+++ b/src/stores/stocksStore.ts
@@ -88,6 +88,35 @@ export const useStocksStore = defineStore('stocksStore', () => {
     )
   }
 
+  // Match a news ticker to a tradable stock. News items only carry `tickers`
+  // (symbols) — no icon URL — so callers (e.g. Market News cards) resolve them
+  // via the tradable-assets list, fetched on app start. Tradable stocks are
+  // keyed by an Ondo-tokenized `symbol` ("AAPLon") while news tickers are the
+  // plain underlying ("AAPL"); match on the underlying by dropping the trailing
+  // "on" (and also accept an already tokenized ticker).
+  const matchStockByTicker = (ticker?: string) => {
+    if (!ticker) return undefined
+    const target = ticker.toUpperCase()
+    return stocksAddresses.value.find(stock => {
+      const sym = stock.symbol?.toUpperCase()
+      if (!sym) return false
+      const base = sym.endsWith('ON') ? sym.slice(0, -2) : sym
+      return base === target || sym === target
+    })
+  }
+
+  // Icon URL for a ticker, or undefined so the caller can fall back to the
+  // initials avatar.
+  const stockIconBySymbol = (ticker?: string): string | undefined => {
+    const match = matchStockByTicker(ticker)
+    return match?.iconPngUrl || match?.iconSvgUrl || undefined
+  }
+
+  // The tokenized tradable symbol ("AAPLon") for a plain ticker — the param the
+  // stock page route expects — or undefined when the stock isn't tradable.
+  const stockTradableSymbol = (ticker?: string): string | undefined =>
+    matchStockByTicker(ticker)?.symbol
+
   /**------------------------
    * Helper Methods
    -------------------------*/
@@ -139,6 +168,8 @@ export const useStocksStore = defineStore('stocksStore', () => {
     hasStocksAddressesData,
     // Helpers
     isStock,
+    stockIconBySymbol,
+    stockTradableSymbol,
     fetchMissingStockData,
     mapMissingStocksInfo,
   }

--- a/tests/unit/components/AppNewsCard.spec.ts
+++ b/tests/unit/components/AppNewsCard.spec.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
+import { RouterLink } from 'vue-router'
 import AppNewsCard from '@/components/AppNewsCard.vue'
+import AppTokenLogo from '@/components/AppTokenLogo.vue'
+
+const badgeStubs = { AppTokenLogo: true, AppTokenSymbol: true, RouterLink: true }
 
 describe('AppNewsCard', () => {
   it('renders title and opens href in a new tab', () => {
@@ -29,5 +33,31 @@ describe('AppNewsCard', () => {
   it('renders no date element when timestamp is omitted', () => {
     const w = mount(AppNewsCard, { props: { title: 'Big news' } })
     expect(w.find('[data-test="news-date"]').exists()).toBe(false)
+  })
+
+  it('passes the resolved token logo through to the footer AppTokenLogo', () => {
+    const w = mount(AppNewsCard, {
+      props: { title: 'n', ticker: 'AAPL', tokenLogo: 'aapl.png' },
+      global: { stubs: badgeStubs },
+    })
+    expect(w.findComponent(AppTokenLogo).props('url')).toBe('aapl.png')
+  })
+
+  it('links the ticker badge to the stock page when tokenTo is set', () => {
+    const to = { name: 'stocks-stock-info', params: { symbol: 'AAPLon' } }
+    const w = mount(AppNewsCard, {
+      props: { title: 'n', ticker: 'AAPL', tokenTo: to },
+      global: { stubs: badgeStubs },
+    })
+    expect(w.findComponent(RouterLink).props('to')).toEqual(to)
+  })
+
+  it('renders the ticker badge as a plain label when tokenTo is absent', () => {
+    const w = mount(AppNewsCard, {
+      props: { title: 'n', ticker: 'AAPL' },
+      global: { stubs: badgeStubs },
+    })
+    expect(w.findComponent(RouterLink).exists()).toBe(false)
+    expect(w.find('[data-test="news-ticker"]').element.tagName).toBe('DIV')
   })
 })

--- a/tests/unit/modules/home/HomeMarketNews.spec.ts
+++ b/tests/unit/modules/home/HomeMarketNews.spec.ts
@@ -32,10 +32,15 @@ const makeNews = (count: number) =>
 const { box } = vi.hoisted(() => ({ box: { value: [] as unknown[] } }))
 
 vi.mock('@/stores/stocksStore', () => ({
-  useStocksStore: () => ({ recentNews: box.value }),
+  useStocksStore: () => ({
+    recentNews: box.value,
+    stockIconBySymbol: (s?: string) => (s ? `icon-${s}` : undefined),
+    stockTradableSymbol: (s?: string) => (s ? `${s}on` : undefined),
+  }),
 }))
 
 import HomeMarketNews from '@/modules/home/sections/HomeMarketNews.vue'
+import AppTokenLogo from '@/components/AppTokenLogo.vue'
 
 describe('HomeMarketNews', () => {
   // The news card renders a token badge (AppTokenLogo + AppTokenSymbol) when a
@@ -45,7 +50,12 @@ describe('HomeMarketNews', () => {
     mount(HomeMarketNews, {
       global: {
         plugins: [i18n],
-        stubs: { AppTokenLogo: true, AppTokenSymbol: true },
+        stubs: {
+          AppTokenLogo: true,
+          AppTokenSymbol: true,
+          // Render the slot so the badge's AppTokenLogo is still mounted.
+          RouterLink: { template: '<a><slot /></a>' },
+        },
       },
     })
 
@@ -69,5 +79,19 @@ describe('HomeMarketNews', () => {
     const w = mountIt()
     expect(w.find('[data-test="news-empty"]').exists()).toBe(true)
     expect(w.findAll('[data-test="news-card"]').length).toBe(0)
+  })
+
+  it('resolves the ticker to a stock logo and passes it to the footer badge', () => {
+    box.value = [
+      {
+        title: 'n0',
+        articleUrl: 'https://x.test/0',
+        timestamp: 1700000000000,
+        tickers: ['AAPL'],
+      },
+    ]
+    const w = mountIt()
+    // Ticker symbol resolved to an icon URL via the store, then passed down.
+    expect(w.findComponent(AppTokenLogo).props('url')).toBe('icon-AAPL')
   })
 })

--- a/tests/unit/stores/stocksStore.spec.ts
+++ b/tests/unit/stores/stocksStore.spec.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { ref, type Ref } from 'vue'
+
+// Keep the real fetch layer (Sentry, configs, network) out of the graph and
+// expose each endpoint's `data` ref by URL so the test can inject a response.
+const dataByUrl: Record<string, Ref<unknown>> = {}
+
+vi.mock('@/composables/useFetchMewApi', () => ({
+  useFetchMewApi: () => ({
+    useMEWFetch: (url: unknown) => ({
+      get: () => ({
+        json: () => {
+          const data = ref<unknown>(null)
+          dataByUrl[typeof url === 'string' ? url : 'ref'] = data
+          return {
+            data,
+            isFetching: ref(false),
+            execute: vi.fn(),
+            onFetchResponse: vi.fn(),
+          }
+        },
+      }),
+    }),
+  }),
+}))
+
+import { useStocksStore } from '@/stores/stocksStore'
+
+describe('stocksStore.stockIconBySymbol', () => {
+  beforeEach(() => setActivePinia(createPinia()))
+
+  it('maps a plain news ticker to a tokenized stock icon, png over svg, case-insensitive', () => {
+    const store = useStocksStore()
+    // Real shape: tradable symbols are Ondo-tokenized ("AAPLon"), stockAlias is
+    // the full company name — news tickers are the plain underlying ("AAPL").
+    dataByUrl['/v1/web/stocks/addresses'].value = [
+      {
+        symbol: 'AAPLon',
+        stockAlias: 'Apple Inc',
+        iconPngUrl: 'aapl.png',
+        iconSvgUrl: 'aapl.svg',
+        addresses: [],
+      },
+      { symbol: 'GOOGLon', stockAlias: 'Alphabet', iconSvgUrl: 'googl.svg', addresses: [] },
+    ]
+
+    expect(store.stockIconBySymbol('AAPL')).toBe('aapl.png')
+    expect(store.stockIconBySymbol('googl')).toBe('googl.svg')
+    // An already-tokenized ticker still resolves.
+    expect(store.stockIconBySymbol('AAPLon')).toBe('aapl.png')
+  })
+
+  it('returns undefined for an unknown or missing symbol', () => {
+    const store = useStocksStore()
+    dataByUrl['/v1/web/stocks/addresses'].value = [
+      { symbol: 'AAPLon', iconPngUrl: 'aapl.png', addresses: [] },
+    ]
+
+    expect(store.stockIconBySymbol('TSLA')).toBeUndefined()
+    expect(store.stockIconBySymbol()).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

Market News cards on the Home page showed a two-letter initials avatar instead of the stock logo, and the token logos in New Listings / Trending stocks were missing their ring/border.

### Market News cards
- News items only carry a plain ticker (`AAPL`), while tradable stocks are keyed by an Ondo-tokenized symbol (`AAPLon`). Added `stocksStore.stockIconBySymbol` / `stockTradableSymbol` that map a plain ticker to its icon URL and tokenized symbol (dropping the trailing `on`), resolved from the tradable-assets list already fetched on app start.
- The footer badge now renders the **real stock logo** and **links to the stock page** (same destination as New Listings cards). Implemented with a stretched-link so the rest of the card still opens the article without nesting anchors.
- Added a minimum gap between the description and the badge so they don't touch on cards with long titles/descriptions.

### New Listings & Trending stocks
- Removed `no-ring` from `AppNewListingCard` and `AppTokenListRow` so the token logos render with the standard `AppTokenLogo` ring/border.

## Testing
- `pnpm vitest run` — 28 tests green (AppNewsCard, AppNewListingCard, AppTokenListRow, HomeMarketNews, stocksStore).
- `pnpm vue-tsc --noEmit` — clean.
- `pnpm eslint` — clean.
- Manual smoke on the Home page: Market News logos resolve (GOOGL/AAPL/META), ticker badge navigates to `/stocks/stock/METAon`, and Trending / New Listings logos show the ring.

## Screens to verify
- Home → Trending stocks (hero), New Listings (Stocks tab), Market News (logos + click a ticker → stock page; gap on tall cards).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Market news cards can display stock logos and link ticker badges directly to stock details.
  * Ticker matching supports standard and tokenized stock symbols.
  * News titles remain linked to articles, while ticker badges are independently navigable when applicable.

* **Bug Fixes**
  * Improved token logo presentation in listing cards and token rows.

* **Tests**
  * Added coverage for ticker navigation, logo resolution, symbol matching, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->