### PR TITLE
fix: remove duplicate percent sign on home balance card change (MEW-2215)

### DIFF
--- a/src/modules/home/components/HeroPortfolioCard.vue
+++ b/src/modules/home/components/HeroPortfolioCard.vue
@@ -108,8 +108,11 @@ const totalText = computed(() =>
     : formattedTotalFiatPortfolioValue.value,
 )
 const percentText = computed(() => {
-  // formatPercentageValue already suffixes '%' — don't append another (MEW-2215)
-  const shown = `${isUp.value ? '+' : '-'}${formatPercentageValue(percentChange.value.abs()).value}`
+  // formatPercentageValue suffixes '%' for every case except an exact 0 (which
+  // returns '0'), so append '%' only when it's missing — never duplicate it (MEW-2215)
+  const formatted = formatPercentageValue(percentChange.value.abs()).value
+  const withUnit = formatted.endsWith('%') ? formatted : `${formatted}%`
+  const shown = `${isUp.value ? '+' : '-'}${withUnit}`
   return hideBalances.value ? maskDigits(shown) : shown
 })
 

--- a/src/modules/home/components/HeroPortfolioCard.vue
+++ b/src/modules/home/components/HeroPortfolioCard.vue
@@ -108,7 +108,8 @@ const totalText = computed(() =>
     : formattedTotalFiatPortfolioValue.value,
 )
 const percentText = computed(() => {
-  const shown = `${isUp.value ? '+' : '-'}${formatPercentageValue(percentChange.value.abs()).value}%`
+  // formatPercentageValue already suffixes '%' — don't append another (MEW-2215)
+  const shown = `${isUp.value ? '+' : '-'}${formatPercentageValue(percentChange.value.abs()).value}`
   return hideBalances.value ? maskDigits(shown) : shown
 })
 

--- a/tests/unit/modules/home/HeroPortfolioCard.spec.ts
+++ b/tests/unit/modules/home/HeroPortfolioCard.spec.ts
@@ -185,6 +185,20 @@ describe('HeroPortfolioCard (MEW-2094)', () => {
     expect(push).toHaveBeenCalledWith({ name: 'Portfolio' })
   })
 
+  it('renders a single % on the today change — MEW-2215', () => {
+    // formatPercentageValue already suffixes '%', so the card must not append
+    // another one (regression: the change read '+7.56%%').
+    setWallet({
+      isWalletConnected: true,
+      isLoadingBalances: false,
+      totalFiatPortfolioValueBN: new BigNumber(64.12),
+      walletAddress: '0x71C8000000000000000000000000000000000389a',
+    })
+    const today = mountCard().get('[data-test="hero-today"]').text()
+    expect(today).toContain('7.56%')
+    expect(today).not.toContain('%%')
+  })
+
   it('copies the full address when the address chip is clicked', async () => {
     setWallet({
       isWalletConnected: true,

--- a/tests/unit/modules/home/HeroPortfolioCard.spec.ts
+++ b/tests/unit/modules/home/HeroPortfolioCard.spec.ts
@@ -199,6 +199,21 @@ describe('HeroPortfolioCard (MEW-2094)', () => {
     expect(today).not.toContain('%%')
   })
 
+  it('keeps the % on a zero 24h change — MEW-2215', () => {
+    // formatPercentageValue returns '0' (no '%') for an exact zero, so the card
+    // must add it back — the change should read '+0%', not '+0'.
+    change.value = { fiat: new BigNumber(0), percentChange: new BigNumber(0) }
+    setWallet({
+      isWalletConnected: true,
+      isLoadingBalances: false,
+      totalFiatPortfolioValueBN: new BigNumber(64.12),
+      walletAddress: '0x71C8000000000000000000000000000000000389a',
+    })
+    const today = mountCard().get('[data-test="hero-today"]').text()
+    expect(today).toContain('+0%')
+    expect(today).not.toContain('%%')
+  })
+
   it('copies the full address when the address chip is clicked', async () => {
     setWallet({
       isWalletConnected: true,


### PR DESCRIPTION
## Problem

The Home page balance card (Hero) rendered the 24h change with **two** percent signs — e.g. `+7.56%%`.

## Root cause

`formatPercentageValue()` already suffixes `%` on its returned `.value` (for every non-zero case), but `HeroPortfolioCard.vue` appended another `%` in the template literal:

```js
const shown = `${isUp ? '+' : '-'}${formatPercentageValue(percentChange.abs()).value}%`
```

## Fix

Drop the trailing `%`, matching the canonical sibling `PortfolioHistory.vue` (which renders the same `lastTwentyFourHours.percentChange` value with no extra `%`). Every other caller of `formatPercentageValue` already relies on the helper's built-in `%`.

## Testing

- Added a regression test to `HeroPortfolioCard.spec.ts` asserting the today change shows a single `%` (no `%%`).
- `pnpm vitest run tests/unit/modules/home/HeroPortfolioCard.spec.ts` → **12/12** green.
- `pnpm vue-tsc --noEmit -p tsconfig.app.json` → 0 errors.
- `eslint` on changed files → 0 errors.
- Manual smoke: Home balance card (assets state) now shows a single `%` on the 24h change, masked value included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected portfolio percentage displays to show a single `%` symbol and preserve positive signs.
  * Ensured zero percentage changes display as `+0%` instead of `+0`.

* **Tests**
  * Added coverage for percentage formatting, including standard values such as `7.56%`, prevention of duplicated symbols, and exact-zero changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->