### PR TITLE
[MEW-2214] fix: keep delete-address modal at 400px instead of stretching on small screens

### DIFF
--- a/src/components/core_layouts/wallet/ManageAccountsDeleteModal.vue
+++ b/src/components/core_layouts/wallet/ManageAccountsDeleteModal.vue
@@ -1,7 +1,7 @@
 <template>
   <app-dialog
     v-model:is-open="isOpen"
-    class="w-full sm:max-w-[400px] sm:mx-auto"
+    class="w-full max-w-[400px] mx-auto"
   >
     <template #title>
       <div class="flex flex-col gap-1 px-6 pt-6 pr-12">


### PR DESCRIPTION
## What this fixes

QA flagged that the delete-address confirmation modal grows to fill the screen on smaller viewports instead of holding its design width.

The cause is that the width cap was only applied from the `sm` breakpoint up:

```
w-full sm:max-w-[400px] sm:mx-auto
```

So anywhere between ~400px and 640px wide, nothing was capping it and `w-full` let it stretch edge to edge.

## The change

Drop the `sm:` prefixes so the cap and centering apply at every size:

```
w-full max-w-[400px] mx-auto
```

Now it sits at 400px on desktop just like before, and only starts shrinking once the viewport is narrower than 400px (the dialog still has its 320px floor from `AppDialog`).

One-line change in `ManageAccountsDeleteModal.vue`.

## Testing

- `pnpm vitest run tests/unit/components/wallet/ManageAccountsDeleteModal.spec.ts` → 3/3 passing.
- Smoke-tested the Remove-address flow across widths (desktop, ~500px, and below 400px) — modal stays at 400px until the screen is narrower, then adjusts down.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the account deletion dialog layout so it remains properly sized and centered across all screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->