### PR TITLE
fix: [MEW-2239] drop "Extension context invalidated" wallet-connect noise

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,7 @@ import rippleDirective from '@/directives/ripple'
 import { autoAnimatePlugin } from '@formkit/auto-animate/vue'
 import configs from '@/configs'
 import {
+  isExtensionContextInvalidatedError,
   isExtensionOrProviderError,
   isForeignStackOverflow,
   isInvalidWalletAddressError,
@@ -87,6 +88,7 @@ if (dsn && process.env.NODE_ENV === 'production') {
     beforeSend(event, hint) {
       const originalException = hint?.originalException
       if (
+        isExtensionContextInvalidatedError(originalException) ||
         isExtensionOrProviderError(originalException) ||
         isInvalidWalletAddressError(originalException) ||
         isMetaMaskSdkDecryptError(originalException) ||

--- a/src/sentry/extensionNoise.ts
+++ b/src/sentry/extensionNoise.ts
@@ -25,6 +25,29 @@ export function isExtensionOrProviderError(err: unknown): boolean {
 }
 
 /**
+ * Whether an error is a Chrome "Extension context invalidated." rejection —
+ * thrown by an injected wallet provider (e.g. Rabby) when the extension's
+ * background context is torn down mid-session (the extension was updated,
+ * reloaded, or disabled while the dApp page stayed open). A pending request
+ * (e.g. `eth_requestAccounts` during connect) then rejects with a raw JSON-RPC
+ * object `{ code: -32603, message: "Extension context invalidated." }`. It is
+ * not app code and MEW can't fix it — the user just reloads so the fresh
+ * extension re-injects — and the connect flow already surfaces a "Failed to
+ * connect" error state, so it is unactionable Sentry noise (APP-MEW-WEB-1JD).
+ * Matched on the (Chrome-provided, un-minified) message, which the serialized
+ * plain-object payload carries at top level; the generic -32603 code alone is
+ * too broad to key on.
+ */
+export function isExtensionContextInvalidatedError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false
+  const message = (err as { message?: unknown }).message
+  return (
+    typeof message === 'string' &&
+    message.toLowerCase().includes('extension context invalidated')
+  )
+}
+
+/**
  * Whether an error is the external "not found rainbowkit" rejection. It is
  * emitted by a wallet's injected in-app-browser detection script (observed on
  * mobile Safari / iOS in-app wallet browsers), never by app code or any bundled

--- a/tests/unit/sentry/extensionNoise.spec.ts
+++ b/tests/unit/sentry/extensionNoise.spec.ts
@@ -4,6 +4,7 @@ import {
   WaitForTransactionReceiptTimeoutError,
 } from 'viem'
 import {
+  isExtensionContextInvalidatedError,
   isExtensionOrProviderError,
   isForeignStackOverflow,
   isInvalidWalletAddressError,
@@ -76,6 +77,54 @@ describe('isExtensionOrProviderError', () => {
     expect(isExtensionOrProviderError(undefined)).toBe(false)
     expect(isExtensionOrProviderError('chrome-extension://x')).toBe(false)
     expect(isExtensionOrProviderError(new Error('plain'))).toBe(false)
+  })
+})
+
+describe('isExtensionContextInvalidatedError', () => {
+  it('is true for the exact production payload (serialized JSON-RPC object)', () => {
+    // APP-MEW-WEB-1JD: the injected Rabby provider rejects a connect request
+    // with a raw object after its extension context was torn down.
+    expect(
+      isExtensionContextInvalidatedError({
+        code: -32603,
+        data: { originalError: {} },
+        message: 'Extension context invalidated.',
+      }),
+    ).toBe(true)
+  })
+
+  it('is true for an Error-object payload and matches regardless of casing/surrounding text', () => {
+    expect(
+      isExtensionContextInvalidatedError(
+        new Error('Extension context invalidated.'),
+      ),
+    ).toBe(true)
+    expect(
+      isExtensionContextInvalidatedError(
+        new Error('Error: extension context invalidated'),
+      ),
+    ).toBe(true)
+  })
+
+  it('is false for a genuine app error', () => {
+    expect(
+      isExtensionContextInvalidatedError(
+        new TypeError("Cannot read properties of undefined (reading 'x')"),
+      ),
+    ).toBe(false)
+    // A different -32603 internal error must NOT be swept up by the code alone.
+    expect(
+      isExtensionContextInvalidatedError({ code: -32603, message: 'Internal' }),
+    ).toBe(false)
+  })
+
+  it('is false for non-object inputs', () => {
+    expect(isExtensionContextInvalidatedError(null)).toBe(false)
+    expect(isExtensionContextInvalidatedError(undefined)).toBe(false)
+    expect(
+      isExtensionContextInvalidatedError('Extension context invalidated.'),
+    ).toBe(false)
+    expect(isExtensionContextInvalidatedError({ message: 42 })).toBe(false)
   })
 })
 


### PR DESCRIPTION
## What was wrong

When a browser-extension wallet (observed with **Rabby** on Chrome) is updated, reloaded, or disabled while the MEW page is still open, its injected provider loses its connection to the extension background. Any connect request in flight (`eth_requestAccounts`) then rejects with a raw Chrome object `{ code: -32603, message: "Extension context invalidated." }`.

The connect flow already handles this for the user (a "Failed to connect" error state is shown), but it also reports the raw object to Sentry via `captureException`. Because it's a plain object rather than an `Error`, Sentry files it as a synthetic crash — "Object captured as exception with keys: code, data, message" — that looks like an app bug but isn't. It's browser-extension teardown noise MEW can't fix (the user just reloads so the fresh extension re-injects).

Sentry: [APP-MEW-WEB-1JD](https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-1JD) — 6 events, 0 users, `handled: yes`, module `access`, transaction `Home`.

## What changed

Added a narrow `isExtensionContextInvalidatedError` predicate to the existing Sentry `beforeSend` noise filter (`src/sentry/extensionNoise.ts`), wired into `main.ts` alongside the other extension/transport predicates. It drops errors whose message contains "Extension context invalidated" and nothing else. The generic `-32603` code is intentionally **not** keyed on (too broad — a real internal error also uses it), so genuine app errors are untouched.

No behavior change for users — only what reaches Sentry changes.

## How to test

This only affects Sentry reporting, so there is no user-visible UI change to verify. Sanity check that the connect flow still works normally:

1. Open the dev server, land on Home.
2. Open the access dialog and connect an injected wallet (e.g. Rabby / MetaMask) on ETHEREUM.
3. Confirm connect succeeds and the wallet-connected toast appears, and that a user-rejected connect still shows the normal "Failed to connect" state.

Automated: `pnpm vitest run tests/unit/sentry/extensionNoise.spec.ts` (new cases cover the exact production payload, an Error-object payload, casing, and that a different `-32603` internal error is **not** dropped). `pnpm vue-tsc --noEmit -p tsconfig.app.json` and ESLint are green.

## Assumptions

- Full-auto sweep: no user confirmation was gathered. Categorized as unactionable browser-extension teardown noise, consistent with the existing `beforeSend` predicates (extension/provider rejections, MetaMask SDK decrypt, Trezor handshake, etc.).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced error-monitoring noise by filtering known browser-extension context invalidation errors.
  * Continued reporting genuine application failures and unrelated internal errors.

* **Tests**
  * Added coverage for matching and non-matching extension errors, including varied message formats and invalid inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->