### PR TITLE
fix: [MEW-2303] remove crashing Base Account wallet from /access

### DIFF
--- a/src/providers/ethereum/wagmiConfig.ts
+++ b/src/providers/ethereum/wagmiConfig.ts
@@ -10,7 +10,16 @@ import type { Chain as wChain } from '@wagmi/core/chains'
 
 type CreateWalletFn = WalletList[number]['wallets'][number]
 
-const REMOVED_WALLETS_ID = ['bitskiWallet', 'backpackWallet', 'portoWallet']
+// `baseAccount` is removed because @base-org/account@1.1.1 (pulled in transitively by
+// @wagmi/connectors) throws a TDZ `ReferenceError: Cannot access 'p' before initialization`
+// from createBaseAccountSDK().getProvider(), so clicking the wallet always crashes.
+// See Sentry APP-MEW-WEB-1C0. Drop the removal once the SDK dependency is bumped past the fix.
+const REMOVED_WALLETS_ID = [
+  'bitskiWallet',
+  'backpackWallet',
+  'portoWallet',
+  'baseAccount',
+]
 
 const projectId = Configs.WALLET_CONNECT_PROJECT_ID
 const allRainbowWallets = Object.values(rainbowWallets).filter(wallet => {

--- a/tests/unit/providers/ethereum/wagmiConfig.spec.ts
+++ b/tests/unit/providers/ethereum/wagmiConfig.spec.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import * as rainbowWallets from '@rainbow-me/rainbowkit/wallets'
+import { generateConfig } from '@/providers/ethereum/wagmiConfig'
+import type { Chain } from '@/mew_api/types'
+
+// Regression for Sentry APP-MEW-WEB-1C0 (MEW-2303): the RainbowKit "Base Account"
+// wallet crashes with a TDZ ReferenceError inside @base-org/account when its
+// connector's getProvider() runs, so it must not be offered.
+describe('wagmiConfig — Base Account wallet removed', () => {
+  it('the removed-id string still matches the RainbowKit wallet function name', () => {
+    // The filter in wagmiConfig matches on `wallet.name` (the factory fn name).
+    // If RainbowKit renames this export the removal would silently no-op.
+    expect(rainbowWallets.baseAccount.name).toBe('baseAccount')
+  })
+
+  it('does not register a baseAccount connector but keeps working wallets', () => {
+    const config = generateConfig([{ chainID: '1' }] as unknown as Chain[])
+    const ids = config.connectors.map(c => c.id)
+    expect(ids).not.toContain('baseAccount')
+    // Guard against a vacuous pass if the whole wallet list ever breaks.
+    expect(ids).toContain('walletConnect')
+  })
+})


### PR DESCRIPTION
## What was wrong

On the /access wallet list, clicking "Base Account" crashed with `ReferenceError: Cannot access 'p' before initialization` and the connection never completed. It was reported 24 times, most recently today, on Chrome for iOS.

The crash comes from the Base Account SDK itself (`@base-org/account@1.1.1`), which RainbowKit pulls in through `@wagmi/connectors` when it builds the Base Account connector. As soon as the connector's provider is created, the SDK throws, so the wallet is unusable for everyone who taps it.

## What changed

Removed the Base Account wallet from the /access list by adding it to the `REMOVED_WALLETS_ID` blocklist in `src/providers/ethereum/wagmiConfig.ts`. This is the same list already used to drop Porto, Backpack and Bitski. The wallet was broken 100% of the time, so taking it off the list removes a dead button rather than a working feature. Added a unit test that asserts the generated wagmi config no longer registers a `baseAccount` connector (while other wallets stay).

## Assumption / follow-up

I chose to drop the wallet rather than upgrade the SDK, because the fix belongs to the third-party bundle and a dependency bump is a separate decision. If the team wants to keep Base Account, the path is to bump `@base-org/account` (a transitive dep of `@wagmi/connectors@7.0.7`) past the version with the TDZ bug and then remove it from the blocklist again.

## How to test

1. Run the app and open /access.
2. Look at the wallet list (both the default view and "show all" / search).
3. Expected: there is no "Base Account" option anywhere in the list, and every other wallet still connects as before. Nothing should throw when opening the list.

## Sentry

https://myetherwallet-inc.sentry.io/issues/APP-MEW-WEB-1C0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Base Account is no longer included among the available wallet connection options.
  - Other supported connection options, including WalletConnect, remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->