### PR TITLE
MEW-2271: Content Group design-library component + /dev preview playground

### DIFF
--- a/src/components/content_group/AppContentGroup.vue
+++ b/src/components/content_group/AppContentGroup.vue
@@ -1,0 +1,111 @@
+<script setup lang="ts">
+import { computed, useSlots } from 'vue'
+import {
+  TITLE_SIZE_CLASS,
+  DESCRIPTION_SIZE_CLASS,
+  TITLE_WEIGHT_CLASS,
+  type ContentGroupAlign,
+  type ContentGroupSize,
+} from './types'
+
+/**
+ * Content Group (design library, MEW-2271). A shared title + description pair
+ * reused inside Pickers, Cells, rows, cards, Toasts and Modal headers — building
+ * it once lets those compose it instead of re-implementing the layout.
+ *
+ * Colours use the current-system tokens (title `t-default`, description subtle
+ * `info`); dark surfaces override the text colour via a wrapper/utility class on
+ * the consumer side (e.g. a Toast passing `text-white`). The `inverted` prop
+ * swaps only the *weights*, not the colour.
+ */
+const props = withDefaults(
+  defineProps<{
+    title: string
+    description?: string
+    size?: ContentGroupSize
+    align?: ContentGroupAlign
+    /** Swaps emphasis: title becomes regular, description becomes semibold. */
+    inverted?: boolean
+    loading?: boolean
+    /** Force a single-line, ellipsised description (defaults to wrapping). */
+    noWrap?: boolean
+  }>(),
+  {
+    size: 'm',
+    align: 'left',
+    inverted: false,
+    loading: false,
+    noWrap: false,
+  },
+)
+
+const slots = useSlots()
+const hasDescription = computed(() => props.description !== undefined)
+
+const alignClass = computed(() =>
+  props.align === 'right' ? 'items-end text-right' : 'items-start text-left',
+)
+
+const titleClass = computed(() => [
+  TITLE_SIZE_CLASS[props.size],
+  props.inverted ? 'font-normal' : TITLE_WEIGHT_CLASS[props.size],
+])
+
+const descriptionClass = computed(() => [
+  DESCRIPTION_SIZE_CLASS[props.size],
+  props.inverted ? 'font-semibold' : 'font-normal',
+  props.noWrap ? 'truncate' : '',
+])
+</script>
+
+<template>
+  <div
+    data-testid="cg-root"
+    class="flex flex-col gap-0.5 min-w-0"
+    :class="alignClass"
+  >
+    <!-- Loading: skeleton bars keep line height stable (12px tall, 4px radius). -->
+    <template v-if="loading">
+      <div class="py-[5px]">
+        <div class="h-3 w-[35px] rounded-[4px] bg-grey-10 animate-pulse"></div>
+      </div>
+      <div v-if="hasDescription" class="py-[5px]">
+        <div class="h-3 w-[79px] rounded-[4px] bg-grey-10 animate-pulse"></div>
+      </div>
+    </template>
+
+    <template v-else>
+      <div class="flex items-center gap-1 min-w-0">
+        <span
+          v-if="slots['title-icon']"
+          class="w-[18px] h-[18px] shrink-0 flex items-center justify-center [&_svg]:w-full [&_svg]:h-full"
+        >
+          <slot name="title-icon" />
+        </span>
+        <span
+          data-testid="cg-title"
+          class="truncate text-t-default"
+          :class="titleClass"
+        >
+          {{ title }}
+        </span>
+      </div>
+
+      <div v-if="hasDescription" class="flex items-center gap-1 min-w-0">
+        <span
+          v-if="slots['description-icon']"
+          class="w-[18px] h-[18px] shrink-0 flex items-center justify-center [&_svg]:w-full [&_svg]:h-full"
+        >
+          <slot name="description-icon" />
+        </span>
+        <span
+          data-testid="cg-description"
+          class="text-info"
+          :class="descriptionClass"
+        >
+          {{ description }}
+        </span>
+      </div>
+    </template>
+  </div>
+</template>

--- a/src/components/content_group/AppContentGroup.vue
+++ b/src/components/content_group/AppContentGroup.vue
@@ -42,8 +42,16 @@ const props = withDefaults(
 const slots = useSlots()
 const hasDescription = computed(() => props.description !== undefined)
 
+// Text alignment cascades to the (possibly wrapping) text and the inline-block
+// skeleton bars. The rows themselves stay full-width (default stretch) so the
+// title can actually clip — items-start/end would shrink them to content width.
 const alignClass = computed(() =>
-  props.align === 'right' ? 'items-end text-right' : 'items-start text-left',
+  props.align === 'right' ? 'text-right' : 'text-left',
+)
+
+// Positions the icon + text within a full-width row.
+const rowJustifyClass = computed(() =>
+  props.align === 'right' ? 'justify-end' : 'justify-start',
 )
 
 const titleClass = computed(() => [
@@ -67,15 +75,19 @@ const descriptionClass = computed(() => [
     <!-- Loading: skeleton bars keep line height stable (12px tall, 4px radius). -->
     <template v-if="loading">
       <div class="py-[5px]">
-        <div class="h-3 w-[35px] rounded-[4px] bg-grey-10 animate-pulse"></div>
+        <div
+          class="inline-block h-3 w-[35px] rounded-[4px] bg-grey-10 animate-pulse"
+        ></div>
       </div>
       <div v-if="hasDescription" class="py-[5px]">
-        <div class="h-3 w-[79px] rounded-[4px] bg-grey-10 animate-pulse"></div>
+        <div
+          class="inline-block h-3 w-[79px] rounded-[4px] bg-grey-10 animate-pulse"
+        ></div>
       </div>
     </template>
 
     <template v-else>
-      <div class="flex items-center gap-1 min-w-0">
+      <div class="flex items-center gap-1 min-w-0" :class="rowJustifyClass">
         <span
           v-if="slots['title-icon']"
           class="w-[18px] h-[18px] shrink-0 flex items-center justify-center [&_svg]:w-full [&_svg]:h-full"
@@ -84,14 +96,18 @@ const descriptionClass = computed(() => [
         </span>
         <span
           data-testid="cg-title"
-          class="truncate text-t-default"
+          class="truncate min-w-0 text-t-default"
           :class="titleClass"
         >
           {{ title }}
         </span>
       </div>
 
-      <div v-if="hasDescription" class="flex items-center gap-1 min-w-0">
+      <div
+        v-if="hasDescription"
+        class="flex items-center gap-1 min-w-0"
+        :class="rowJustifyClass"
+      >
         <span
           v-if="slots['description-icon']"
           class="w-[18px] h-[18px] shrink-0 flex items-center justify-center [&_svg]:w-full [&_svg]:h-full"
@@ -100,7 +116,7 @@ const descriptionClass = computed(() => [
         </span>
         <span
           data-testid="cg-description"
-          class="text-info"
+          class="min-w-0 text-info"
           :class="descriptionClass"
         >
           {{ description }}

--- a/src/components/content_group/types.ts
+++ b/src/components/content_group/types.ts
@@ -1,0 +1,24 @@
+export type ContentGroupSize = 'm' | 'l'
+export type ContentGroupAlign = 'left' | 'right'
+
+/**
+ * Content Group typography (design library, MEW-2271). Its Figma section is
+ * "not published", so these map the Figma tokens to the closest current-system
+ * utilities and are centralized here for a one-line swap once design finalizes:
+ *   label/base = 16 · heading/base = 20 · text/sm = 14 · text/base = 16
+ */
+export const TITLE_SIZE_CLASS: Record<ContentGroupSize, string> = {
+  m: 'text-s-16', // label/base
+  l: 'text-s-20', // heading/base
+}
+
+export const DESCRIPTION_SIZE_CLASS: Record<ContentGroupSize, string> = {
+  m: 'text-s-14', // text/sm
+  l: 'text-s-16', // text/base
+}
+
+/** Default (non-inverted) title weight: label/base = medium, heading/base = semibold. */
+export const TITLE_WEIGHT_CLASS: Record<ContentGroupSize, string> = {
+  m: 'font-medium',
+  l: 'font-semibold',
+}

--- a/src/components/core_layouts/TheAppLayout.vue
+++ b/src/components/core_layouts/TheAppLayout.vue
@@ -55,6 +55,7 @@
             <router-view />
           </div>
           <MewFooter
+            v-if="!isDevPlayground"
             :use-i18n="useI18n"
             :amplitude="analytics.amplitude"
             :link-component="RouterLink"
@@ -65,6 +66,7 @@
             class="px-3 xs:px-5"
           />
           <div
+            v-if="!isDevPlayground"
             class="sticky flex items-center justify-center w-full bottom-0 z-10"
           >
             <a

--- a/src/components/core_layouts/TheAppLayout.vue
+++ b/src/components/core_layouts/TheAppLayout.vue
@@ -36,7 +36,12 @@
       <div
         :class="['relative flex justify-center  w-full mt-[68px] sm:mt-[76px]']"
       >
-        <main :class="[' basis-full w-full max-w-[1440px] mx-auto relative']">
+        <main
+          :class="[
+            'basis-full w-full relative',
+            isDevPlayground ? '' : 'max-w-[1440px] mx-auto',
+          ]"
+        >
           <div
             :class="[
               'min-h-[600px]',
@@ -44,7 +49,7 @@
               // px-8 py-8 = 32px on all sides), so the wrapper adds none — else
               // the hero's top padding stacks on the wrapper's. Other routes
               // keep the shared page padding.
-              isNewHome ? '' : 'pt-3 xs:pt-6 px-3 xs:px-5',
+              isNewHome || isDevPlayground ? '' : 'pt-3 xs:pt-6 px-3 xs:px-5',
             ]"
           >
             <router-view />
@@ -182,6 +187,12 @@ const backgroundClass = computed(() => {
 // The Home page ('/') keeps the layout max-width but drops the shared
 // horizontal padding, so its sections own their padding.
 const isNewHome = computed(() => pageRouteName(route) === ROUTES_MAIN.HOME.NAME)
+
+// DEV-only design-library playground (MEW-2271) renders full-bleed: no wrapper
+// padding or max-width, so its sidebar sits flush against the viewport edge.
+const isDevPlayground = computed(
+  () => route.path === '/dev' || route.path.startsWith('/dev/'),
+)
 
 const appLayoutStore = useAppLayoutStore()
 const { isOverflowHidden } = storeToRefs(appLayoutStore)

--- a/src/router/routesDefault.ts
+++ b/src/router/routesDefault.ts
@@ -23,6 +23,32 @@ const ViewHome = () => import('@/views/ViewHome.vue')
 
 type RouteNameCollection = RouterOptions['routes']
 const DefaultRoutes = <RouteNameCollection>[
+  // DEV-only design-library previews (MEW-2271). A sidebar shell (ViewDevLayout)
+  // lists the components with previews; each renders in its <router-view>. Never
+  // registered in production builds.
+  ...(import.meta.env.MODE !== 'production'
+    ? [
+        {
+          path: '/dev',
+          component: () => import('@/views/ViewDevLayout.vue'),
+          meta: { noAuth: true },
+          children: [
+            {
+              path: '',
+              name: 'DevIndex',
+              component: () => import('@/views/ViewDevIndex.vue'),
+              meta: { noAuth: true },
+            },
+            {
+              path: 'content-group',
+              name: 'DevContentGroup',
+              component: () => import('@/views/ViewContentGroupShowcase.vue'),
+              meta: { noAuth: true },
+            },
+          ],
+        },
+      ]
+    : []),
   {
     // New public Home is the root; disconnected users land here.
     path: ROUTES_MAIN.HOME.PATH,

--- a/src/views/ViewContentGroupShowcase.vue
+++ b/src/views/ViewContentGroupShowcase.vue
@@ -27,7 +27,7 @@ const combos = SIZES.flatMap(size =>
 
 <template>
   <div class="p-8 flex flex-col gap-12 max-w-3xl mx-auto">
-    <h1 class="text-s-24 font-bold">Content Group — design library (MEW-2271)</h1>
+    <h1 class="text-s-24 font-bold">Content Group</h1>
 
     <!-- Size × Align × Inverted matrix -->
     <section class="flex flex-col gap-4">

--- a/src/views/ViewContentGroupShowcase.vue
+++ b/src/views/ViewContentGroupShowcase.vue
@@ -1,0 +1,104 @@
+<script setup lang="ts">
+// DEV-only gallery for the Content Group design-library component (MEW-2271).
+// Never registered in production builds — see routesDefault.ts. Lets us eyeball
+// the Size × Align × Inverted matrix, the icon slots and the loading state
+// against Figma.
+import { WalletIcon, CheckBadgeIcon } from '@heroicons/vue/24/solid'
+import AppContentGroup from '@/components/content_group/AppContentGroup.vue'
+import type {
+  ContentGroupAlign,
+  ContentGroupSize,
+} from '@/components/content_group/types'
+
+const SIZES: ContentGroupSize[] = ['m', 'l']
+const ALIGNS: ContentGroupAlign[] = ['left', 'right']
+
+const combos = SIZES.flatMap(size =>
+  ALIGNS.flatMap(align =>
+    [false, true].map(inverted => ({
+      size,
+      align,
+      inverted,
+      label: `size=${size} · align=${align} · inverted=${inverted}`,
+    })),
+  ),
+)
+</script>
+
+<template>
+  <div class="p-8 flex flex-col gap-12 max-w-3xl mx-auto">
+    <h1 class="text-s-24 font-bold">Content Group — design library (MEW-2271)</h1>
+
+    <!-- Size × Align × Inverted matrix -->
+    <section class="flex flex-col gap-4">
+      <h2 class="text-s-16 font-semibold">Size × Align × Inverted</h2>
+      <div class="grid grid-cols-2 gap-4">
+        <div
+          v-for="c in combos"
+          :key="c.label"
+          class="border border-grey-10 rounded-12 p-4 bg-white"
+        >
+          <p class="text-s-11 text-info mb-2">{{ c.label }}</p>
+          <AppContentGroup
+            title="Ethereum"
+            description="The world computer, secured by proof of stake."
+            :size="c.size"
+            :align="c.align"
+            :inverted="c.inverted"
+          />
+        </div>
+      </div>
+    </section>
+
+    <!-- Icon slots populated -->
+    <section class="flex flex-col gap-4">
+      <h2 class="text-s-16 font-semibold">Icon slots (18px, both lines)</h2>
+      <div class="flex gap-8">
+        <div class="border border-grey-10 rounded-12 p-4 bg-white">
+          <AppContentGroup title="My Wallet" description="Verified account">
+            <template #title-icon><WalletIcon /></template>
+            <template #description-icon><CheckBadgeIcon /></template>
+          </AppContentGroup>
+        </div>
+        <div class="border border-grey-10 rounded-12 p-4 bg-white">
+          <AppContentGroup size="l" title="My Wallet" description="Verified">
+            <template #title-icon><WalletIcon /></template>
+          </AppContentGroup>
+        </div>
+      </div>
+    </section>
+
+    <!-- Overflow: default single-line title + wrapping description, and noWrap -->
+    <section class="flex flex-col gap-4">
+      <h2 class="text-s-16 font-semibold">Overflow (constrained to 180px)</h2>
+      <div class="flex gap-8">
+        <div class="w-[180px] border border-grey-10 rounded-12 p-4 bg-white">
+          <AppContentGroup
+            title="A very long title that should ellipsis"
+            description="A long description that is allowed to wrap onto multiple lines by default."
+          />
+        </div>
+        <div class="w-[180px] border border-grey-10 rounded-12 p-4 bg-white">
+          <AppContentGroup
+            title="A very long title that should ellipsis"
+            description="A long single-line description with ellipsis"
+            no-wrap
+          />
+        </div>
+      </div>
+    </section>
+
+    <!-- Loading state -->
+    <section class="flex flex-col gap-4">
+      <h2 class="text-s-16 font-semibold">Loading (Skeleton)</h2>
+      <div class="flex gap-8">
+        <div class="border border-grey-10 rounded-12 p-4 bg-white">
+          <AppContentGroup title="Title" description="Description" loading />
+        </div>
+        <div class="border border-grey-10 rounded-12 p-4 bg-white">
+          <AppContentGroup title="Title only" loading />
+        </div>
+      </div>
+    </section>
+  </div>
+</template>

--- a/src/views/ViewDevIndex.vue
+++ b/src/views/ViewDevIndex.vue
@@ -1,0 +1,10 @@
+<template>
+  <div class="p-8 max-w-3xl">
+    <h1 class="text-s-24 font-bold text-t-default mb-2">
+      Design library — dev previews
+    </h1>
+    <p class="text-s-14 text-info">
+      Select a component from the sidebar to preview it against Figma.
+    </p>
+  </div>
+</template>

--- a/src/views/ViewDevLayout.vue
+++ b/src/views/ViewDevLayout.vue
@@ -9,8 +9,14 @@ const COMPONENTS: { name: string; to: string }[] = [
 </script>
 
 <template>
-  <div class="flex min-h-screen bg-app-background">
-    <aside class="w-56 shrink-0 border-r border-grey-10 bg-white p-4">
+  <!-- Fixed to the space below the app header so only the main column scrolls;
+       the sidebar stays put. Header is 68px (xs) / 76px (sm+) — see TheHeader. -->
+  <div
+    class="flex h-[calc(100dvh-68px)] sm:h-[calc(100dvh-76px)] overflow-hidden bg-app-background"
+  >
+    <aside
+      class="w-56 shrink-0 overflow-y-auto border-r border-grey-10 bg-white p-4"
+    >
       <router-link
         to="/dev"
         class="block text-s-16 font-bold text-t-default mb-4 hoverOpacity"
@@ -32,7 +38,7 @@ const COMPONENTS: { name: string; to: string }[] = [
         </router-link>
       </nav>
     </aside>
-    <main class="flex-1 min-w-0 overflow-x-auto">
+    <main class="flex-1 min-w-0 overflow-auto">
       <router-view />
     </main>
   </div>

--- a/src/views/ViewDevLayout.vue
+++ b/src/views/ViewDevLayout.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+// DEV-only shell for the design-library previews (MEW-2271). The sidebar lists
+// the components that have a preview page; the selected one renders in the main
+// area via <router-view>. Add a row here as each component gains a preview.
+// Never registered in production builds — see routesDefault.ts.
+const COMPONENTS: { name: string; to: string }[] = [
+  { name: 'Content Group', to: '/dev/content-group' },
+]
+</script>
+
+<template>
+  <div class="flex min-h-screen bg-app-background">
+    <aside class="w-56 shrink-0 border-r border-grey-10 bg-white p-4">
+      <router-link
+        to="/dev"
+        class="block text-s-16 font-bold text-t-default mb-4 hoverOpacity"
+      >
+        Design library
+      </router-link>
+      <p class="text-s-11 font-bold uppercase text-info tracking-sp-06 mb-2">
+        Components
+      </p>
+      <nav class="flex flex-col gap-1">
+        <router-link
+          v-for="c in COMPONENTS"
+          :key="c.to"
+          :to="c.to"
+          class="rounded-8 px-3 py-2 text-s-14 text-t-default hoverNoBG transition-colors"
+          active-class="bg-grey-10 font-medium"
+        >
+          {{ c.name }}
+        </router-link>
+      </nav>
+    </aside>
+    <main class="flex-1 min-w-0 overflow-x-auto">
+      <router-view />
+    </main>
+  </div>
+</template>

--- a/tests/unit/components/content_group/AppContentGroup.spec.ts
+++ b/tests/unit/components/content_group/AppContentGroup.spec.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import AppContentGroup from '@/components/content_group/AppContentGroup.vue'
+
+const title = () => '[data-testid="cg-title"]'
+const description = () => '[data-testid="cg-description"]'
+
+describe('AppContentGroup', () => {
+  it('renders title and description text', () => {
+    const wrapper = mount(AppContentGroup, {
+      props: { title: 'Balance', description: 'Total value' },
+    })
+    expect(wrapper.text()).toContain('Balance')
+    expect(wrapper.text()).toContain('Total value')
+  })
+
+  it('omits the description block when no description is given', () => {
+    const wrapper = mount(AppContentGroup, { props: { title: 'Only title' } })
+    expect(wrapper.find(description()).exists()).toBe(false)
+  })
+
+  it('size "m" uses label/base (16) title and text/sm (14) description', () => {
+    const wrapper = mount(AppContentGroup, {
+      props: { title: 'T', description: 'D', size: 'm' },
+    })
+    expect(wrapper.get(title()).classes()).toContain('text-s-16')
+    expect(wrapper.get(description()).classes()).toContain('text-s-14')
+  })
+
+  it('size "l" uses heading/base (20) title and text/base (16) description', () => {
+    const wrapper = mount(AppContentGroup, {
+      props: { title: 'T', description: 'D', size: 'l' },
+    })
+    expect(wrapper.get(title()).classes()).toContain('text-s-20')
+    expect(wrapper.get(description()).classes()).toContain('text-s-16')
+  })
+
+  it('default weights: title emphasized, description regular', () => {
+    const wrapper = mount(AppContentGroup, {
+      props: { title: 'T', description: 'D', size: 'm' },
+    })
+    expect(wrapper.get(title()).classes()).toContain('font-medium')
+    expect(wrapper.get(description()).classes()).toContain('font-normal')
+  })
+
+  it('inverted swaps weights: title regular, description semibold', () => {
+    const wrapper = mount(AppContentGroup, {
+      props: { title: 'T', description: 'D', inverted: true },
+    })
+    expect(wrapper.get(title()).classes()).toContain('font-normal')
+    expect(wrapper.get(description()).classes()).toContain('font-semibold')
+  })
+
+  it('align "right" right-aligns both lines', () => {
+    const wrapper = mount(AppContentGroup, {
+      props: { title: 'T', description: 'D', align: 'right' },
+    })
+    expect(wrapper.get('[data-testid="cg-root"]').classes()).toContain(
+      'text-right',
+    )
+  })
+
+  it('title is single-line (truncates) by default; description wraps', () => {
+    const wrapper = mount(AppContentGroup, {
+      props: { title: 'T', description: 'D' },
+    })
+    expect(wrapper.get(title()).classes()).toContain('truncate')
+    expect(wrapper.get(description()).classes()).not.toContain('truncate')
+  })
+
+  it('noWrap makes the description single-line', () => {
+    const wrapper = mount(AppContentGroup, {
+      props: { title: 'T', description: 'D', noWrap: true },
+    })
+    expect(wrapper.get(description()).classes()).toContain('truncate')
+  })
+
+  it('loading replaces text with skeletons', () => {
+    const wrapper = mount(AppContentGroup, {
+      props: { title: 'Secret', description: 'Hidden', loading: true },
+    })
+    expect(wrapper.text()).not.toContain('Secret')
+    expect(wrapper.text()).not.toContain('Hidden')
+    expect(wrapper.html()).toContain('animate-pulse')
+    expect(wrapper.find(title()).exists()).toBe(false)
+  })
+
+  it('renders title-icon and description-icon slots', () => {
+    const wrapper = mount(AppContentGroup, {
+      props: { title: 'T', description: 'D' },
+      slots: {
+        'title-icon': '<svg data-testid="ti" />',
+        'description-icon': '<svg data-testid="di" />',
+      },
+    })
+    expect(wrapper.find('[data-testid="ti"]').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="di"]').exists()).toBe(true)
+  })
+})

--- a/tests/unit/components/content_group/AppContentGroup.spec.ts
+++ b/tests/unit/components/content_group/AppContentGroup.spec.ts
@@ -55,9 +55,12 @@ describe('AppContentGroup', () => {
     const wrapper = mount(AppContentGroup, {
       props: { title: 'T', description: 'D', align: 'right' },
     })
-    expect(wrapper.get('[data-testid="cg-root"]').classes()).toContain(
-      'text-right',
-    )
+    const rootClasses = wrapper.get('[data-testid="cg-root"]').classes()
+    expect(rootClasses).toContain('text-right')
+    // Aligning via items-start/end would shrink the rows to content width and
+    // break the title ellipsis — rows must stay full-width. Guard against it.
+    expect(rootClasses).not.toContain('items-end')
+    expect(rootClasses).not.toContain('items-start')
   })
 
   it('title is single-line (truncates) by default; description wraps', () => {
@@ -65,6 +68,8 @@ describe('AppContentGroup', () => {
       props: { title: 'T', description: 'D' },
     })
     expect(wrapper.get(title()).classes()).toContain('truncate')
+    // min-w-0 lets the flex item shrink so the ellipsis actually clips.
+    expect(wrapper.get(title()).classes()).toContain('min-w-0')
     expect(wrapper.get(description()).classes()).not.toContain('truncate')
   })
 


### PR DESCRIPTION
## What

Adds the `ContentGroup` component for the design library: a title + description pair that Pickers, Cells, rows, cards, Toasts and Modal headers can reuse instead of each re-implementing the layout.

`src/components/content_group/AppContentGroup.vue` (+ `types.ts`):
- Props: `title`, `description`, `size` (m/l), `align` (left/right), `inverted`, `loading`, `noWrap`.
- Named `title-icon` / `description-icon` slots, rendered at 18px.
- Typography and subtle description colour per the ticket. `inverted` swaps the title/description weights; the colour stays consumer-driven so dark surfaces (e.g. a Toast) override it via a wrapper class.
- Loading swaps in Skeleton bars. The title is single-line with ellipsis and the description wraps, with `noWrap` as the single-line escape hatch.

Also adds a DEV-only `/dev` playground: a sidebar shell that lists the design-library components with previews, seeded with Content Group at `/dev/content-group`. It is registered only outside production builds.

## Notes

The component's Figma section is still marked "not published", so the typography and colour tokens map to the closest current-system utilities. They live in `content_group/types.ts` so they are a one-line swap once design publishes.

## Testing

`pnpm vitest run tests/unit/components/content_group` (11 cases), `pnpm vue-tsc`, and eslint all pass. Visually, `/dev/content-group` covers the Size × Align × Inverted matrix, both icon slots, the overflow cases and the loading state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable Content Group component for consistently displaying titles and descriptions.
  * Supports multiple sizes, alignment options, inverted typography, loading skeletons, text truncation, and optional icons.
* **Developer Experience**
  * Added a development-only design library playground with component previews and Content Group examples.
* **Tests**
  * Added coverage for Content Group rendering, styling variants, loading states, truncation, alignment, and icon slots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->