### PR TITLE
fix: [MEW-2256] sign legacy txs with hardware wallet on non-EIP-1559 chains

### DIFF
--- a/src/providers/ethereum/evmHardwareWallet.ts
+++ b/src/providers/ethereum/evmHardwareWallet.ts
@@ -1,5 +1,5 @@
 import { bytesToHex } from 'web3-utils'
-import { FeeMarketEIP1559Transaction } from '@ethereumjs/tx'
+import { FeeMarketEIP1559Transaction, LegacyTransaction } from '@ethereumjs/tx'
 import { commonGenerator } from './utils'
 import { Hardfork } from '@ethereumjs/common'
 import { fromRpcSig, hexToBytes } from '@ethereumjs/util'
@@ -51,13 +51,25 @@ export default class EvmHardwareWallet extends BaseEvmWallet {
     serializedTx: HexPrefixedString,
   ): Promise<PostSignedTransaction> {
     try {
-      const common = commonGenerator(BigInt(this.chainId), Hardfork.London)
-      const tx = FeeMarketEIP1559Transaction.fromSerializedTx(
-        hexToBytes(serializedTx),
-        { common },
-      )
+      const bytes = hexToBytes(serializedTx)
+      // Non-EIP-1559 chains (e.g. Rootstock) return a legacy type-0 tx whose
+      // first byte is an RLP list prefix, which the EIP-1559 class rejects;
+      // try 1559 first, then fall back to LegacyTransaction.
+      let tx: FeeMarketEIP1559Transaction | LegacyTransaction
+      try {
+        tx = FeeMarketEIP1559Transaction.fromSerializedTx(bytes, {
+          common: commonGenerator(BigInt(this.chainId), Hardfork.London),
+        })
+      } catch {
+        tx = LegacyTransaction.fromSerializedTx(bytes, {
+          common: commonGenerator(BigInt(this.chainId), Hardfork.Berlin),
+        })
+      }
       const walletSig = (await this.hwWalletInstance.signTransaction({
-        transaction: tx,
+        // The Trezor signer (@enkryptcom/hw-wallets) accepts a LegacyTransaction;
+        // the cast only works around the narrower Eth type on the LedgerManager
+        // arm of the HWManager union.
+        transaction: tx as FeeMarketEIP1559Transaction,
         networkName: this.networkName as NetworkNames,
         pathIndex: this.index,
         pathType: {

--- a/tests/unit/providers/ethereum/evmHardwareWallet.spec.ts
+++ b/tests/unit/providers/ethereum/evmHardwareWallet.spec.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  FeeMarketEIP1559Transaction,
+  LegacyTransaction,
+} from '@ethereumjs/tx'
+import { Common } from '@ethereumjs/common'
+import { bytesToHex } from '@ethereumjs/util'
+import { HWwalletType } from '@enkryptcom/types'
+
+// Importing the wallet transitively pulls in the store/analytics layer, whose
+// hardware-wallet SDK is unavailable under jsdom (mirrors baseEvmWallet.spec).
+vi.mock('@/analytics', () => ({ analytics: {} }))
+vi.mock('@/mew_api/fetchWithRetry', () => ({ fetchWithRetry: vi.fn() }))
+
+import EvmHardwareWallet from '@/providers/ethereum/evmHardwareWallet'
+import type { HexPrefixedString } from '@/providers/types'
+import type { HWManager } from '@/providers/hw/types'
+
+// A syntactically valid 65-byte signature (r || s || v). r/s are well below the
+// secp256k1 order so ethereumjs accepts them; only the shape matters here.
+const FAKE_SIG = ('0x' + '11'.repeat(32) + '22'.repeat(32) + '1c') as HexPrefixedString
+
+// Build an unsigned serialized tx of each type, as the MEW API would hand it.
+const legacySerialized = (chainId: number): HexPrefixedString =>
+  bytesToHex(
+    LegacyTransaction.fromTxData(
+      { nonce: 1, gasPrice: 1_000_000_000, gasLimit: 21_000, to: `0x${'ab'.repeat(20)}`, value: 1 },
+      { common: Common.custom({ chainId }) },
+    ).serialize(),
+  ) as HexPrefixedString
+
+const eip1559Serialized = (chainId: number): HexPrefixedString =>
+  bytesToHex(
+    FeeMarketEIP1559Transaction.fromTxData(
+      { nonce: 1, maxFeePerGas: 1_000_000_000, maxPriorityFeePerGas: 1, gasLimit: 21_000, to: `0x${'ab'.repeat(20)}`, value: 1 },
+      { common: Common.custom({ chainId }) },
+    ).serialize(),
+  ) as HexPrefixedString
+
+const makeWallet = (chainId: string) => {
+  const signTransaction = vi.fn().mockResolvedValue(FAKE_SIG)
+  const hwWalletInstance = { signTransaction } as unknown as HWManager
+  const wallet = new EvmHardwareWallet(
+    chainId,
+    `0x${'cd'.repeat(20)}` as HexPrefixedString,
+    'ROOTSTOCK',
+    '0',
+    { path: "m/44'/137'/0'/0/0", label: 'test', basePath: "m/44'/137'/0'/0" },
+    HWwalletType.trezor,
+    hwWalletInstance,
+  )
+  return { wallet, signTransaction }
+}
+
+describe('EvmHardwareWallet.SignTransaction — legacy tx fallback (MEW-2256)', () => {
+  it('signs a legacy (type-0) tx on a non-EIP-1559 chain like Rootstock (chainId 30)', async () => {
+    const { wallet, signTransaction } = makeWallet('30')
+
+    const result = await wallet.SignTransaction(legacySerialized(30))
+
+    // Regression: previously threw "not an EIP-1559 transaction (…received: 0xeb)".
+    expect(result.signed).toMatch(/^0x/)
+    // The device must receive a LegacyTransaction, not the EIP-1559 class.
+    expect(signTransaction).toHaveBeenCalledTimes(1)
+    const dispatched = signTransaction.mock.calls[0][0].transaction
+    expect(dispatched).toBeInstanceOf(LegacyTransaction)
+    expect(dispatched.type).toBe(0)
+  })
+
+  it('still signs an EIP-1559 (type-2) tx on chains that support it (chainId 1)', async () => {
+    const { wallet, signTransaction } = makeWallet('1')
+
+    const result = await wallet.SignTransaction(eip1559Serialized(1))
+
+    expect(result.signed).toMatch(/^0x/)
+    const dispatched = signTransaction.mock.calls[0][0].transaction
+    expect(dispatched).toBeInstanceOf(FeeMarketEIP1559Transaction)
+    expect(dispatched.type).toBe(2)
+  })
+})


### PR DESCRIPTION
## What was wrong

Sending a transaction with a **hardware wallet** (Trezor) on **Rootstock** (RBTC, chainID 30) — and any other non-EIP-1559 EVM chain — failed with a "Transaction failed to send" toast. Under the hood the signer threw:

```
Invalid serialized tx input: not an EIP-1559 transaction (wrong tx type, expected: 2, received: 0xeb)
```

`EvmHardwareWallet.SignTransaction` always parsed the unsigned transaction as an **EIP-1559** (type-2) transaction. Rootstock produces a **legacy type-0** transaction whose first byte is an RLP list prefix (`0xeb`), not the EIP-1559 type byte `0x02`, so parsing threw and the transaction never reached the device.

## What changed

`EvmHardwareWallet.SignTransaction` now tries the EIP-1559 transaction class first and, if that fails, falls back to the **legacy** transaction class (with the pre-1559 `Berlin` hardfork) before handing it to the device — exactly the pattern the private-key signer (`PrivateKeyWallet`) already uses. The hardware signer library (`@enkryptcom/hw-wallets`) already accepts a legacy transaction, so no device-side change is needed for Trezor.

One file changed (`src/providers/ethereum/evmHardwareWallet.ts`) plus a new regression test.

## How to test

1. Connect a **Trezor** hardware wallet.
2. Switch to the **Rootstock** (RBTC) network.
3. From Portfolio → Send, send a small amount of RBTC to any address.
4. **Expected:** the Trezor prompts to confirm and the transaction signs & broadcasts successfully — no "Transaction failed to send" toast, no `not an EIP-1559 transaction` error.

Automated: `pnpm vitest run tests/unit/providers/ethereum/evmHardwareWallet.spec.ts` — the new spec reproduces the exact production error against the old code and passes with the fix (covers both the legacy Rootstock path and the unchanged EIP-1559 path).

## Notes / assumptions (full-auto run, no user confirmation)

- **Scoped to the reported (Trezor) path.** Ledger also lists Rootstock as supported, but `LedgerEthereum.signTransaction` needs a separate, device-verifiable change for legacy txs (`getMessageToSign()` returns a field array to RLP-encode, plus EIP-155 `v` reconstruction). That's a money-signing change that can't be unit-verified without a physical Ledger, so it's intentionally left out and logged as a follow-up. If a Ledger is available, please include Ledger + Rootstock in the smoke test.
- The global `isEIP1559SupportedNetwork` flag is currently a hardcoded `true` (not per-chain), so the try/legacy-fallback approach — rather than branching on that flag — is the robust fix and matches `PrivateKeyWallet`.

## Sentry

https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-1DQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved hardware-wallet transaction signing compatibility for legacy transactions on networks such as Rootstock.
  - Continued support for EIP-1559 transactions on compatible networks.

- **Tests**
  - Added coverage for signing both legacy and EIP-1559 transaction formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->