### PR TITLE
fix: [MEW-2298] drop proxy-invariant removeListener noise from injected wallet extension

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -31,6 +31,7 @@ import {
   isLockedDeviceError,
   isMetaMaskSdkDecryptError,
   isProviderNotFoundError,
+  isProviderProxyRemoveListenerError,
   isRainbowKitNotFoundError,
   isStorageQuotaExceededError,
   isTransactionReceiptTimeoutError,
@@ -114,6 +115,11 @@ if (dsn && process.env.NODE_ENV === 'production') {
         isLockedDeviceError(originalException) ||
         isMetaMaskSdkDecryptError(originalException) ||
         isProviderNotFoundError(originalException) ||
+        // V8 Proxy-invariant TypeError when wagmi reads `removeListener` off a
+        // `window.ethereum` a browser extension wrapped in a non-compliant
+        // Proxy — fire-and-forget inside wagmi's connector setup, no fixable
+        // MEW frame, external noise (APP-MEW-WEB-1K8 / MEW-2298).
+        isProviderProxyRemoveListenerError(originalException) ||
         isRainbowKitNotFoundError(originalException) ||
         isStorageQuotaExceededError(originalException) ||
         isTransactionReceiptTimeoutError(originalException) ||

--- a/src/sentry/extensionNoise.ts
+++ b/src/sentry/extensionNoise.ts
@@ -388,3 +388,32 @@ export function isWalletConnectSubscribeInterruptedError(err: unknown): boolean 
   const message = (err as { message?: unknown }).message
   return typeof message === 'string' && message.includes(MESSAGE)
 }
+
+/**
+ * Whether an error is the V8/Chrome `Proxy`-invariant `TypeError` thrown when
+ * wagmi's injected connector reads `removeListener` off a `window.ethereum`
+ * that a browser extension has wrapped in a misbehaving `Proxy`.
+ *
+ * During `generateConfig` (`src/providers/ethereum/wagmiConfig.ts`) -> wagmi
+ * `createConfig`, the injected connector's async `setup()` — fired and never
+ * awaited — calls `getProvider()`, which reads `provider.removeListener` to
+ * normalize the EIP-1193 event API. If the extension's proxy declares
+ * `removeListener` as a read-only, non-configurable data property but its `get`
+ * trap returns a different function, V8 throws `'get' on proxy: property
+ * 'removeListener' is a read-only and non-configurable data property ... but the
+ * proxy did not return its actual value`. Being fire-and-forget, it reaches the
+ * global `onunhandledrejection` handler with no fixable MEW frame — the
+ * extension is broken, not app code — so it is external, unactionable Sentry
+ * noise (APP-MEW-WEB-1K8). Matched on the V8-generated message (minification-
+ * proof) keyed to the `'get' on proxy` + `removeListener` shape so genuine app
+ * `TypeError`s are untouched. Handles both the Error-object and bare-string
+ * payload shapes.
+ */
+export function isProviderProxyRemoveListenerError(err: unknown): boolean {
+  const matches = (m: string): boolean =>
+    m.includes("'get' on proxy") && m.includes('removeListener')
+  if (typeof err === 'string') return matches(err)
+  if (!err || typeof err !== 'object') return false
+  const message = (err as { message?: unknown }).message
+  return typeof message === 'string' && matches(message)
+}

--- a/tests/unit/sentry/extensionNoise.spec.ts
+++ b/tests/unit/sentry/extensionNoise.spec.ts
@@ -16,6 +16,7 @@ import {
   isLockedDeviceError,
   isMetaMaskSdkDecryptError,
   isProviderNotFoundError,
+  isProviderProxyRemoveListenerError,
   isRainbowKitNotFoundError,
   isStorageQuotaExceededError,
   isTransactionReceiptTimeoutError,
@@ -875,5 +876,53 @@ describe('isWalletConnectSubscribeInterruptedError', () => {
     expect(isWalletConnectSubscribeInterruptedError({})).toBe(false)
     expect(isWalletConnectSubscribeInterruptedError({ message: 42 })).toBe(false)
     expect(isWalletConnectSubscribeInterruptedError('something else')).toBe(false)
+  })
+})
+
+describe('isProviderProxyRemoveListenerError', () => {
+  // The exact production message (APP-MEW-WEB-1K8): a browser extension proxies
+  // window.ethereum and wagmi's injected connector reads `removeListener`.
+  const MSG =
+    "'get' on proxy: property 'removeListener' is a read-only and non-configurable data property on the proxy target but the proxy did not return its actual value (expected 'function(e,t){...}' but got 'function(e,t){...}')"
+
+  it('drops the V8 proxy-invariant removeListener TypeError', () => {
+    expect(isProviderProxyRemoveListenerError(new TypeError(MSG))).toBe(true)
+  })
+
+  it('is true for the serialized production payload (plain object with message)', () => {
+    expect(isProviderProxyRemoveListenerError({ message: MSG })).toBe(true)
+  })
+
+  it('is true for a bare-string rejection', () => {
+    expect(isProviderProxyRemoveListenerError(MSG)).toBe(true)
+    expect(isProviderProxyRemoveListenerError(`TypeError: ${MSG}`)).toBe(true)
+  })
+
+  it('does NOT match a proxy-invariant error for a different property', () => {
+    expect(
+      isProviderProxyRemoveListenerError(
+        new TypeError(
+          "'get' on proxy: property 'request' is a read-only and non-configurable data property on the proxy target but the proxy did not return its actual value",
+        ),
+      ),
+    ).toBe(false)
+  })
+
+  it('is false for a genuine app TypeError that merely mentions removeListener', () => {
+    expect(
+      isProviderProxyRemoveListenerError(
+        new TypeError(
+          "Cannot read properties of undefined (reading 'removeListener')",
+        ),
+      ),
+    ).toBe(false)
+  })
+
+  it('is false for non-matching inputs', () => {
+    expect(isProviderProxyRemoveListenerError(null)).toBe(false)
+    expect(isProviderProxyRemoveListenerError(undefined)).toBe(false)
+    expect(isProviderProxyRemoveListenerError({})).toBe(false)
+    expect(isProviderProxyRemoveListenerError({ message: 42 })).toBe(false)
+    expect(isProviderProxyRemoveListenerError('something else')).toBe(false)
   })
 })


### PR DESCRIPTION
## What was wrong

On the Access page, some users have a browser wallet extension that wraps `window.ethereum` in a JavaScript `Proxy` that doesn't follow the language rules. When wagmi reads `removeListener` off that provider while building its config, the browser throws a `TypeError` ("'get' on proxy: property 'removeListener' ..."). That read happens in a fire-and-forget path deep inside wagmi, so nobody catches it and it lands in Sentry as an unhandled rejection.

There's no MEW code to fix here (the extension is the broken part) and no user is affected. The wallet list still renders. It's just Sentry noise. Reported as APP-MEW-WEB-1K8, 5 events, 0 users, single burst.

## What changed

Added a narrow `beforeSend` filter in the Sentry setup that drops only this specific error, matched on the browser's `'get' on proxy` + `removeListener` message. Everything else keeps reporting. It's wired into `main.ts` next to the other extension-noise filters and covered by unit tests.

Files:
- `src/sentry/extensionNoise.ts` (new `isProviderProxyRemoveListenerError` predicate)
- `src/main.ts` (import + `beforeSend` chain)
- `tests/unit/sentry/extensionNoise.spec.ts` (7 cases: exact payload, object, string, wrong-property, genuine-error, non-matching)

## How to test

This can't be reproduced without a misbehaving wallet extension, so the check is the tests plus a boot:
- `pnpm vitest run tests/unit/sentry/extensionNoise.spec.ts` passes (95 cases)
- `pnpm vue-tsc --noEmit -p tsconfig.app.json` clean
- dev server boots and `/access` renders the wallet list normally

## Heads up on conflicts

This touches `src/sentry/extensionNoise.ts` and `src/main.ts`, which other in-flight sweep PRs (#5763, #5748, #5749) also touch. The predicate is additive, so expect a small conflict in the import list and the `beforeSend` chain when these merge. Order the merges and re-run the spec after rebasing.

## Sentry

https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-1K8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced Sentry noise by filtering a known browser-extension-related `removeListener` error before it is reported.

* **Tests**
  * Added coverage for matching error formats and confirmed unrelated errors continue to be reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->