### PR TITLE
fix: [MEW-2297] drop metamask sdk undefined-provider sentry noise

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -30,6 +30,7 @@ import {
   isInvalidWalletAddressError,
   isLockedDeviceError,
   isMetaMaskSdkDecryptError,
+  isMetaMaskSdkUndefinedProviderError,
   isProviderNotFoundError,
   isRainbowKitNotFoundError,
   isStorageQuotaExceededError,
@@ -113,6 +114,11 @@ if (dsn && process.env.NODE_ENV === 'production') {
         // shown to the user as a toast; unactionable noise (APP-MEW-WEB-BH).
         isLockedDeviceError(originalException) ||
         isMetaMaskSdkDecryptError(originalException) ||
+        // MetaMask SDK "SDK state invalid -- undefined provider" — thrown inside
+        // the bundled SDK when it loses the mobile-app connection and
+        // activeProvider is undefined; no app frame, no user affected
+        // (APP-MEW-WEB-SN / MEW-2297).
+        isMetaMaskSdkUndefinedProviderError(originalException) ||
         isProviderNotFoundError(originalException) ||
         isRainbowKitNotFoundError(originalException) ||
         isStorageQuotaExceededError(originalException) ||

--- a/src/sentry/extensionNoise.ts
+++ b/src/sentry/extensionNoise.ts
@@ -100,6 +100,28 @@ export function isMetaMaskSdkDecryptError(err: unknown): boolean {
 }
 
 /**
+ * Whether an error is the MetaMask SDK's `SDK state invalid -- undefined
+ * provider` failure. The SDK throws it entirely inside its own
+ * `_handleStreamDisconnect` / `_initializeState` path when it loses the
+ * connection to the MetaMask-mobile app and `activeProvider` is `undefined`
+ * during re-initialization (a stale / dropped mobile pairing session). Every
+ * frame is in the bundled `metamask-sdk` chunk — no MEW code is in the stack
+ * and no user is affected — so it is pure Sentry noise, a sibling of
+ * `isMetaMaskSdkDecryptError`. Matched on the (unminified) thrown message AND a
+ * `metamask-sdk` stack frame so an unrelated app error is left untouched.
+ */
+export function isMetaMaskSdkUndefinedProviderError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false
+  const e = err as { message?: unknown; stack?: unknown }
+  return (
+    typeof e.message === 'string' &&
+    e.message.includes('SDK state invalid -- undefined provider') &&
+    typeof e.stack === 'string' &&
+    e.stack.includes('metamask-sdk')
+  )
+}
+
+/**
  * Whether an error is a wagmi `ProviderNotFoundError` — thrown when a connector
  * calls `getProvider()` and no injected wallet is present (e.g. the user clicks
  * "Browser Wallet" with no extension installed). The connect flow already

--- a/tests/unit/sentry/extensionNoise.spec.ts
+++ b/tests/unit/sentry/extensionNoise.spec.ts
@@ -15,6 +15,7 @@ import {
   isInvalidWalletAddressError,
   isLockedDeviceError,
   isMetaMaskSdkDecryptError,
+  isMetaMaskSdkUndefinedProviderError,
   isProviderNotFoundError,
   isRainbowKitNotFoundError,
   isStorageQuotaExceededError,
@@ -591,6 +592,42 @@ describe('isMetaMaskSdkDecryptError', () => {
     expect(isMetaMaskSdkDecryptError(null)).toBe(false)
     expect(isMetaMaskSdkDecryptError('aes/gcm: invalid ghash tag')).toBe(false)
     expect(isMetaMaskSdkDecryptError({})).toBe(false)
+  })
+})
+
+describe('isMetaMaskSdkUndefinedProviderError', () => {
+  it('drops the MetaMask SDK "undefined provider" rejection (APP-MEW-WEB-SN)', () => {
+    const err = new Error('SDK state invalid -- undefined provider')
+    err.stack =
+      'Error: SDK state invalid -- undefined provider\n' +
+      '    at /assets/metamask-sdk-BjvlAT9C.js:27:111644\n' +
+      '    at /assets/metamask-sdk-BjvlAT9C.js:1:77170'
+    expect(isMetaMaskSdkUndefinedProviderError(err)).toBe(true)
+  })
+
+  it('ignores the same message from a non-metamask-sdk frame', () => {
+    const err = new Error('SDK state invalid -- undefined provider')
+    err.stack =
+      'Error: SDK state invalid -- undefined provider\n' +
+      '    at /assets/index-abc123.js:1:100'
+    expect(isMetaMaskSdkUndefinedProviderError(err)).toBe(false)
+  })
+
+  it('ignores an unrelated metamask-sdk error', () => {
+    const err = new Error('some other failure')
+    err.stack =
+      'Error: some other failure\n    at /assets/metamask-sdk-BjvlAT9C.js:1:1'
+    expect(isMetaMaskSdkUndefinedProviderError(err)).toBe(false)
+  })
+
+  it('handles non-error inputs', () => {
+    expect(isMetaMaskSdkUndefinedProviderError(null)).toBe(false)
+    expect(
+      isMetaMaskSdkUndefinedProviderError(
+        'SDK state invalid -- undefined provider',
+      ),
+    ).toBe(false)
+    expect(isMetaMaskSdkUndefinedProviderError({})).toBe(false)
   })
 })
 


### PR DESCRIPTION
## What was wrong

On the wallet access screen, MetaMask-mobile users were generating a Sentry error: `SDK state invalid -- undefined provider`. It is thrown inside the bundled MetaMask SDK when it loses the connection to the MetaMask-mobile app and its active provider is gone during re-initialization (a stale or dropped pairing session). No MEW code runs in that stack, the user does not see a broken screen (they were not even connected), and Sentry already flags it as `handled`. It is noise: 70 events since April, 0 users impacted.

## What changed

Added a small `beforeSend` filter that drops this specific error before it reaches Sentry. It follows the same approach we already use for the MetaMask SDK decrypt error (`isMetaMaskSdkDecryptError`): match on the exact thrown message plus a `metamask-sdk` frame in the stack, so a genuine app error that happened to share the wording would still get through.

- New `isMetaMaskSdkUndefinedProviderError` predicate in `src/sentry/extensionNoise.ts`
- Wired into the `beforeSend` list in `src/main.ts`
- Unit tests in `tests/unit/sentry/extensionNoise.spec.ts`

## How to test

This only changes Sentry reporting, so there is no UI behavior to click through. To verify the guard logic:

```
pnpm vitest run tests/unit/sentry/extensionNoise.spec.ts
```

Check the `isMetaMaskSdkUndefinedProviderError` block (drops the real payload, ignores the same message from a non-metamask frame, ignores an unrelated metamask error). The filter only runs during production Sentry init, so it will not fire in dev. After merge, confirm the event stops arriving on the Sentry issue below.

## Sentry

https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-SN

## Notes / assumptions

This was worked as part of an automated Sentry sweep, so a couple of judgment calls were made without a human in the loop:

- Treated it as third-party SDK noise, not an actionable app bug. Every stack frame is in the bundled `metamask-sdk` chunk, there is no first-party frame to guard, and it is already handled with no users affected. Same call we made for the sibling decrypt error.
- Matched on the message string plus the `metamask-sdk` frame rather than an error `name`/`code`, because the SDK throws a plain `Error` with no stable name, mirroring the existing decrypt predicate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced Sentry noise by excluding a specific MetaMask SDK “undefined provider” error from error reporting.
  - Other errors, unrelated MetaMask SDK issues, and non-error values continue to be reported or handled normally.

- **Tests**
  - Added coverage to verify the filtering behavior and prevent unrelated errors from being excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->