### PR TITLE
fix: [MEW-2299] auto-reload on all stale-deploy dynamic import failures

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -38,6 +38,7 @@ import {
   isWalletConnectSubscribeInterruptedError,
 } from '@/sentry/extensionNoise'
 import { isTransientRpcError } from '@/modules/trade/common/transientRpcError'
+import { CHUNK_LOAD_ERROR_MESSAGES } from '@/router/chunkError'
 
 const app = createApp(App)
 
@@ -59,8 +60,10 @@ if (dsn && process.env.NODE_ENV === 'production') {
       // Stale-deploy lazy-chunk errors: a cached index.html requests hashed
       // assets that no longer exist after a redeploy. These are already
       // auto-recovered by router.onError (reload once), so they are noise.
-      'Unable to preload CSS',
-      'Failed to fetch dynamically imported module',
+      // Covers every browser wording of the same failure (Safari "Importing a
+      // module script failed" APP-MEW-WEB-A5, "text/html ... MIME type"
+      // APP-MEW-WEB-B8, "Unable to preload CSS" APP-MEW-WEB-1K6).
+      ...CHUNK_LOAD_ERROR_MESSAGES,
       // WalletConnect benign rejections when the user abandons the connection flow
       'Proposal expired',
       'Pairing expired',

--- a/src/router/chunkError.ts
+++ b/src/router/chunkError.ts
@@ -1,0 +1,28 @@
+// Stale-deploy lazy-chunk failures. After a deploy, a client still running the
+// old index.html asks the CDN for hashed JS/CSS filenames the new deploy has
+// removed. The CDN answers with an HTML fallback page or a 404, so the
+// route-level dynamic import() (or its CSS preload) throws. The wording differs
+// per browser engine, but the recovery is the same for all of them: reload once
+// so the client picks up the fresh index.html and its current asset hashes.
+//
+//   Chromium   "Failed to fetch dynamically imported module"
+//   Firefox    "error loading dynamically imported module"
+//   WebKit     "Importing a module script failed" (Safari — APP-MEW-WEB-A5)
+//   stale HTML "'text/html' is not a valid JavaScript MIME type" (APP-MEW-WEB-B8)
+//   CSS        "Unable to preload CSS for ..." (APP-MEW-WEB-1K6)
+//
+// This list is the single source of truth: router.onError uses it to decide
+// when to reload, and main.ts spreads it into Sentry's ignoreErrors so the
+// auto-recovered errors stop being reported.
+export const CHUNK_LOAD_ERROR_MESSAGES = [
+  'Failed to fetch dynamically imported module',
+  'error loading dynamically imported module',
+  'Importing a module script failed',
+  'is not a valid JavaScript MIME type',
+  'Unable to preload CSS',
+] as const
+
+export function isChunkLoadError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+  return CHUNK_LOAD_ERROR_MESSAGES.some(fragment => message.includes(fragment))
+}

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -3,6 +3,7 @@ import { useWalletStore } from '@/stores/walletStore'
 import { useWatchOnlyStore } from '@/stores/watchOnlyStore'
 import DefaultRoutes from './routesDefault'
 import { pageRouteName } from './routeHierarchy'
+import { isChunkLoadError } from './chunkError'
 
 // A persisted watch-only address restores into a wallet asynchronously (on the
 // chains-load), which happens after this guard runs on a fresh load. Treat it
@@ -49,17 +50,12 @@ router.beforeEach((to, from, next) => {
 })
 
 router.onError((error, to) => {
-  const message = error instanceof Error ? error.message : String(error)
-  const isChunkError =
-    message.includes('Failed to fetch dynamically imported module') ||
-    message.includes('Unable to preload CSS')
+  if (!isChunkLoadError(error)) return
 
-  if (isChunkError) {
-    const reloadKey = `chunk-reload:${to.fullPath}`
-    if (!sessionStorage.getItem(reloadKey)) {
-      sessionStorage.setItem(reloadKey, '1')
-      window.location.href = to.fullPath
-    }
+  const reloadKey = `chunk-reload:${to.fullPath}`
+  if (!sessionStorage.getItem(reloadKey)) {
+    sessionStorage.setItem(reloadKey, '1')
+    window.location.href = to.fullPath
   }
 })
 

--- a/tests/unit/router/chunkError.spec.ts
+++ b/tests/unit/router/chunkError.spec.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import {
+  CHUNK_LOAD_ERROR_MESSAGES,
+  isChunkLoadError,
+} from '@/router/chunkError'
+
+describe('isChunkLoadError', () => {
+  it('is true for the Safari/WebKit dynamic-import failure (APP-MEW-WEB-A5)', () => {
+    expect(
+      isChunkLoadError(new TypeError('Importing a module script failed.')),
+    ).toBe(true)
+  })
+
+  it('is true for the stale-HTML MIME-type failure (APP-MEW-WEB-B8)', () => {
+    expect(
+      isChunkLoadError(
+        new TypeError("'text/html' is not a valid JavaScript MIME type."),
+      ),
+    ).toBe(true)
+  })
+
+  it('is true for the CSS preload failure (APP-MEW-WEB-1K6)', () => {
+    expect(
+      isChunkLoadError(
+        new Error(
+          'Unable to preload CSS for /assets/useFetchWatchlist-abc123.css',
+        ),
+      ),
+    ).toBe(true)
+  })
+
+  it('is true for the Chromium and Firefox dynamic-import wordings', () => {
+    expect(
+      isChunkLoadError(
+        new TypeError(
+          'Failed to fetch dynamically imported module: https://app.myetherwallet.com/assets/token-info-home-abc.js',
+        ),
+      ),
+    ).toBe(true)
+    expect(
+      isChunkLoadError(
+        new Error('error loading dynamically imported module'),
+      ),
+    ).toBe(true)
+  })
+
+  it('handles non-Error payloads (bare string rejection)', () => {
+    expect(isChunkLoadError('Importing a module script failed.')).toBe(true)
+    expect(isChunkLoadError('some unrelated string')).toBe(false)
+  })
+
+  it('is false for unrelated errors and nullish values', () => {
+    expect(isChunkLoadError(new TypeError('x is not a function'))).toBe(false)
+    expect(isChunkLoadError(null)).toBe(false)
+    expect(isChunkLoadError(undefined)).toBe(false)
+  })
+
+  it('exposes the shared message list used by the Sentry ignoreErrors filter', () => {
+    expect(CHUNK_LOAD_ERROR_MESSAGES).toContain('Importing a module script failed')
+    expect(CHUNK_LOAD_ERROR_MESSAGES).toContain('is not a valid JavaScript MIME type')
+    expect(CHUNK_LOAD_ERROR_MESSAGES).toContain('Unable to preload CSS')
+  })
+})


### PR DESCRIPTION
## What was wrong

Right after a deploy, a browser still running the previous `index.html` requests hashed JS/CSS chunk filenames that the new deploy already removed from the CDN. The CDN answers with an HTML fallback page or a 404, so the route-level dynamic `import()` throws and the page stays broken until a manual refresh.

The app already recovers from this by reloading once (`router.onError`), but the guard only matched two of the wordings browsers use for it. Safari's `Importing a module script failed.` (APP-MEW-WEB-A5) and Chrome-iOS's `'text/html' is not a valid JavaScript MIME type.` (APP-MEW-WEB-B8) were not matched, so those users never got the auto-reload and the errors kept landing in Sentry.

## What changed

- Pulled the chunk-error message check out of `router.onError` into a small shared `isChunkLoadError` helper, and extended it to cover every browser wording of the same stale-deploy failure (Chromium, Firefox, Safari, the `text/html` MIME case, and CSS preload).
- `router.onError` now reloads once for all of those, so Safari and Chrome-iOS users recover the same way the others already did.
- Sentry's `ignoreErrors` list now reuses that same shared list, so the three now-auto-recovered issues stop being reported instead of drifting out of sync with the router.
- Added a unit test for the matcher.

No behaviour change for a healthy deploy: the matcher only fires on a genuine chunk-load failure, and the reload is still guarded by a per-path `sessionStorage` one-shot flag so it can't loop.

## How to test

This is a deploy-timing failure that can't be reproduced by clicking through a single dev build, so it is verified from source and unit tests:

- `pnpm vitest run tests/unit/router/chunkError.spec.ts` and `pnpm vitest run tests/unit/router/` are green.
- `pnpm vue-tsc --noEmit -p tsconfig.app.json` and lint are clean.
- Smoke check: the app boots normally and routes work (a healthy build takes no reload path). To exercise the recovery manually, throw one of the listed messages from a route's dynamic import and confirm the app reloads exactly once.

## Sentry

- APP-MEW-WEB-A5 (primary): https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-A5
- APP-MEW-WEB-B8: https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-B8
- APP-MEW-WEB-1K6: https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-1K6

## Notes / assumptions

- Ran full-auto as part of a Sentry sweep, so no interactive smoke confirmation. 1K6 (`Unable to preload CSS`) was already handled on `feat/v7-develop`; it's included here because it shares the same matcher and I folded all three into one list.
- Kept the existing `router.onError` reload pattern rather than adding a separate `vite:preloadError` listener, since these failures all surface through route-level dynamic imports and the router hook already covers them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery when updated deployments cause application resources to fail loading.
  - The app now recognizes a wider range of browser-specific loading errors and can automatically reload once to restore access.
  - Improved handling of failed CSS and dynamically imported resource loads across Safari, Chromium, Firefox, and other browsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->