### PR TITLE
[MEW-2208] feat: Sentry instrumentation for perps

### DIFF
--- a/src/modules/perps/ModulePerpInfo.vue
+++ b/src/modules/perps/ModulePerpInfo.vue
@@ -978,6 +978,8 @@ import {
   ChevronDownIcon,
 } from '@heroicons/vue/24/outline'
 import { perpsClient, PERPS_INFO_PAGE_SIZE } from './configs'
+import { capturePerps } from './sentry'
+import { PERPS_FEATURE } from '@/sentry/constants'
 import { useCursorPaginate } from './composables/useCursorPaginate'
 import {
   usePerpsMarkets,
@@ -1120,8 +1122,12 @@ const fetchPerpetualInfo = async () => {
   try {
     const res = await perpsClient.getPerpetualInfo(props.market)
     if (res.success) perpInfo.value = res.result
-  } catch {
+  } catch (e) {
     perpInfo.value = undefined
+    capturePerps(PERPS_FEATURE.MARKETS, e, {
+      title: 'PERPS: Error fetching perpetual info',
+      extra: { market: props.market },
+    })
   }
 }
 
@@ -1243,7 +1249,7 @@ async function fetchOpenOrdersCount() {
     openOrdersCountForMarket.value = pendingCount
     openOrdersCountIsCapped.value =
       !!res.pageInfo?.nextCursor && pendingCount >= OPEN_COUNT_LIMIT
-  } catch {
+  } catch (e) {
     if (
       seq !== openOrdersFetchSeq ||
       market !== props.market ||
@@ -1252,6 +1258,10 @@ async function fetchOpenOrdersCount() {
       return
     openOrdersCountForMarket.value = 0
     openOrdersCountIsCapped.value = false
+    capturePerps(PERPS_FEATURE.ORDER, e, {
+      title: 'PERPS: Error fetching open orders count',
+      extra: { market: props.market },
+    })
   }
 }
 
@@ -1325,7 +1335,9 @@ const cancelInfoOrder = async (order: ApiOrder): Promise<boolean> => {
     await Promise.all([ordersPagination.refetch(), fetchOpenOrdersCount()])
     return true
   } catch (e) {
-    console.error('Failed to cancel order:', e)
+    capturePerps(PERPS_FEATURE.ORDER, e, {
+      title: 'PERPS: Cancel order failed',
+    })
     const errorMessage = e instanceof Error ? e.message : String(e)
     void analytics.trackPerpsOrderCancelErrorEvent(
       PerpsOrderEvent.CANCEL_SUBMIT_ERROR,
@@ -1583,6 +1595,10 @@ const saveLeverage = async () => {
       PerpsChangeLeverageEvent.SUBMIT_FAIL,
       failPayload,
     )
+    capturePerps(PERPS_FEATURE.LEVERAGE, e, {
+      title: 'PERPS: Set leverage failed',
+      extra: { market: props.market, newLeverage: tempLeverage.value },
+    })
   } finally {
     isSavingLeverage.value = false
   }
@@ -1683,9 +1699,13 @@ const fetchChart = async () => {
       chartLabels.value = []
       chartPoints.value = []
     }
-  } catch {
+  } catch (e) {
     chartLabels.value = []
     chartPoints.value = []
+    capturePerps(PERPS_FEATURE.MARKETS, e, {
+      title: 'PERPS: Error fetching chart history',
+      extra: { market: props.market },
+    })
   } finally {
     chartLoading.value = false
   }

--- a/src/modules/perps/components/PerpsDepositDialog.vue
+++ b/src/modules/perps/components/PerpsDepositDialog.vue
@@ -257,6 +257,8 @@ import {
   IS_PERPS_LIVE,
 } from '../configs'
 import { usePerpsAuth } from '../composables/usePerpsAuth'
+import { capturePerps } from '../sentry'
+import { PERPS_FEATURE } from '@/sentry/constants'
 import { useWalletStore } from '@/stores/walletStore'
 import { storeToRefs } from 'pinia'
 import { Contract } from 'web3-eth-contract'
@@ -523,6 +525,9 @@ const fetchDepositAddress = async () => {
   } catch (e) {
     error.value =
       e instanceof Error ? e.message : t('perps.deposit.fetch-address-failed')
+    capturePerps(PERPS_FEATURE.DEPOSIT, e, {
+      title: 'PERPS: Error fetching deposit address',
+    })
   } finally {
     loading.value = false
   }
@@ -565,6 +570,10 @@ const sendSandboxDeposit = async () => {
         errorMessage: msg,
       })
       perpsToasts.toastFailedToInitiateDeposit()
+      capturePerps(PERPS_FEATURE.DEPOSIT, e, {
+        title: 'PERPS: Sandbox deposit failed',
+        extra: { depositAmount, token: 'USDC' },
+      })
     }
   } finally {
     sending.value = false
@@ -661,6 +670,10 @@ const sendLiveDeposit = async () => {
         errorMessage: msg,
       })
       perpsToasts.toastFailedToCreditAccount()
+      capturePerps(PERPS_FEATURE.DEPOSIT, e, {
+        title: 'PERPS: Deposit transaction failed',
+        extra: { depositAmount, token: 'USDC' },
+      })
     }
   } finally {
     sending.value = false

--- a/src/modules/perps/components/PerpsMarketList.vue
+++ b/src/modules/perps/components/PerpsMarketList.vue
@@ -673,6 +673,8 @@ import { usePerpsPositions } from '../composables/usePerpsPositions'
 import { usePerpsRestriction } from '../composables/usePerpsRestriction'
 import { usePaginate } from '@/composables/usePaginate'
 import { PERPS_PAGE_SIZE, perpsClient } from '../configs'
+import { capturePerps } from '../sentry'
+import { PERPS_FEATURE } from '@/sentry/constants'
 import PerpsPagination from './PerpsPagination.vue'
 import PerpsSelectLeverageDialog from './PerpsSelectLeverageDialog.vue'
 import { usePerpsToasts } from '../composables/usePerpsToasts'
@@ -774,6 +776,10 @@ const saveLeverage = async () => {
       PerpsChangeLeverageEvent.SUBMIT_FAIL,
       failPayload,
     )
+    capturePerps(PERPS_FEATURE.LEVERAGE, e, {
+      title: 'PERPS: Set leverage failed',
+      extra: { market: leverageMarket.value, newLeverage: tempLeverage.value },
+    })
   } finally {
     isSavingLeverage.value = false
   }

--- a/src/modules/perps/components/PerpsOrderDialog.vue
+++ b/src/modules/perps/components/PerpsOrderDialog.vue
@@ -85,6 +85,8 @@ import AppBtnText from '@/components/AppBtnText.vue'
 import AppTooltip from '@/components/AppTooltip.vue'
 import type { ApiOrder } from '../sdk/types'
 import { perpsClient } from '../configs'
+import { capturePerps } from '../sentry'
+import { PERPS_FEATURE } from '@/sentry/constants'
 import {
   formatUsdc,
   formatPrice,
@@ -160,9 +162,12 @@ watch(
       } else {
         fetchedFee.value = null
       }
-    } catch {
+    } catch (e) {
       if (token !== currentFetchToken.value) return
       fetchedFee.value = null
+      capturePerps(PERPS_FEATURE.ORDER, e, {
+        title: 'PERPS: Error fetching order detail',
+      })
     }
   },
   { immediate: true },

--- a/src/modules/perps/components/PerpsPositionsTable.vue
+++ b/src/modules/perps/components/PerpsPositionsTable.vue
@@ -921,6 +921,8 @@ import {
 } from '../utils/formatters'
 import { getBase, getLogoUrl } from '../utils/market'
 import { perpsClient, PERPS_PAGE_SIZE } from '../configs'
+import { capturePerps } from '../sentry'
+import { PERPS_FEATURE } from '@/sentry/constants'
 import { usePaginate } from '@/composables/usePaginate'
 import type { Position, ApiOrder, ApiFill } from '../sdk/types'
 import { useWalletStore } from '@/stores/walletStore'
@@ -985,6 +987,10 @@ const saveLeverage = async () => {
       PerpsChangeLeverageEvent.SUBMIT_FAIL,
       failPayload,
     )
+    capturePerps(PERPS_FEATURE.LEVERAGE, e, {
+      title: 'PERPS: Set leverage failed',
+      extra: { market: fullMarketName.value, newLeverage: localLeverage.value },
+    })
   } finally {
     isSavingLeverage.value = false
   }
@@ -1302,7 +1308,9 @@ async function cancelOrder(order: ApiOrder) {
     showOrderDialog.value = false
     await refetchOrders()
   } catch (e) {
-    console.error('Failed to cancel order:', e)
+    capturePerps(PERPS_FEATURE.ORDER, e, {
+      title: 'PERPS: Cancel order failed',
+    })
     const errorMessage = e instanceof Error ? e.message : String(e)
     void analytics.trackPerpsOrderCancelErrorEvent(
       PerpsOrderEvent.CANCEL_SUBMIT_ERROR,

--- a/src/modules/perps/components/PerpsWithdrawDialog.vue
+++ b/src/modules/perps/components/PerpsWithdrawDialog.vue
@@ -135,8 +135,8 @@ import { storeToRefs } from 'pinia'
 import { usePerpsToasts } from '@/modules/perps/composables/usePerpsToasts'
 import { hasInvalidPrecision } from '../utils/formatters'
 import AppBlockie from '@/components/AppBlockie.vue'
-import { captureException } from '@sentry/vue'
-import { SENTRY_MODULE_TAGS } from '@/sentry/constants'
+import { capturePerps } from '../sentry'
+import { PERPS_FEATURE } from '@/sentry/constants'
 import { useI18n } from 'vue-i18n'
 import { toChecksumAddress } from '@/utils/addressUtils'
 import {
@@ -237,11 +237,8 @@ async function refreshAddressBookStatus() {
     )
   } catch (e) {
     isAddressAuthorized.value = false
-    captureException(e, {
-      ...SENTRY_MODULE_TAGS.PERPS,
-      extra: {
-        title: 'PERPS: Error fetching address book',
-      },
+    capturePerps(PERPS_FEATURE.WITHDRAW, e, {
+      title: 'PERPS: Error fetching address book',
     })
   } finally {
     addressBookLoading.value = false
@@ -271,11 +268,8 @@ watch(
         accountRes?.result?.withdrawalFeeUSD ?? DEFAULT_WITHDRAWAL_FEE_USD
     } catch (e) {
       // Keep the default fee shown if the lookup fails.
-      captureException(e, {
-        ...SENTRY_MODULE_TAGS.PERPS,
-        extra: {
-          title: 'PERPS: Error fetching withdrawal fee',
-        },
+      capturePerps(PERPS_FEATURE.WITHDRAW, e, {
+        title: 'PERPS: Error fetching withdrawal fee',
       })
     }
   },
@@ -316,6 +310,9 @@ async function submitAuthorize() {
       PerpsWithdrawAuthorizeEvent.ERROR,
       { errorMessage: msg },
     )
+    capturePerps(PERPS_FEATURE.WITHDRAW, e, {
+      title: 'PERPS: Authorize withdrawal address failed',
+    })
   } finally {
     authorizing.value = false
   }
@@ -359,6 +356,10 @@ async function submitWithdraw() {
       withdrawAmount,
       token: 'USDC',
       errorMessage: msg,
+    })
+    capturePerps(PERPS_FEATURE.WITHDRAW, e, {
+      title: 'PERPS: Withdraw submit failed',
+      extra: { withdrawAmount, token: 'USDC' },
     })
   } finally {
     sending.value = false

--- a/src/modules/perps/composables/useCursorPaginate.ts
+++ b/src/modules/perps/composables/useCursorPaginate.ts
@@ -1,5 +1,7 @@
 import { ref, computed, type Ref } from 'vue'
 import type { PaginatedResponse } from '../sdk/types'
+import { capturePerps } from '../sentry'
+import { PERPS_FEATURE } from '@/sentry/constants'
 
 export function useCursorPaginate<T>(
   fetcher: (opts: {
@@ -26,7 +28,10 @@ export function useCursorPaginate<T>(
       items.value = res.result ?? []
       nextCursor.value = res.pageInfo?.nextCursor
       return true
-    } catch {
+    } catch (e) {
+      capturePerps(PERPS_FEATURE.HISTORY, e, {
+        title: 'PERPS: Error fetching paginated page',
+      })
       return false
     } finally {
       if (epoch === requestEpoch) loading.value = false

--- a/src/modules/perps/composables/usePerpsAuth.ts
+++ b/src/modules/perps/composables/usePerpsAuth.ts
@@ -1,5 +1,7 @@
 import { ref, watch, effectScope } from 'vue'
 import { BUILDER_CODE, perpsClient } from '../configs'
+import { capturePerps } from '../sentry'
+import { PERPS_FEATURE } from '@/sentry/constants'
 import { useWalletStore } from '@/stores/walletStore'
 import { storeToRefs } from 'pinia'
 import type { PerpsBalance, PortfolioSummary } from '../sdk/types'
@@ -109,8 +111,11 @@ function resetPerpsData() {
   for (const fn of _dataResetHandlers) {
     try {
       fn()
-    } catch {
+    } catch (e) {
       // a failing reset handler must not block the others
+      capturePerps(PERPS_FEATURE.AUTH, e, {
+        title: 'PERPS: Auth data-reset handler failed',
+      })
     }
   }
 }
@@ -169,8 +174,11 @@ async function tryRestoreAuth(address: string, generation: number) {
       decryptedAccount = storedAccounts[i]
         ? await decrypt(storedAccounts[i], address)
         : null
-    } catch {
+    } catch (e) {
       accountFailed = true
+      capturePerps(PERPS_FEATURE.AUTH, e, {
+        title: 'PERPS: Auth account decrypt failed',
+      })
     }
     if (isStale()) return
     token.value = decryptedToken
@@ -402,6 +410,10 @@ export function usePerpsAuth() {
           errorMessage,
           walletType: walletTypeStr,
         })
+        capturePerps(PERPS_FEATURE.AUTH, e, {
+          title: 'PERPS: Sign-in failed',
+          extra: { source, walletType: walletTypeStr },
+        })
       }
     } finally {
       showSigningPrompt.value = false
@@ -500,8 +512,11 @@ export function usePerpsBalance() {
       try {
         const res = await perpsClient.getPerpsBalance()
         balance.value = res.result
-      } catch {
+      } catch (e) {
         balance.value = null
+        capturePerps(PERPS_FEATURE.PORTFOLIO, e, {
+          title: 'PERPS: Error fetching balance',
+        })
       } finally {
         loading.value = false
       }
@@ -597,8 +612,11 @@ export function usePerpsPortfolioSummary() {
       try {
         const res = await perpsClient.getPortfolioSummary()
         summary.value = res.result
-      } catch {
+      } catch (e) {
         summary.value = null
+        capturePerps(PERPS_FEATURE.PORTFOLIO, e, {
+          title: 'PERPS: Error fetching portfolio summary',
+        })
       } finally {
         loading.value = false
       }

--- a/src/modules/perps/composables/usePerpsHistory.ts
+++ b/src/modules/perps/composables/usePerpsHistory.ts
@@ -1,5 +1,7 @@
 import { ref, watchEffect, onUnmounted, type Ref } from 'vue'
 import { perpsClient, PERPS_PAGE_SIZE } from '../configs'
+import { capturePerps } from '../sentry'
+import { PERPS_FEATURE } from '@/sentry/constants'
 import { usePerpsAuth } from './usePerpsAuth'
 import { usePerpsMarkets } from './usePerpsMarkets'
 import { usePerpsToasts } from './usePerpsToasts'
@@ -225,9 +227,12 @@ export function usePerpsDepositsWithdrawals() {
       ])
       deposits.value = dRes.result ?? []
       withdrawals.value = wRes.result ?? []
-    } catch {
+    } catch (e) {
       deposits.value = []
       withdrawals.value = []
+      capturePerps(PERPS_FEATURE.HISTORY, e, {
+        title: 'PERPS: Error fetching deposits/withdrawals history',
+      })
     } finally {
       loading.value = false
     }

--- a/src/modules/perps/composables/usePerpsMarkets.ts
+++ b/src/modules/perps/composables/usePerpsMarkets.ts
@@ -1,6 +1,8 @@
 import { ref, effectScope } from 'vue'
 import type { Contract, TradingPair } from '../sdk/types'
 import { perpsClient } from '../configs'
+import { capturePerps } from '../sentry'
+import { PERPS_FEATURE } from '@/sentry/constants'
 import { perpsWs } from '../sdk/ws'
 import { ensurePerpsWsLifecycle } from './usePerpsWsLifecycle'
 
@@ -21,6 +23,9 @@ async function fetchMarkets() {
   } catch (e) {
     marketsError.value =
       e instanceof Error ? e.message : 'Failed to fetch markets'
+    capturePerps(PERPS_FEATURE.MARKETS, e, {
+      title: 'PERPS: Error fetching markets',
+    })
   } finally {
     marketsLoading.value = false
   }
@@ -60,8 +65,11 @@ async function fetchContracts() {
         contracts.value = data.result
       }
     }
-  } catch {
+  } catch (e) {
     contractsError.value = 'No markets found'
+    capturePerps(PERPS_FEATURE.MARKETS, e, {
+      title: 'PERPS: Error fetching contracts',
+    })
   } finally {
     contractsLoading.value = false
   }

--- a/src/modules/perps/composables/usePerpsPortfolioGraph.ts
+++ b/src/modules/perps/composables/usePerpsPortfolioGraph.ts
@@ -1,5 +1,7 @@
 import { ref, watch, effectScope } from 'vue'
 import { perpsClient } from '../configs'
+import { capturePerps } from '../sentry'
+import { PERPS_FEATURE } from '@/sentry/constants'
 import { usePerpsAuth, onPerpsAuthReset } from './usePerpsAuth'
 import type { PortfolioGraphPoint } from '../sdk/types'
 
@@ -36,8 +38,11 @@ export function usePerpsPortfolioGraph() {
       const result = res.result ?? []
       _cache.value.set(_graphRange.value, result)
       _graphData.value = result
-    } catch {
+    } catch (e) {
       _graphData.value = []
+      capturePerps(PERPS_FEATURE.PORTFOLIO, e, {
+        title: 'PERPS: Error fetching portfolio graph',
+      })
     } finally {
       _graphLoading.value = false
     }

--- a/src/modules/perps/composables/usePerpsPositions.ts
+++ b/src/modules/perps/composables/usePerpsPositions.ts
@@ -1,5 +1,7 @@
 import { ref, watch, effectScope } from 'vue'
 import { perpsClient } from '../configs'
+import { capturePerps } from '../sentry'
+import { PERPS_FEATURE } from '@/sentry/constants'
 import { usePerpsAuth, onPerpsAuthReset } from './usePerpsAuth'
 import { perpsWs } from '../sdk/ws'
 import { ensurePerpsWsLifecycle } from './usePerpsWsLifecycle'
@@ -24,6 +26,9 @@ async function fetchPositions() {
     positions.value = res.result ?? []
   } catch (e) {
     error.value = e instanceof Error ? e.message : 'Failed to load positions'
+    capturePerps(PERPS_FEATURE.POSITION, e, {
+      title: 'PERPS: Error fetching positions',
+    })
   } finally {
     loading.value = false
     hasLoaded.value = true

--- a/src/modules/perps/composables/usePerpsStatus.ts
+++ b/src/modules/perps/composables/usePerpsStatus.ts
@@ -1,11 +1,8 @@
 import { computed, getCurrentScope, onScopeDispose, ref } from 'vue'
-import { captureException } from '@sentry/vue'
-import Configs from '@/configs'
-import { SENTRY_MODULE_TAGS } from '@/sentry/constants'
+import { capturePerps } from '../sentry'
+import { PERPS_FEATURE } from '@/sentry/constants'
 import { perpsClient } from '../configs'
 import { PerpsHttpError } from '../sdk/client'
-
-const isDevMode = Configs.IS_DEV_MODE
 
 /**
  * `/status` is unauthenticated and returns a single field, so polling it is
@@ -62,18 +59,10 @@ export async function fetchPerpsStatus(): Promise<number | null> {
     statusCode.value = 200
   } catch (e) {
     statusCode.value = e instanceof PerpsHttpError ? e.status : null
-    if (isDevMode) {
-      console.error('Failed to fetch perps status:', e)
-    } else {
-      captureException(e, {
-        ...SENTRY_MODULE_TAGS.PERPS,
-        extra: {
-          title: 'PERPS: Error fetching service status',
-          httpStatus: statusCode.value,
-          errorMessage: (e as Error).message || 'Unknown error',
-        },
-      })
-    }
+    capturePerps(PERPS_FEATURE.STATUS, e, {
+      title: 'PERPS: Error fetching service status',
+      extra: { httpStatus: statusCode.value },
+    })
   } finally {
     isLoadingStatus.value = false
   }

--- a/src/modules/perps/composables/usePerpsTradeForm.ts
+++ b/src/modules/perps/composables/usePerpsTradeForm.ts
@@ -20,6 +20,8 @@ import type {
 } from '@/analytics'
 import type { MaxOrderSizeResult } from '../sdk/types'
 import { perpsClient } from '../configs'
+import { capturePerps } from '../sentry'
+import { PERPS_FEATURE } from '@/sentry/constants'
 import { usePerpsAuth, usePerpsBalance } from './usePerpsAuth'
 import { usePerpsMarkets, usePerpsContracts } from './usePerpsMarkets'
 import { usePerpsPositions } from './usePerpsPositions'
@@ -706,6 +708,10 @@ export function usePerpsTradeForm() {
         PerpsClosePositionEvent.SUBMIT_FAIL,
         failPayload,
       )
+      capturePerps(PERPS_FEATURE.POSITION, e, {
+        title: 'PERPS: Close position failed',
+        extra: { market: fullMarketName.value },
+      })
     } finally {
       isClosing.value = false
     }
@@ -1136,6 +1142,13 @@ export function usePerpsTradeForm() {
         PerpsChangeLeverageEvent.SUBMIT_FAIL,
         failPayload,
       )
+      capturePerps(PERPS_FEATURE.LEVERAGE, e, {
+        title: 'PERPS: Set leverage failed',
+        extra: {
+          market: fullMarketName.value,
+          newLeverage: tempLeverage.value,
+        },
+      })
     } finally {
       isSavingLeverage.value = false
     }
@@ -1156,7 +1169,10 @@ export function usePerpsTradeForm() {
         leverage.value = Math.min(parsed, marketMaxLeverage.value)
       }
     } catch (e) {
-      console.error('Failed to fetch leverage:', e)
+      capturePerps(PERPS_FEATURE.LEVERAGE, e, {
+        title: 'PERPS: Error fetching leverage',
+        extra: { market: fullMarketName.value },
+      })
     } finally {
       isFetchingLeverage.value = false
     }
@@ -1171,7 +1187,10 @@ export function usePerpsTradeForm() {
         setPercentage(10)
       }
     } catch (e) {
-      console.error('Failed to fetch max order size:', e)
+      capturePerps(PERPS_FEATURE.ORDER, e, {
+        title: 'PERPS: Error fetching max order size',
+        extra: { market: fullMarketName.value },
+      })
     }
   }
 
@@ -1578,6 +1597,14 @@ export function usePerpsTradeForm() {
         PerpsTradeOrderEvent.SUBMIT_FAIL,
         failPayload,
       )
+      capturePerps(PERPS_FEATURE.ORDER, error, {
+        title: 'PERPS: Order creation failed',
+        extra: {
+          market: fullMarketName.value,
+          orderType: orderType.value,
+          side: orderSide.value,
+        },
+      })
     } finally {
       isSubmitting.value = false
     }

--- a/src/modules/perps/sdk/ws.ts
+++ b/src/modules/perps/sdk/ws.ts
@@ -8,6 +8,8 @@ import type {
   WsOutboundFrame,
 } from './wsTypes'
 import { perpsWsUrl } from '../configs'
+import { capturePerps } from '../sentry'
+import { PERPS_FEATURE } from '@/sentry/constants'
 
 const PRIVATE_CHANNELS = new Set<WsChannel>([
   'balancePerps',
@@ -227,7 +229,10 @@ export function createPerpsWs(opts: PerpsWsOptions = {}): PerpsWs {
     let frame: WsInboundFrame
     try {
       frame = JSON.parse(raw) as WsInboundFrame
-    } catch {
+    } catch (e) {
+      capturePerps(PERPS_FEATURE.TRANSPORT, e, {
+        title: 'PERPS: WS frame parse failed',
+      })
       return
     }
     if (frame.type === 'loggedIn') {

--- a/src/modules/perps/sentry.ts
+++ b/src/modules/perps/sentry.ts
@@ -1,0 +1,56 @@
+import { captureException } from '@sentry/vue'
+import Configs from '@/configs'
+import { perpsTags, type PerpsFeature } from '@/sentry/constants'
+import { isUserRejectionError } from '@/utils/walletUtils'
+import { PerpsHttpError, PerpsServiceUnavailableError } from './sdk/client'
+
+const isDevMode = Configs.IS_DEV_MODE
+
+/**
+ * Errors that are already handled elsewhere and are pure noise in Sentry:
+ *  - user rejections (EIP-1193 4001 / "rejected"/"denied"/…) — the user chose
+ *    to cancel; nothing is broken.
+ *  - `PerpsServiceUnavailableError` — the outage is already surfaced by the
+ *    status banner, and gating it stops one report per gated endpoint.
+ *  - 401s — the re-auth path (`onUnauthorized`) already reacts to these.
+ */
+export const isPerpsNoise = (e: unknown): boolean => {
+  if (isUserRejectionError(e)) return true
+  if (e instanceof PerpsServiceUnavailableError) return true
+  if (e instanceof PerpsHttpError && e.status === 401) return true
+  return false
+}
+
+interface CapturePerpsOptions {
+  /** Short human-readable title shown at the top of the Sentry extra block. */
+  title: string
+  /** Extra context — ids, amounts (as strings), http status. Never PII/secrets. */
+  extra?: Record<string, unknown>
+}
+
+/**
+ * Single entry point for reporting a perps failure to Sentry. Tags it with
+ * `module:perps` + `feature:<feature>`, gates out known-noise errors, and in dev
+ * logs to the console instead — so the ~30 perps call sites don't each repeat
+ * the dev-branch and noise-gate boilerplate.
+ */
+export const capturePerps = (
+  feature: PerpsFeature,
+  e: unknown,
+  { title, extra }: CapturePerpsOptions,
+): void => {
+  if (isPerpsNoise(e)) return
+  if (isDevMode) {
+    console.error(`[perps:${feature}] ${title}`, e)
+    return
+  }
+  captureException(e, {
+    ...perpsTags(feature),
+    extra: {
+      title,
+      errorMessage:
+        (e instanceof Error ? e.message : String(e ?? '')) || 'Unknown error',
+      ...extra,
+    },
+  })
+}

--- a/src/sentry/constants.ts
+++ b/src/sentry/constants.ts
@@ -7,3 +7,31 @@ export const SENTRY_MODULE_TAGS = {
   PORTFOLIO: { tags: { module: 'portfolio' } },
   PERPS: { tags: { module: 'perps' } },
 } as const
+
+/**
+ * Per-feature axis for the perps module. `module: 'perps'` stays intact so
+ * existing Sentry searches and alerts keep working; `feature` narrows within it
+ * (`feature:order`, `feature:withdraw`, …) and mirrors the analytics taxonomy in
+ * `analytics/events.ts`. Applied via `perpsTags()` (see `modules/perps/sentry.ts`).
+ */
+export const PERPS_FEATURE = {
+  AUTH: 'auth',
+  DEPOSIT: 'deposit',
+  WITHDRAW: 'withdraw',
+  ORDER: 'order',
+  POSITION: 'position',
+  LEVERAGE: 'leverage',
+  TPSL: 'tpsl',
+  MARKETS: 'markets',
+  PORTFOLIO: 'portfolio',
+  HISTORY: 'history',
+  TRANSPORT: 'transport',
+  STATUS: 'status',
+} as const
+
+export type PerpsFeature = (typeof PERPS_FEATURE)[keyof typeof PERPS_FEATURE]
+
+/** `module:perps` + `feature:<feature>` tags for a Sentry capture context. */
+export const perpsTags = (feature: PerpsFeature) => ({
+  tags: { ...SENTRY_MODULE_TAGS.PERPS.tags, feature },
+})

--- a/tests/unit/modules/perps/sentry.spec.ts
+++ b/tests/unit/modules/perps/sentry.spec.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const captureExceptionSpy = vi.fn()
+vi.mock('@sentry/vue', () => ({
+  captureException: (...args: unknown[]) => captureExceptionSpy(...args),
+}))
+
+// `sentry.ts` reads `Configs.IS_DEV_MODE` once at module load, so the mock
+// exposes it through a getter and each `load()` re-imports a fresh graph with
+// the desired value.
+let devMode = false
+vi.mock('@/configs', () => ({
+  default: {
+    get IS_DEV_MODE() {
+      return devMode
+    },
+  },
+}))
+
+// The noise gate narrows with `instanceof`, so the error classes must come from
+// the SAME module graph as `sentry.ts` — a class imported once at the top would
+// be a different identity after `resetModules`. Hence both are re-imported here.
+const load = async (isDev = false) => {
+  devMode = isDev
+  vi.resetModules()
+  captureExceptionSpy.mockReset()
+  const { PerpsHttpError, PerpsServiceUnavailableError } = await import(
+    '@/modules/perps/sdk/client'
+  )
+  const sentry = await import('@/modules/perps/sentry')
+  const { PERPS_FEATURE, perpsTags } = await import('@/sentry/constants')
+  return { ...sentry, PerpsHttpError, PerpsServiceUnavailableError, PERPS_FEATURE, perpsTags }
+}
+
+describe('perps sentry helper', () => {
+  beforeEach(() => {
+    captureExceptionSpy.mockReset()
+  })
+
+  describe('perpsTags', () => {
+    it('keeps module:perps intact and adds the feature axis', async () => {
+      const { perpsTags, PERPS_FEATURE } = await load()
+      expect(perpsTags(PERPS_FEATURE.ORDER)).toEqual({
+        tags: { module: 'perps', feature: 'order' },
+      })
+    })
+  })
+
+  describe('isPerpsNoise', () => {
+    it('gates user rejections (EIP-1193 4001 and message patterns)', async () => {
+      const { isPerpsNoise } = await load()
+      expect(isPerpsNoise({ code: 4001, message: 'User rejected' })).toBe(true)
+      expect(isPerpsNoise(new Error('User denied transaction signature'))).toBe(
+        true,
+      )
+    })
+
+    it('gates the service-unavailable sentinel (already surfaced by the status banner)', async () => {
+      const { isPerpsNoise, PerpsServiceUnavailableError } = await load()
+      expect(isPerpsNoise(new PerpsServiceUnavailableError())).toBe(true)
+    })
+
+    it('gates 401s (handled by the re-auth path)', async () => {
+      const { isPerpsNoise, PerpsHttpError } = await load()
+      expect(isPerpsNoise(new PerpsHttpError(401, 'Unauthorized'))).toBe(true)
+    })
+
+    it('does NOT gate real failures (5xx, generic errors)', async () => {
+      const { isPerpsNoise, PerpsHttpError } = await load()
+      expect(isPerpsNoise(new PerpsHttpError(500, 'Internal error'))).toBe(false)
+      expect(isPerpsNoise(new PerpsHttpError(400, 'Bad request'))).toBe(false)
+      expect(isPerpsNoise(new Error('boom'))).toBe(false)
+    })
+  })
+
+  describe('capturePerps (production)', () => {
+    it('reports a real failure to Sentry with module + feature tags and extra', async () => {
+      const { capturePerps, PERPS_FEATURE, PerpsHttpError } = await load(false)
+      const err = new PerpsHttpError(500, 'Internal error')
+      capturePerps(PERPS_FEATURE.ORDER, err, {
+        title: 'PERPS: Order creation failed',
+        extra: { market: 'BTC-USD' },
+      })
+      expect(captureExceptionSpy).toHaveBeenCalledTimes(1)
+      const [reported, ctx] = captureExceptionSpy.mock.calls[0]
+      expect(reported).toBe(err)
+      expect(ctx.tags).toEqual({ module: 'perps', feature: 'order' })
+      expect(ctx.extra.title).toBe('PERPS: Order creation failed')
+      expect(ctx.extra.errorMessage).toBe('Internal error')
+      expect(ctx.extra.market).toBe('BTC-USD')
+    })
+
+    it('swallows gated noise without reporting to Sentry', async () => {
+      const { capturePerps, PERPS_FEATURE, PerpsServiceUnavailableError } =
+        await load(false)
+      capturePerps(PERPS_FEATURE.WITHDRAW, new PerpsServiceUnavailableError(), {
+        title: 'PERPS: Withdraw failed',
+      })
+      capturePerps(
+        PERPS_FEATURE.ORDER,
+        { code: 4001, message: 'User rejected' },
+        { title: 'PERPS: Order failed' },
+      )
+      expect(captureExceptionSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('capturePerps (dev mode)', () => {
+    it('never reaches Sentry in dev mode', async () => {
+      const { capturePerps, PERPS_FEATURE, PerpsHttpError } = await load(true)
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      capturePerps(PERPS_FEATURE.ORDER, new PerpsHttpError(500, 'boom'), {
+        title: 'PERPS: Order creation failed',
+      })
+      expect(captureExceptionSpy).not.toHaveBeenCalled()
+      expect(spy).toHaveBeenCalled()
+      spy.mockRestore()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

The perps module had 41 catch blocks but only 3 Sentry call sites — failed orders, withdrawals and deposits produced zero telemetry, so we only heard about them from support tickets. This extends the existing `SENTRY_MODULE_TAGS` convention with a per-feature axis and instruments every meaningful perps failure path against it.

## What changed

- **`src/sentry/constants.ts`** — add `PERPS_FEATURE` (`auth`, `deposit`, `withdraw`, `order`, `position`, `leverage`, `tpsl`, `markets`, `portfolio`, `history`, `transport`, `status`, mirroring the `analytics/events.ts` taxonomy) and a `perpsTags(feature)` helper. `module: 'perps'` is kept intact so existing Sentry searches and alerts keep working; `feature` narrows within it (`feature:order`, `feature:withdraw`, …).
- **`src/modules/perps/sentry.ts`** (new) — `capturePerps(feature, e, { title, extra })`: a single wrapper that tags with `module:perps` + `feature:<feature>`, gates out known noise, and in dev logs to the console instead of reporting, so ~30 call sites don't each repeat that boilerplate. The noise gate (`isPerpsNoise`) drops:
  - user rejections (reuses the shared `isUserRejectionError` — EIP-1193 `4001` / "rejected"/"denied"/…),
  - `PerpsServiceUnavailableError` (the outage is already surfaced by the status banner), and
  - `401`s (already handled by the `onUnauthorized` re-auth path).
- **~34 call sites across 15 files** instrumented: order create/close, set/fetch leverage, max-order-size (`usePerpsTradeForm`), withdraw submit + authorize + address-book/fee reads (`PerpsWithdrawDialog`), deposit tx + address read (`PerpsDepositDialog`), sign-in + auth-reset + account-decrypt + balance/summary (`usePerpsAuth`), markets/contracts (`usePerpsMarkets`), deposits/withdrawals + paginated lists (`usePerpsHistory`, `useCursorPaginate`), portfolio graph + positions (`usePerpsPortfolioGraph`, `usePerpsPositions`), service status (`usePerpsStatus`), WS frame parse (`sdk/ws.ts`), and the market-info / positions-table / order-dialog paths (`ModulePerpInfo`, `PerpsPositionsTable`, `PerpsMarketList`, `PerpsOrderDialog`).
- **Migrated** the 3 existing `captureException` sites (status + two in `PerpsWithdrawDialog`) to the helper.

The four duplicated set-leverage handlers are instrumented as-is; deduping them stays a separate refactor. The multi-address decrypt-fail restore paths, the best-effort mark-price REST seed, and the SDK error-body parse swallow are deliberately left silent (expected/benign, not noise-worthy).

## Testing

- New unit test `tests/unit/modules/perps/sentry.spec.ts` covers the noise gate and the prod/dev branches (**8/8**).
- `pnpm vue-tsc --noEmit` — clean.
- `pnpm lint` on the changed files — clean.

## Out of scope (tracked separately)

- Sandbox smoke that confirms a failed order / failed withdraw land in Sentry with the right `feature` tag (needs a real-DSN build + sandbox).
- Alert rules on `feature:order` and `feature:withdraw` (needs Sentry project admin).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error monitoring across perpetual trading features, including authentication, markets, orders, positions, deposits, withdrawals, portfolio data, and history.
  * Added clearer error context for affected markets, leverage, transaction amounts, tokens, and wallet details.
  * Reduced noisy reporting for expected user rejections and known service or authorization errors.
  * Added monitoring for WebSocket message parsing failures and perps status issues.
* **Tests**
  * Added coverage for error filtering, feature tagging, development behavior, and Sentry reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->