### PR TITLE
fix: [MEW-2238] guard notification status update against missing status

### DIFF
--- a/src/modules/notifications/ModuleNotifications.vue
+++ b/src/modules/notifications/ModuleNotifications.vue
@@ -550,9 +550,13 @@ type StatusNotificationType = 'transaction' | 'swap' | 'bridge'
 const updateNotificationStatus = (
   hash: string,
   type: StatusNotificationType,
-  apiStatus: { status: string },
+  apiStatus: { status?: string },
 ) => {
   if (!walletAddress.value) return
+  // The status endpoint can return an error/edge payload without a string
+  // `status` (fetch does not throw on non-2xx). Skip and keep polling instead
+  // of crashing on `undefined.toLowerCase()`.
+  if (typeof apiStatus?.status !== 'string') return
   const _status = apiStatus.status.toLowerCase()
   let newStatus: 'sent' | 'confirmed' | 'failed' = 'sent'
 


### PR DESCRIPTION
## What was wrong

On the Portfolio page, the notifications popup polls each pending transaction/swap/bridge for its on-chain status. When the status API returned a payload without a proper `status` value (for example an error/edge response), the app threw `TypeError: Cannot read properties of undefined (reading 'toLowerCase')`. The error was caught and reported to Sentry (`handled`), but as a side effect the affected notification's status silently never updated to Confirmed/Failed.

## What changed

Added a guard at the single place all three notification types funnel through (`updateNotificationStatus`). If the status response has no usable text `status`, we now skip that poll cycle and keep polling, instead of crashing. One file, one function.

- `src/modules/notifications/ModuleNotifications.vue` — skip when `apiStatus.status` isn't a string; param type loosened to `{ status?: string }`.

## How to test

1. Open the dev server and go to `/portfolio` (connect any wallet, e.g. a watch-only address).
2. Trigger a transaction/swap/bridge so a pending notification appears and status polling starts, or open the notifications popup with an existing pending item.
3. Confirm the app no longer throws in the console and the notification updates to Confirmed/Failed once a valid status is returned. A malformed/error status response should no longer crash the poller — it just keeps polling.

## Notes / assumptions (full-auto run)

- Root cause verified from source: `startStatusPolling` → `pollStatus` uses a raw `fetch()` (which does not throw on non-2xx) and passes any truthy JSON to `updateNotificationStatus`; the `if (data)` guard only covered null. The minified Sentry frame `Bi.status.toLowerCase()` maps exactly to line 556.
- No regression test added: the target is a private closure inside the SFC with heavy Pinia/i18n/analytics dependencies; mounting the whole component to reach it would be disproportionate for a one-line guard. Type-check (`vue-tsc`) and lint are green.

## Sentry

https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-1G0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification status handling when the status service returns an incomplete or error response.
  * Prevented notification polling from crashing and ensured it continues while awaiting a valid status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->