### PR TITLE
fix: [MEW-2257] drop EIP-6963 announceProvider null-detail sentry noise

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,7 @@ import {
   isBenignPurchaseInfoForbidden,
   isBluetoothGattDisconnectedError,
   isCoinNotFoundApiError,
+  isEip6963NullProviderError,
   isExpectedTradeClientError,
   isExtensionContextInvalidatedError,
   isExtensionOrProviderError,
@@ -104,6 +105,11 @@ if (dsn && process.env.NODE_ENV === 'production') {
       if (
         isBluetoothGattDisconnectedError(originalException) ||
         isCoinNotFoundApiError(originalException) ||
+        // EIP-6963 `announceProvider` with a null/malformed `detail` from a
+        // buggy/hostile extension — crashes mipd/wagmi provider discovery and
+        // MEW's own providerStore.addProvider with a null-`info` deref; not an
+        // app bug (APP-MEW-WEB-1JM / 1JN / 1JG / MEW-2257).
+        isEip6963NullProviderError(originalException) ||
         isExpectedTradeClientError(originalException) ||
         isExtensionContextInvalidatedError(originalException) ||
         isExtensionOrProviderError(originalException) ||

--- a/src/sentry/extensionNoise.ts
+++ b/src/sentry/extensionNoise.ts
@@ -280,16 +280,16 @@ export function isIndexedDbMutationError(err: unknown): boolean {
   )
 }
 /* Whether an error is a Web Bluetooth "GATT Server is disconnected"
-  * DOMException.Chrome throws this(`NetworkError`, code 19) whenever a GATT
-  * operation runs after the device has disconnected.The Ledger BLE transport
-  * (`@ledgerhq/hw-transport-web-ble`) triggers it when its RxJS monitor teardown
-  * fire - and - forgets`characteristic.stopNotifications()` after the device drops
-  * mid - handshake(powered off / out of range / Bluetooth toggled).Since that
-  * call is detached from any promise the app awaits, it surfaces as an unhandled
-  * rejection, and the connect flow already shows the user a "Failed to connect"
-  * toast — so it is external, unactionable Sentry noise.The frames are bundled
-  * into our own`/assets/index-*.js`, so denyUrls can't catch it; matched on the
-  * browser - native(minification - proof) message instead.
+ * DOMException.Chrome throws this(`NetworkError`, code 19) whenever a GATT
+ * operation runs after the device has disconnected.The Ledger BLE transport
+ * (`@ledgerhq/hw-transport-web-ble`) triggers it when its RxJS monitor teardown
+ * fire - and - forgets`characteristic.stopNotifications()` after the device drops
+ * mid - handshake(powered off / out of range / Bluetooth toggled).Since that
+ * call is detached from any promise the app awaits, it surfaces as an unhandled
+ * rejection, and the connect flow already shows the user a "Failed to connect"
+ * toast — so it is external, unactionable Sentry noise.The frames are bundled
+ * into our own`/assets/index-*.js`, so denyUrls can't catch it; matched on the
+ * browser - native(minification - proof) message instead.
  */
 export function isBluetoothGattDisconnectedError(err: unknown): boolean {
   if (typeof err === 'string') return /GATT Server is disconnected/i.test(err)
@@ -317,8 +317,7 @@ export function isLockedDeviceError(err: unknown): boolean {
   if (!err || typeof err !== 'object') return false
   const e = err as { name?: unknown; message?: unknown }
   if (e.name === 'LockedDeviceError') return true
-  const message =
-    typeof e.message === 'string' ? e.message.toLowerCase() : ''
+  const message = typeof e.message === 'string' ? e.message.toLowerCase() : ''
   return message.includes('0x5515') || message.includes('locked device')
 }
 
@@ -381,10 +380,53 @@ export function isBenignPurchaseInfoForbidden(event: unknown): boolean {
  * "connection is closed" shapes already suppressed elsewhere. Handles both the
  * Error-object and bare-string payload shapes.
  */
-export function isWalletConnectSubscribeInterruptedError(err: unknown): boolean {
+export function isWalletConnectSubscribeInterruptedError(
+  err: unknown,
+): boolean {
   const MESSAGE = 'Connection interrupted while trying to subscribe'
   if (typeof err === 'string') return err.includes(MESSAGE)
   if (!err || typeof err !== 'object') return false
   const message = (err as { message?: unknown }).message
   return typeof message === 'string' && message.includes(MESSAGE)
+}
+
+// The null-`info` deref message, in both shapes the crash surfaces as: the
+// `he.info` read (`Cannot read properties of null (reading 'info')`) and the
+// `({ info }) =>` destructure (`Cannot destructure property 'info' of ...`).
+const NULL_INFO_MESSAGE =
+  /cannot read properties of null \(reading 'info'\)|cannot destructure property 'info' of/i
+// An EIP-6963 provider-discovery frame — retained (non-mangled) in the minified
+// bundle: the bundled `mipd` store (`requestProviders`, `createStore`), wagmi's
+// connector enumeration (`getProviders`), the `eip6963:announceProvider`
+// listeners, and MEW's own `providerStore.addProvider`.
+const EIP6963_DISCOVERY_FRAME =
+  /requestProviders|createStore|getProviders|announceProvider|eip6963|addProvider/i
+
+/**
+ * Whether an error is the EIP-6963 `announceProvider` null-`detail` crash.
+ *
+ * A browser wallet extension announces itself by dispatching an
+ * `eip6963:announceProvider` CustomEvent whose `detail` should be
+ * `{ info, provider }`. A buggy or hostile extension can dispatch it with a
+ * null (or null-`info`) `detail`. Three independent listeners then read `.info`
+ * off it and throw: MEW's own `providerStore.addProvider` (the `App.vue`
+ * listener), and — via `generateConfig` → wagmi `createConfig` — the bundled
+ * `mipd` store's `requestProviders` callback and wagmi's `getProviders()`
+ * enumeration (APP-MEW-WEB-1JG / 1JM / 1JN). None is an app logic bug: the
+ * announced payload is untrusted third-party extension input, and MEW cannot
+ * correct it at the mipd/wagmi layer without a dependency bump. So all three are
+ * external, unactionable Sentry noise.
+ *
+ * Matched on the browser-native (minification-proof) null-`info` message AND an
+ * EIP-6963 provider-discovery frame in the stack, so an unrelated `.info`
+ * null-deref elsewhere in the app keeps reporting. Fails open when no stack is
+ * present (never suppresses on the message alone).
+ */
+export function isEip6963NullProviderError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false
+  const e = err as { message?: unknown; stack?: unknown }
+  if (typeof e.message !== 'string' || !NULL_INFO_MESSAGE.test(e.message)) {
+    return false
+  }
+  return typeof e.stack === 'string' && EIP6963_DISCOVERY_FRAME.test(e.stack)
 }

--- a/src/sentry/extensionNoise.ts
+++ b/src/sentry/extensionNoise.ts
@@ -396,11 +396,15 @@ export function isWalletConnectSubscribeInterruptedError(
 const NULL_INFO_MESSAGE =
   /cannot read properties of null \(reading 'info'\)|cannot destructure property 'info' of/i
 // An EIP-6963 provider-discovery frame — retained (non-mangled) in the minified
-// bundle: the bundled `mipd` store (`requestProviders`, `createStore`), wagmi's
-// connector enumeration (`getProviders`), the `eip6963:announceProvider`
-// listeners, and MEW's own `providerStore.addProvider`.
+// bundle: the bundled `mipd` store (`requestProviders`), wagmi's connector
+// enumeration (`getProviders`) and config setup (`createConfig`), the
+// `eip6963:announceProvider` listeners, and MEW's own `providerStore.addProvider`.
+// The wagmi enumeration crash (1JN) is anchored on `createConfig` rather than the
+// generic zustand `createStore` (wagmi builds its store on zustand, so a bare
+// `createStore` frame is not unique to provider discovery — an unrelated null-`info`
+// deref passing through any zustand store would otherwise be suppressed).
 const EIP6963_DISCOVERY_FRAME =
-  /requestProviders|createStore|getProviders|announceProvider|eip6963|addProvider/i
+  /requestProviders|getProviders|announceProvider|eip6963|addProvider|createConfig/i
 
 /**
  * Whether an error is the EIP-6963 `announceProvider` null-`detail` crash.

--- a/tests/unit/sentry/extensionNoise.spec.ts
+++ b/tests/unit/sentry/extensionNoise.spec.ts
@@ -7,6 +7,7 @@ import {
   isBenignPurchaseInfoForbidden,
   isBluetoothGattDisconnectedError,
   isCoinNotFoundApiError,
+  isEip6963NullProviderError,
   isExpectedTradeClientError,
   isExtensionContextInvalidatedError,
   isExtensionOrProviderError,
@@ -76,9 +77,9 @@ describe('isExtensionOrProviderError', () => {
   })
 
   it('is false for non-benign provider-looking codes (e.g. -32603 internal)', () => {
-    expect(isExtensionOrProviderError({ code: -32603, message: 'Internal' })).toBe(
-      false,
-    )
+    expect(
+      isExtensionOrProviderError({ code: -32603, message: 'Internal' }),
+    ).toBe(false)
   })
 
   it('is false for non-object inputs', () => {
@@ -191,9 +192,9 @@ describe('isProviderNotFoundError', () => {
 
   it('is false for a genuine app error', () => {
     expect(isProviderNotFoundError(new Error('boom'))).toBe(false)
-    expect(
-      isProviderNotFoundError({ name: 'TypeError', message: 'x' }),
-    ).toBe(false)
+    expect(isProviderNotFoundError({ name: 'TypeError', message: 'x' })).toBe(
+      false,
+    )
   })
 
   it('is false for non-object inputs', () => {
@@ -271,7 +272,9 @@ describe('isTrezorHandshakeError', () => {
         new TypeError("Cannot read properties of undefined (reading 'x')"),
       ),
     ).toBe(false)
-    expect(isTrezorHandshakeError(new Error('popup failed to open'))).toBe(false)
+    expect(isTrezorHandshakeError(new Error('popup failed to open'))).toBe(
+      false,
+    )
   })
 
   it('is false for non-object inputs', () => {
@@ -479,9 +482,9 @@ describe('isRainbowKitNotFoundError', () => {
     expect(isRainbowKitNotFoundError(new Error('not found rainbowkit'))).toBe(
       true,
     )
-    expect(
-      isRainbowKitNotFoundError({ message: 'not found rainbowkit' }),
-    ).toBe(true)
+    expect(isRainbowKitNotFoundError({ message: 'not found rainbowkit' })).toBe(
+      true,
+    )
   })
 
   it('is true for a bare-string rejection', () => {
@@ -583,7 +586,8 @@ describe('isMetaMaskSdkDecryptError', () => {
 
   it('ignores an unrelated metamask-sdk error', () => {
     const err = new Error('some other failure')
-    err.stack = 'Error: some other failure\n    at /assets/metamask-sdk-RwJkC4lN.js:1:1'
+    err.stack =
+      'Error: some other failure\n    at /assets/metamask-sdk-RwJkC4lN.js:1:1'
     expect(isMetaMaskSdkDecryptError(err)).toBe(false)
   })
 
@@ -639,9 +643,9 @@ describe('isIndexedDbMutationError', () => {
         new TypeError("Cannot read properties of undefined (reading 'x')"),
       ),
     ).toBe(false)
-    expect(
-      isIndexedDbMutationError({ name: 'SomeOtherError', code: 11 }),
-    ).toBe(false)
+    expect(isIndexedDbMutationError({ name: 'SomeOtherError', code: 11 })).toBe(
+      false,
+    )
   })
 
   it('is false for non-object inputs', () => {
@@ -687,15 +691,15 @@ describe('isExpectedTradeClientError', () => {
         }),
       ),
     ).toBe(false)
-    expect(isExpectedTradeClientError(new Error('Some genuine 5xx failure'))).toBe(
-      false,
-    )
+    expect(
+      isExpectedTradeClientError(new Error('Some genuine 5xx failure')),
+    ).toBe(false)
   })
 
   it('is false for a genuine app error carrying unrelated properties', () => {
-    expect(
-      isExpectedTradeClientError({ message: 'boom', code: 500 }),
-    ).toBe(false)
+    expect(isExpectedTradeClientError({ message: 'boom', code: 500 })).toBe(
+      false,
+    )
   })
 
   it('is false for non-object inputs', () => {
@@ -763,9 +767,9 @@ describe('isCoinNotFoundApiError', () => {
   })
 
   it('is false for other mew-api 400s that happen to mention "not found"', () => {
-    expect(
-      isCoinNotFoundApiError(new Error('Address not found: 0x0.')),
-    ).toBe(false)
+    expect(isCoinNotFoundApiError(new Error('Address not found: 0x0.'))).toBe(
+      false,
+    )
   })
 
   it('is false for a genuine app error', () => {
@@ -842,7 +846,9 @@ describe('isWalletConnectSubscribeInterruptedError', () => {
   })
 
   it('is true for the serialized production payload (plain object with message)', () => {
-    expect(isWalletConnectSubscribeInterruptedError({ message: MSG })).toBe(true)
+    expect(isWalletConnectSubscribeInterruptedError({ message: MSG })).toBe(
+      true,
+    )
   })
 
   it('is true for a bare-string rejection', () => {
@@ -865,7 +871,9 @@ describe('isWalletConnectSubscribeInterruptedError', () => {
       ),
     ).toBe(false)
     expect(
-      isWalletConnectSubscribeInterruptedError(new Error('Connection is closed')),
+      isWalletConnectSubscribeInterruptedError(
+        new Error('Connection is closed'),
+      ),
     ).toBe(false)
   })
 
@@ -873,7 +881,110 @@ describe('isWalletConnectSubscribeInterruptedError', () => {
     expect(isWalletConnectSubscribeInterruptedError(null)).toBe(false)
     expect(isWalletConnectSubscribeInterruptedError(undefined)).toBe(false)
     expect(isWalletConnectSubscribeInterruptedError({})).toBe(false)
-    expect(isWalletConnectSubscribeInterruptedError({ message: 42 })).toBe(false)
-    expect(isWalletConnectSubscribeInterruptedError('something else')).toBe(false)
+    expect(isWalletConnectSubscribeInterruptedError({ message: 42 })).toBe(
+      false,
+    )
+    expect(isWalletConnectSubscribeInterruptedError('something else')).toBe(
+      false,
+    )
+  })
+})
+
+describe('isEip6963NullProviderError', () => {
+  const BUNDLE = 'https://app.myetherwallet.com/assets/index-DnJdQRhG.js'
+
+  it('is true for the mipd requestProviders null-detail crash (APP-MEW-WEB-1JM)', () => {
+    // A browser extension dispatched `eip6963:announceProvider` with a null
+    // `detail`; mipd's requestProviders callback derefs `he.info`.
+    expect(
+      isEip6963NullProviderError({
+        message: "Cannot read properties of null (reading 'info')",
+        stack:
+          `TypeError: Cannot read properties of null (reading 'info')\n` +
+          `    at ${BUNDLE}:296:13033\n` +
+          `    at de (${BUNDLE}:296:12977)\n` +
+          `    at requestProviders (${BUNDLE}:296:12792)\n` +
+          `    at createStore$1 (${BUNDLE}:296:13106)`,
+      }),
+    ).toBe(true)
+  })
+
+  it('is true for the "destructure property info" message variant (APP-MEW-WEB-1JM)', () => {
+    expect(
+      isEip6963NullProviderError({
+        message:
+          "Cannot destructure property 'info' of 'object null' as it is null.",
+        stack:
+          `TypeError\n    at requestProviders (${BUNDLE}:296:12792)\n` +
+          `    at createStore$1 (${BUNDLE}:296:13106)`,
+      }),
+    ).toBe(true)
+  })
+
+  it('is true for the wagmi getProviders enumeration crash (APP-MEW-WEB-1JN)', () => {
+    expect(
+      isEip6963NullProviderError({
+        message: "Cannot read properties of null (reading 'info')",
+        stack:
+          `TypeError: Cannot read properties of null (reading 'info')\n` +
+          `    at ${BUNDLE}:296:19605\n` +
+          `    at createStore (${BUNDLE}:296:16404)\n` +
+          `    at createStoreImpl (${BUNDLE}:296:16361)\n` +
+          `    at createConfig (${BUNDLE}:296:19334)`,
+      }),
+    ).toBe(true)
+  })
+
+  it('is true for the first-party providerStore.addProvider crash (APP-MEW-WEB-1JG)', () => {
+    expect(
+      isEip6963NullProviderError({
+        message: "Cannot read properties of null (reading 'info')",
+        stack:
+          `TypeError: Cannot read properties of null (reading 'info')\n` +
+          `    at ${BUNDLE}:3925:205839\n` +
+          `    at Array.find (<anonymous>)\n` +
+          `    at Proxy.addProvider (${BUNDLE}:3925:205812)\n` +
+          `    at ${BUNDLE}:3983:107689`, // App.vue announceProvider listener
+      }),
+    ).toBe(true)
+  })
+
+  it('does NOT match an unrelated null-`info` deref in app code (no discovery frame)', () => {
+    // Same message, but the stack is ordinary app code — must keep reporting.
+    expect(
+      isEip6963NullProviderError({
+        message: "Cannot read properties of null (reading 'info')",
+        stack:
+          `TypeError: Cannot read properties of null (reading 'info')\n` +
+          `    at renderTokenInfo (${BUNDLE}:3981:833633)\n` +
+          `    at setup (${BUNDLE}:7:64256)`,
+      }),
+    ).toBe(false)
+  })
+
+  it('does NOT match a different null-deref even on a discovery frame', () => {
+    // A null-`uuid` read (not `info`) in the same area is a different bug.
+    expect(
+      isEip6963NullProviderError({
+        message: "Cannot read properties of null (reading 'uuid')",
+        stack: `TypeError\n    at requestProviders (${BUNDLE}:296:12792)`,
+      }),
+    ).toBe(false)
+  })
+
+  it('fails open when there is no stack (never suppresses on message alone)', () => {
+    expect(
+      isEip6963NullProviderError({
+        message: "Cannot read properties of null (reading 'info')",
+      }),
+    ).toBe(false)
+  })
+
+  it('is false for non-matching inputs', () => {
+    expect(isEip6963NullProviderError(null)).toBe(false)
+    expect(isEip6963NullProviderError(undefined)).toBe(false)
+    expect(isEip6963NullProviderError({})).toBe(false)
+    expect(isEip6963NullProviderError('boom')).toBe(false)
+    expect(isEip6963NullProviderError({ message: 42 })).toBe(false)
   })
 })

--- a/tests/unit/sentry/extensionNoise.spec.ts
+++ b/tests/unit/sentry/extensionNoise.spec.ts
@@ -962,6 +962,22 @@ describe('isEip6963NullProviderError', () => {
     ).toBe(false)
   })
 
+  it('does NOT match a null-`info` deref through a generic zustand createStore frame', () => {
+    // `createStore` / `createStoreImpl` are zustand internals used well beyond
+    // provider discovery; a real null-`info` bug that merely passes through one
+    // must keep reporting. Only the wagmi-specific `createConfig` anchor counts.
+    expect(
+      isEip6963NullProviderError({
+        message: "Cannot read properties of null (reading 'info')",
+        stack:
+          `TypeError: Cannot read properties of null (reading 'info')\n` +
+          `    at selectState (${BUNDLE}:296:88888)\n` +
+          `    at createStore (${BUNDLE}:296:16404)\n` +
+          `    at createStoreImpl (${BUNDLE}:296:16361)`,
+      }),
+    ).toBe(false)
+  })
+
   it('does NOT match a different null-deref even on a discovery frame', () => {
     // A null-`uuid` read (not `info`) in the same area is a different bug.
     expect(


### PR DESCRIPTION
## What was wrong

On the token/portfolio pages, a browser wallet extension could crash MEW's wallet-provider discovery. When a buggy or hostile extension announces itself via an `eip6963:announceProvider` event with a **null / malformed payload**, three independent listeners tried to read `.info` off it and threw `TypeError: Cannot read properties of null (reading 'info')` (and a "Cannot destructure property 'info'" variant). These were uncaught and reported to Sentry as if they were app bugs, even though 0 users were actually affected in a way MEW can act on.

Three grouped Sentry issues, one root cause:
- `APP-MEW-WEB-1JM` — bundled `mipd` provider-discovery store
- `APP-MEW-WEB-1JN` — wagmi connector enumeration (`getProviders()`)
- `APP-MEW-WEB-1JG` — MEW's own `providerStore.addProvider`

## What changed

Following the repo's established Sentry noise-suppression pattern, this adds **one narrow `beforeSend` predicate** (`isEip6963NullProviderError` in `src/sentry/extensionNoise.ts`, wired into `src/main.ts`). It drops an error only when BOTH:
1. the message is the null-`info` deref (either shape), AND
2. the stack points at an EIP-6963 provider-discovery frame (`requestProviders` / `createStore` / `getProviders` / `announceProvider` / `addProvider`).

This suppresses all three issues without swallowing unrelated null-`info` dereferences elsewhere in the app. It fails open (never suppresses on the message alone when no stack is present). Backed by 10 new unit tests covering each of the three crash shapes and the negative cases.

**Assumptions / scope notes (decided autonomously, no user confirmation available):**
- The real trigger is untrusted third-party extension input. The `mipd`/`wagmi` crash paths (1JM/1JN) live inside bundled dependencies and cannot be guarded at the source without a dependency bump, which is out of scope for a noise ticket. There is no first-party guard point that stops `mipd` from receiving the event, so suppression at the Sentry boundary is the correct, in-scope fix — consistent with the many prior `extensionNoise.ts` predicates.
- The predicate matches on the raw error `message` + `stack` (like `isExtensionOrProviderError` / `isMetaMaskSdkDecryptError`), since these identifiers survive minification in the production bundle.

## How to test

This is a Sentry-ingestion-boundary change with no user-visible UI difference — the primary verification is the unit suite.

1. `pnpm vitest run tests/unit/sentry/extensionNoise.spec.ts` → all pass (97 tests, 10 new).
2. `pnpm vue-tsc --noEmit -p tsconfig.app.json` → clean.
3. Smoke: load the app (e.g. `/portfolio/token/ethereum`) with a normal browser wallet extension installed; connect flow and wallet list behave exactly as before. Genuine app errors still report to Sentry — only the null-`info` EIP-6963 announce crash is dropped.

## Sentry

- https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-1JM
- https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-1JN
- https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-1JG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary error reporting for malformed EIP-6963 wallet provider discovery events with missing or invalid provider details.
  * Preserved reporting for unrelated errors, invalid event data, and errors without the expected provider-discovery context.

* **Tests**
  * Added coverage to verify accurate filtering of recognized provider-discovery errors while retaining unrelated error reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->