### PR TITLE
fix: 🐛 rootstock send

### DIFF
--- a/src/modules/send/components/EvmTransactionConfirmation.vue
+++ b/src/modules/send/components/EvmTransactionConfirmation.vue
@@ -462,6 +462,11 @@ const confirmTransaction = async () => {
           textSecondary: getLocalizedWalletError(msg) ?? errorMessage,
         })
 
+        // Close the verify dialog on failure so stale tx details (from
+        // address, amounts) don't linger behind the error toast.
+        openModal.value = false
+        model.value = false
+
         captureException(e instanceof Error ? e : new Error(msg), {
           ...SENTRY_MODULE_TAGS.SEND,
           extra: {
@@ -500,6 +505,8 @@ const confirmTransaction = async () => {
       text: t('send.toast.tx-send-failed'),
       textSecondary: getLocalizedWalletError(errorMessage) ?? errorMessage,
     })
+    openModal.value = false
+    model.value = false
     // A transient Trezor empty-payload signing failure (APP-MEW-WEB-56) is
     // surfaced to the user as a friendly "reconnect" toast above and is safe to
     // retry, so don't report it to Sentry as a crash.

--- a/src/providers/ethereum/wagmiWallet.ts
+++ b/src/providers/ethereum/wagmiWallet.ts
@@ -1,4 +1,4 @@
-import { FeeMarketEIP1559Transaction } from '@ethereumjs/tx'
+import { FeeMarketEIP1559Transaction, LegacyTransaction } from '@ethereumjs/tx'
 import { commonGenerator } from './utils'
 import { WalletType, type HexPrefixedString } from '../types'
 import { hexToBytes } from '@ethereumjs/util'
@@ -52,31 +52,52 @@ class WagmiWallet extends BaseEvmWallet {
     }
   }
 
+  private parseSerializedTx(serializedTx: HexPrefixedString) {
+    try {
+      const tx = FeeMarketEIP1559Transaction.fromSerializedTx(
+        hexToBytes(serializedTx),
+        { common: commonGenerator(BigInt(this.chainId), Hardfork.London) },
+      )
+      const txObj = tx.toJSON()
+      return {
+        ...txObj,
+        accessList:
+          txObj.accessList?.map(item => ({
+            address: item.address as `0x${string}`,
+            storageKeys: item.storageKeys as readonly `0x${string}`[],
+          })) ?? undefined,
+        maxFeePerGas: fromHex(txObj.maxFeePerGas ?? '0x0', 'bigint'),
+        maxPriorityFeePerGas: fromHex(
+          txObj.maxPriorityFeePerGas ?? '0x0',
+          'bigint',
+        ),
+        nonce: fromHex(txObj.nonce ?? '0x0', 'number'),
+        chainId: fromHex(txObj.chainId ?? '0x0', 'number'),
+        value: fromHex(txObj.value ?? '0x0', 'bigint'),
+        type: 'eip1559' as const,
+      }
+      // on fail, assume legacy tx (e.g. Rootstock) — a legacy RLP has no type
+      // byte, so parsing it as EIP-1559 misreads the payload as the tx type
+    } catch {
+      const tx = LegacyTransaction.fromSerializedTx(hexToBytes(serializedTx), {
+        common: commonGenerator(BigInt(this.chainId), Hardfork.Berlin),
+      })
+      const txObj = tx.toJSON()
+      return {
+        ...txObj,
+        gasPrice: fromHex(txObj.gasPrice ?? '0x0', 'bigint'),
+        nonce: fromHex(txObj.nonce ?? '0x0', 'number'),
+        chainId: Number(this.chainId),
+        value: fromHex(txObj.value ?? '0x0', 'bigint'),
+        type: 'legacy' as const,
+      }
+    }
+  }
+
   override async SendTransaction(
     serializedTx: HexPrefixedString,
   ): Promise<HexPrefixedString> {
-    const tx = FeeMarketEIP1559Transaction.fromSerializedTx(
-      hexToBytes(serializedTx),
-      { common: commonGenerator(BigInt(this.chainId), Hardfork.London) },
-    )
-    const txObj = tx.toJSON()
-    const parseTx = {
-      ...txObj,
-      accessList:
-        txObj.accessList?.map(item => ({
-          address: item.address as `0x${string}`,
-          storageKeys: item.storageKeys as readonly `0x${string}`[],
-        })) ?? undefined,
-      maxFeePerGas: fromHex(txObj.maxFeePerGas ?? '0x0', 'bigint'),
-      maxPriorityFeePerGas: fromHex(
-        txObj.maxPriorityFeePerGas ?? '0x0',
-        'bigint',
-      ),
-      nonce: fromHex(txObj.nonce ?? '0x0', 'number'),
-      chainId: fromHex(txObj.chainId ?? '0x0', 'number'),
-      value: fromHex(txObj.value ?? '0x0', 'bigint'),
-      type: 'eip1559' as const,
-    }
+    const parseTx = this.parseSerializedTx(serializedTx)
     const from = await this.getAddress()
     const params = {
       connector: this.connector,

--- a/src/providers/ethereum/wagmiWallet.ts
+++ b/src/providers/ethereum/wagmiWallet.ts
@@ -1,4 +1,4 @@
-import { FeeMarketEIP1559Transaction } from '@ethereumjs/tx'
+import { FeeMarketEIP1559Transaction, LegacyTransaction } from '@ethereumjs/tx'
 import { commonGenerator } from './utils'
 import { WalletType, type HexPrefixedString } from '../types'
 import { hexToBytes } from '@ethereumjs/util'
@@ -52,31 +52,58 @@ class WagmiWallet extends BaseEvmWallet {
     }
   }
 
+  // Builds explicit sendTransaction fields — never spread tx.toJSON() here:
+  // it carries signature slots (v/r/s) that strict wallets reject.
+  private parseSerializedTx(serializedTx: HexPrefixedString) {
+    try {
+      const tx = FeeMarketEIP1559Transaction.fromSerializedTx(
+        hexToBytes(serializedTx),
+        { common: commonGenerator(BigInt(this.chainId), Hardfork.London) },
+      )
+      const txObj = tx.toJSON()
+      return {
+        to: txObj.to as `0x${string}` | undefined,
+        data: txObj.data as `0x${string}` | undefined,
+        gas: fromHex(txObj.gasLimit ?? '0x0', 'bigint'),
+        accessList:
+          txObj.accessList?.map(item => ({
+            address: item.address as `0x${string}`,
+            storageKeys: item.storageKeys as readonly `0x${string}`[],
+          })) ?? undefined,
+        maxFeePerGas: fromHex(txObj.maxFeePerGas ?? '0x0', 'bigint'),
+        maxPriorityFeePerGas: fromHex(
+          txObj.maxPriorityFeePerGas ?? '0x0',
+          'bigint',
+        ),
+        nonce: fromHex(txObj.nonce ?? '0x0', 'number'),
+        chainId: fromHex(txObj.chainId ?? '0x0', 'number'),
+        value: fromHex(txObj.value ?? '0x0', 'bigint'),
+        type: 'eip1559' as const,
+      }
+      // on fail, assume legacy tx (e.g. Rootstock) — a legacy RLP has no type
+      // byte, so parsing it as EIP-1559 misreads the payload as the tx type
+    } catch {
+      const tx = LegacyTransaction.fromSerializedTx(hexToBytes(serializedTx), {
+        common: commonGenerator(BigInt(this.chainId), Hardfork.Berlin),
+      })
+      const txObj = tx.toJSON()
+      return {
+        to: txObj.to as `0x${string}` | undefined,
+        data: txObj.data as `0x${string}` | undefined,
+        gas: fromHex(txObj.gasLimit ?? '0x0', 'bigint'),
+        gasPrice: fromHex(txObj.gasPrice ?? '0x0', 'bigint'),
+        nonce: fromHex(txObj.nonce ?? '0x0', 'number'),
+        chainId: Number(this.chainId),
+        value: fromHex(txObj.value ?? '0x0', 'bigint'),
+        type: 'legacy' as const,
+      }
+    }
+  }
+
   override async SendTransaction(
     serializedTx: HexPrefixedString,
   ): Promise<HexPrefixedString> {
-    const tx = FeeMarketEIP1559Transaction.fromSerializedTx(
-      hexToBytes(serializedTx),
-      { common: commonGenerator(BigInt(this.chainId), Hardfork.London) },
-    )
-    const txObj = tx.toJSON()
-    const parseTx = {
-      ...txObj,
-      accessList:
-        txObj.accessList?.map(item => ({
-          address: item.address as `0x${string}`,
-          storageKeys: item.storageKeys as readonly `0x${string}`[],
-        })) ?? undefined,
-      maxFeePerGas: fromHex(txObj.maxFeePerGas ?? '0x0', 'bigint'),
-      maxPriorityFeePerGas: fromHex(
-        txObj.maxPriorityFeePerGas ?? '0x0',
-        'bigint',
-      ),
-      nonce: fromHex(txObj.nonce ?? '0x0', 'number'),
-      chainId: fromHex(txObj.chainId ?? '0x0', 'number'),
-      value: fromHex(txObj.value ?? '0x0', 'bigint'),
-      type: 'eip1559' as const,
-    }
+    const parseTx = this.parseSerializedTx(serializedTx)
     const from = await this.getAddress()
     const params = {
       connector: this.connector,

--- a/src/providers/ethereum/web3InjectedWallet.ts
+++ b/src/providers/ethereum/web3InjectedWallet.ts
@@ -1,4 +1,4 @@
-import { FeeMarketEIP1559Transaction } from '@ethereumjs/tx'
+import { FeeMarketEIP1559Transaction, LegacyTransaction } from '@ethereumjs/tx'
 import { commonGenerator } from './utils'
 import { WalletType, type HexPrefixedString } from '../types'
 import { hexToBytes } from '@ethereumjs/util'
@@ -46,17 +46,43 @@ class Web3InjectedWallet extends BaseEvmWallet {
     }
   }
 
+  private parseSerializedTx(serializedTx: HexPrefixedString) {
+    try {
+      const tx = FeeMarketEIP1559Transaction.fromSerializedTx(
+        hexToBytes(serializedTx),
+        { common: commonGenerator(BigInt(this.chainId), Hardfork.London) },
+      )
+      return tx.toJSON()
+      // on fail, assume legacy tx (e.g. Rootstock) — a legacy RLP has no type
+      // byte, so parsing it as EIP-1559 misreads the payload as the tx type
+    } catch {
+      const tx = LegacyTransaction.fromSerializedTx(hexToBytes(serializedTx), {
+        common: commonGenerator(BigInt(this.chainId), Hardfork.Berlin),
+      })
+      return tx.toJSON()
+    }
+  }
+
   override async SendTransaction(
     serializedTx: HexPrefixedString,
   ): Promise<HexPrefixedString> {
-    const tx = FeeMarketEIP1559Transaction.fromSerializedTx(
-      hexToBytes(serializedTx),
-      { common: commonGenerator(BigInt(this.chainId), Hardfork.London) },
-    )
-    const txObj = tx.toJSON()
+    const txObj = this.parseSerializedTx(serializedTx)
+    // Only pass fields eth_sendTransaction understands — the parsed JSON also
+    // carries signature slots (v/r/s) that strict wallets like Enkrypt reject.
     const params = {
       from: this.address,
-      ...txObj,
+      to: txObj.to,
+      value: txObj.value,
+      data: txObj.data,
+      nonce: txObj.nonce,
+      gas: txObj.gasLimit,
+      type: txObj.type,
+      ...(txObj.gasPrice
+        ? { gasPrice: txObj.gasPrice }
+        : {
+            maxFeePerGas: txObj.maxFeePerGas,
+            maxPriorityFeePerGas: txObj.maxPriorityFeePerGas,
+          }),
     }
 
     const txHash = await this.provider.provider.request({

--- a/src/providers/ethereum/web3InjectedWallet.ts
+++ b/src/providers/ethereum/web3InjectedWallet.ts
@@ -1,4 +1,4 @@
-import { FeeMarketEIP1559Transaction } from '@ethereumjs/tx'
+import { FeeMarketEIP1559Transaction, LegacyTransaction } from '@ethereumjs/tx'
 import { commonGenerator } from './utils'
 import { WalletType, type HexPrefixedString } from '../types'
 import { hexToBytes } from '@ethereumjs/util'
@@ -46,14 +46,27 @@ class Web3InjectedWallet extends BaseEvmWallet {
     }
   }
 
+  private parseSerializedTx(serializedTx: HexPrefixedString) {
+    try {
+      const tx = FeeMarketEIP1559Transaction.fromSerializedTx(
+        hexToBytes(serializedTx),
+        { common: commonGenerator(BigInt(this.chainId), Hardfork.London) },
+      )
+      return tx.toJSON()
+      // on fail, assume legacy tx (e.g. Rootstock) — a legacy RLP has no type
+      // byte, so parsing it as EIP-1559 misreads the payload as the tx type
+    } catch {
+      const tx = LegacyTransaction.fromSerializedTx(hexToBytes(serializedTx), {
+        common: commonGenerator(BigInt(this.chainId), Hardfork.Berlin),
+      })
+      return tx.toJSON()
+    }
+  }
+
   override async SendTransaction(
     serializedTx: HexPrefixedString,
   ): Promise<HexPrefixedString> {
-    const tx = FeeMarketEIP1559Transaction.fromSerializedTx(
-      hexToBytes(serializedTx),
-      { common: commonGenerator(BigInt(this.chainId), Hardfork.London) },
-    )
-    const txObj = tx.toJSON()
+    const txObj = this.parseSerializedTx(serializedTx)
     const params = {
       from: this.address,
       ...txObj,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Transaction confirmation dialogs now close when sending fails, including immediate errors and rejected transactions, preventing outdated details from remaining visible.
  - Improved support for submitting serialized Ethereum transactions across supported wallet connections, including modern EIP-1559 and legacy transaction formats.
  - Added fallback handling to improve transaction submission reliability when modern transaction decoding is unsuccessful.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->