### PR TITLE
feat: portfolio unconnected state instead of redirect to Home (MEW-2216)

### DIFF
--- a/src/router/routesDefault.ts
+++ b/src/router/routesDefault.ts
@@ -34,12 +34,17 @@ const DefaultRoutes = <RouteNameCollection>[
     },
   },
   {
-    // The wallet portfolio moved off the root; requires a connected wallet
-    // (the guard bounces disconnected users to '/'). Its connect/create and
-    // token/stock-info children keep their own `noAuth` where they had it.
+    // The wallet portfolio moved off the root. It stays reachable without a
+    // wallet (`noAuth`) so disconnected users get its connect-wallet state
+    // (ViewPortfolio renders <connect-wallet> when !isWalletConnected) instead
+    // of being bounced to Home. Its connect/create and token/stock-info
+    // children inherit `noAuth` — all are meant to be reachable disconnected.
     path: ROUTES_MAIN.PORTFOLIO.PATH,
     name: ROUTES_MAIN.PORTFOLIO.NAME,
     component: PortfolioView,
+    meta: {
+      noAuth: true,
+    },
     children: [
       CREATE_ROUTES,
       ACCESS_ROUTES,

--- a/tests/unit/router/portfolioRoute.spec.ts
+++ b/tests/unit/router/portfolioRoute.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from 'vitest'
+import type { RouteRecordRaw } from 'vue-router'
+
+// routesDefault pulls this in at module load; stub it so importing the routes
+// doesn't drag in the trading-restriction composable and its deps.
+vi.mock('@/composables/useTradingRestriction', () => ({
+  fetchTradingRestriction: vi.fn(),
+}))
+// routesAccess/routesCreate import walletConfigs, which transitively loads the
+// Ledger hw-wallet module (fails under jsdom) — stub the lists they need.
+vi.mock('@/modules/access/common/walletConfigs', () => ({
+  ACCESS_WALLET_VIEWS: ['default', 'ledger'],
+  ACCESS_WALLET_VIEWS_DEFAULT: 'default',
+  CREATE_WALLET_VIEWS: ['default'],
+}))
+
+import DefaultRoutes from '@/router/routesDefault'
+
+const route = (name: string): RouteRecordRaw | undefined =>
+  (DefaultRoutes as RouteRecordRaw[]).find(r => r.name === name)
+
+describe('/portfolio route (MEW-2216 — unconnected state)', () => {
+  it('is noAuth so disconnected users see the connect-wallet state instead of bouncing to Home', () => {
+    expect(route('Portfolio')?.meta?.noAuth).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

When no wallet is connected, `/portfolio` used to bounce to Home. This restores the portfolio **unconnected state** so disconnected users land on the connect-wallet page instead.

The router guard (`router/index.ts` `beforeEach`) redirects any route without `meta.noAuth` to `/` when there's no wallet. The Portfolio route had no `noAuth`, so disconnected users never reached the connect-wallet state that `ViewPortfolio.vue` already renders (`<connect-wallet v-if="!isWalletConnected" />`).

## Changes

- `src/router/routesDefault.ts`: mark the `/portfolio` route as `meta: { noAuth: true }` so the guard no longer redirects to Home; refresh the now-stale route comment. Its connect/create and token/stock-info children inherit `noAuth` — all are meant to be reachable while disconnected.
- No new components: the unconnected view (`modules/portfolio/components/ConnectWallet.vue`, matching the Figma) and its wiring in `ViewPortfolio.vue` already existed.
- `tests/unit/router/portfolioRoute.spec.ts`: guards the `noAuth` flag against regression.

## Testing

- `pnpm vitest run tests/unit/router/portfolioRoute.spec.ts` → 1/1
- `pnpm vue-tsc --noEmit -p tsconfig.app.json` → exit 0
- eslint clean on changed files
- Manual: `/portfolio` while disconnected shows the connect-wallet hero (no bounce); Connect Wallet → access flow; Create a new wallet → create flow; connecting a wallet renders the real portfolio.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disconnected users can now access the portfolio page and see the connect-wallet state instead of being redirected away.
  * Portfolio-related pages remain accessible while a wallet is not connected.

* **Tests**
  * Added coverage to verify portfolio access for disconnected users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->