### PR TITLE
fix: [MEW-2240] drop WalletConnect subscribe-interrupted Sentry noise

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,7 @@ import {
   isRainbowKitNotFoundError,
   isTransactionReceiptTimeoutError,
   isTrezorHandshakeError,
+  isWalletConnectSubscribeInterruptedError,
 } from '@/sentry/extensionNoise'
 import { isTransientRpcError } from '@/modules/trade/composables/transientRpcError'
 
@@ -95,6 +96,11 @@ if (dsn && process.env.NODE_ENV === 'production') {
         isTransactionReceiptTimeoutError(originalException) ||
         isTransientRpcError(originalException) ||
         isTrezorHandshakeError(originalException) ||
+        // WalletConnect relay "Connection interrupted while trying to subscribe"
+        // — a transient relay-WebSocket drop thrown inside @walletconnect/core,
+        // no app frame, already handled by the connect flow (APP-MEW-WEB-61 /
+        // MEW-2240).
+        isWalletConnectSubscribeInterruptedError(originalException) ||
         // iOS injected-script "Maximum call stack" RangeErrors with no app
         // frame — external, unactionable noise (APP-MEW-WEB-BB / MEW-2065).
         isForeignStackOverflow(event)

--- a/src/sentry/extensionNoise.ts
+++ b/src/sentry/extensionNoise.ts
@@ -186,3 +186,24 @@ export function isTransactionReceiptTimeoutError(err: unknown): boolean {
   }
   return false
 }
+
+/**
+ * Whether an error is the WalletConnect relay "Connection interrupted while
+ * trying to subscribe" rejection. Thrown entirely inside `@walletconnect/core`'s
+ * Relayer when the relay WebSocket (`wss://relay.walletconnect.org`) disconnects
+ * mid-(re)connect while it is subscribing to a session topic — an
+ * `onunhandledrejection` that reaches the global Sentry `beforeSend` with no MEW
+ * frame in the stack. The connect flow already handles it (the user can retry),
+ * so it is transient, unactionable network noise (APP-MEW-WEB-61 / MEW-2240).
+ * MEW code never throws this message, so matching on the library-specific
+ * message is safe. Distinct from the sibling `/Subscribing to \w+ failed/` and
+ * "connection is closed" shapes already suppressed elsewhere. Handles both the
+ * Error-object and bare-string payload shapes.
+ */
+export function isWalletConnectSubscribeInterruptedError(err: unknown): boolean {
+  const MESSAGE = 'Connection interrupted while trying to subscribe'
+  if (typeof err === 'string') return err.includes(MESSAGE)
+  if (!err || typeof err !== 'object') return false
+  const message = (err as { message?: unknown }).message
+  return typeof message === 'string' && message.includes(MESSAGE)
+}

--- a/tests/unit/sentry/extensionNoise.spec.ts
+++ b/tests/unit/sentry/extensionNoise.spec.ts
@@ -12,6 +12,7 @@ import {
   isRainbowKitNotFoundError,
   isTransactionReceiptTimeoutError,
   isTrezorHandshakeError,
+  isWalletConnectSubscribeInterruptedError,
 } from '@/sentry/extensionNoise'
 
 describe('isExtensionOrProviderError', () => {
@@ -403,6 +404,52 @@ describe('isRainbowKitNotFoundError', () => {
     expect(isRainbowKitNotFoundError(undefined)).toBe(false)
     expect(isRainbowKitNotFoundError({ message: 42 })).toBe(false)
     expect(isRainbowKitNotFoundError('something else')).toBe(false)
+  })
+})
+
+describe('isWalletConnectSubscribeInterruptedError', () => {
+  const MSG = 'Connection interrupted while trying to subscribe'
+
+  it('drops the @walletconnect/core relay rejection (APP-MEW-WEB-61)', () => {
+    // The exact production trigger: the relay WebSocket disconnects mid-connect
+    // and the Relayer rejects with `new Error(...)`.
+    expect(isWalletConnectSubscribeInterruptedError(new Error(MSG))).toBe(true)
+  })
+
+  it('is true for the serialized production payload (plain object with message)', () => {
+    expect(isWalletConnectSubscribeInterruptedError({ message: MSG })).toBe(true)
+  })
+
+  it('is true for a bare-string rejection', () => {
+    expect(isWalletConnectSubscribeInterruptedError(MSG)).toBe(true)
+    expect(isWalletConnectSubscribeInterruptedError(`Error: ${MSG}`)).toBe(true)
+  })
+
+  it('does NOT over-match the sibling "Subscribing to X failed" shape', () => {
+    expect(
+      isWalletConnectSubscribeInterruptedError(
+        new Error('Subscribing to abc123 failed, please try again'),
+      ),
+    ).toBe(false)
+  })
+
+  it('is false for a genuine app error', () => {
+    expect(
+      isWalletConnectSubscribeInterruptedError(
+        new TypeError("Cannot read properties of undefined (reading 'x')"),
+      ),
+    ).toBe(false)
+    expect(
+      isWalletConnectSubscribeInterruptedError(new Error('Connection is closed')),
+    ).toBe(false)
+  })
+
+  it('is false for non-matching inputs', () => {
+    expect(isWalletConnectSubscribeInterruptedError(null)).toBe(false)
+    expect(isWalletConnectSubscribeInterruptedError(undefined)).toBe(false)
+    expect(isWalletConnectSubscribeInterruptedError({})).toBe(false)
+    expect(isWalletConnectSubscribeInterruptedError({ message: 42 })).toBe(false)
+    expect(isWalletConnectSubscribeInterruptedError('something else')).toBe(false)
   })
 })
 


### PR DESCRIPTION
## What was wrong

Sentry issue [APP-MEW-WEB-61](https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-61) reports `Error: Connection interrupted while trying to subscribe` (269 events, 0 users, `handled: no`) on the `/access` route. It is thrown entirely inside `@walletconnect/core`'s Relayer when the relay WebSocket (`wss://relay.walletconnect.org`) disconnects mid-(re)connect while it is subscribing to a session topic — an unhandled promise rejection with no MEW frame in the stack. The connect flow already handles it (the user can retry), so it is pure transient network noise cluttering Sentry.

## What changed

Noise-suppression only — **no functional change**.

- New narrow predicate `isWalletConnectSubscribeInterruptedError` in `src/sentry/extensionNoise.ts`, matching only this library-specific message (handles both the `Error` object and bare-string payload shapes).
- Wired into the Sentry `beforeSend` hook in `src/main.ts` so the event is dropped before it reaches Sentry.
- Unit tests in `tests/unit/sentry/extensionNoise.spec.ts` proving the predicate matches this shape and does **not** over-match genuine app errors or the sibling `Subscribing to X failed` / `Connection is closed` shapes.

## Assumptions / decisions (full-auto run, no user confirmation)

- Chose the tested-predicate + `beforeSend` pattern (consistent with the existing `extensionNoise.ts` predicates like `isForeignStackOverflow`) over a plain `ignoreErrors` regex, so the match is unit-tested against over-matching. Message-only matching (no stack-frame requirement) was deliberate: production stacks are hashed bundles (`assets/index.es-*.js`) with no readable `@walletconnect` string, and MEW code never throws this exact message — mirroring the existing `isTrezorHandshakeError` / `isRainbowKitNotFoundError` precedent.
- Confirmed the message is not already suppressed: the existing `ignoreErrors` entry `/Subscribing to \w+ failed, please try again/` and `isTransientRpcError` (`connection is closed`) are different shapes.

## How to test

This is Sentry-only noise suppression, so there is nothing new to see in the UI — verification is the automated suite:

- `pnpm vitest run tests/unit/sentry/extensionNoise.spec.ts` (49 passing, incl. the new `isWalletConnectSubscribeInterruptedError` block).
- `pnpm vue-tsc --noEmit -p tsconfig.app.json` (clean).
- Smoke: load `/access`, start a WalletConnect connection, confirm the connect flow still works normally (no behavior change). The suppression only affects what is forwarded to Sentry.

## Sentry

https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-61

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced monitoring noise by filtering transient WalletConnect subscription interruption errors from error reports.
  * Preserved reporting for genuine application errors and unrelated failures.

* **Tests**
  * Added coverage for WalletConnect interruption errors across supported error formats and non-matching cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->